### PR TITLE
fix: log cleanly closed connection as debug only

### DIFF
--- a/custom_components/aseko_local/aseko_server.py
+++ b/custom_components/aseko_local/aseko_server.py
@@ -128,16 +128,22 @@ class AsekoDeviceServer:
                     break
 
                 except asyncio.IncompleteReadError as exc:
-                    _LOGGER.error(
-                        "Client %s closed the connection after %d bytes (expected %d):\n%s",
-                        addr,
-                        len(exc.partial),
-                        MESSAGE_SIZE,
-                        exc.partial.hex(" ", 1),
-                    )
-                    # Store partial frame for diagnostics so users with non-standard
-                    # frame lengths can share the raw data without enabling debug logging.
-                    await self._call_raw_sink(exc.partial)
+                    if len(exc.partial) == 0:
+                        _LOGGER.debug(
+                            "Client %s closed the connection",
+                            addr,
+                        )
+                    else:
+                        _LOGGER.error(
+                            "Client %s closed the connection after %d bytes (expected %d):\n%s",
+                            addr,
+                            len(exc.partial),
+                            MESSAGE_SIZE,
+                            exc.partial.hex(" ", 1),
+                        )
+                        # Store partial frame for diagnostics so users with non-standard
+                        # frame lengths can share the raw data without enabling debug logging.
+                        await self._call_raw_sink(exc.partial)
                     break
 
                 # Try to decode the frame

--- a/custom_components/aseko_local/manifest.json
+++ b/custom_components/aseko_local/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/hopkins-tk/home-assistant-aseko-local/issues",
   "requirements": [],
-  "version": "v1.4.0"
+  "version": "v1.4.1"
 }


### PR DESCRIPTION
We are spamming logs with ERROR every 10 seconds:

 ```
2026-04-13 21:07:47.126 ERROR (MainThread) [custom_components.aseko_local.aseko_server] Client ('xxx.xxx.xxx.xxx', XXX) closed the connection after 0 bytes (expected 120):

2026-04-13 21:07:56.879 ERROR (MainThread) [custom_components.aseko_local.aseko_server] Client ('xxx.xxx.xxx.xxx', XXX) closed the connection after 0 bytes (expected 120):
```

To mitigate this, we should log ERROR only in case some data are received, but it is not the full message.