### PR TITLE
feat: rework decoder in respect to HOME units

### DIFF
--- a/custom_components/aseko_local/aseko_decoder.py
+++ b/custom_components/aseko_local/aseko_decoder.py
@@ -16,9 +16,11 @@ from .aseko_data import (
 from .const import (
     PROBE_CLF_MISSING,
     PROBE_DOSE_MISSING,
-    PROBE_REDOX_MISSING,
     PROBE_OXY_MISSING,
+    PROBE_REDOX_MISSING,
     UNIT_TYPE_HOME,
+    UNIT_TYPE_HOME_CLF,
+    UNIT_TYPE_HOME_REDOX,
     UNIT_TYPE_NET,
     UNIT_TYPE_OXY,
     UNIT_TYPE_PROFI,
@@ -65,20 +67,20 @@ class AsekoDecoder:
     def _unit_type(data: bytes) -> AsekoDeviceType | None:
         """Determine the Aseko device type. Returns None until a reliable detection is possible."""
 
+        if data[4] == UNIT_TYPE_PROFI:  # Uncertain
+            return AsekoDeviceType.PROFI
+
+        if data[4] > UNIT_TYPE_SALT:
+            return AsekoDeviceType.SALT
+
+        if data[4] > UNIT_TYPE_NET:
+            return AsekoDeviceType.NET
+
         if data[4] == UNIT_TYPE_OXY:
             return AsekoDeviceType.OXY
 
-        if data[4] == UNIT_TYPE_PROFI:
-            return AsekoDeviceType.PROFI
-
-        if (data[4] & UNIT_TYPE_SALT) == UNIT_TYPE_SALT:
-            return AsekoDeviceType.SALT
-
-        if (data[4] & UNIT_TYPE_HOME) == UNIT_TYPE_HOME:
+        if data[4] >= UNIT_TYPE_HOME:
             return AsekoDeviceType.HOME
-
-        if bool(data[4] & UNIT_TYPE_NET):
-            return AsekoDeviceType.NET
 
         _LOGGER.warning("Unknown unit type: %s", data[4])
         return None
@@ -89,33 +91,54 @@ class AsekoDecoder:
     ) -> set[AsekoProbeType]:
         """Determine types of probes installed from the binary data."""
 
+        # Let's try to read everything for unknown unit type
+        if device_type is None:
+            return {
+                AsekoProbeType.PH,
+                AsekoProbeType.CLF,
+                AsekoProbeType.CLT,
+                AsekoProbeType.REDOX,
+                AsekoProbeType.DOSE,
+                AsekoProbeType.OXY,
+            }
+
         # OXY has no CLF/REDOX probe hardware. The SANOSIL (OXY Pure) probe
         # occupies the CLF slot physically, so PROBE_CLF_MISSING bit is 0 –
         # which would incorrectly add CLF without this guard.
-        if device_type == AsekoDeviceType.OXY:
+        elif device_type == AsekoDeviceType.OXY:
             return {AsekoProbeType.PH, AsekoProbeType.OXY}
 
-        probe_info = data[4]
+        # HOME units have different bitmask logic, and the bits are not consistent across HOME vs. NET/SALT as initially hoped
+        # – instead, they seem to indicate specific HOME subtypes with fixed probe configurations.
+        # The CLF vs. REDOX distinction is determined by the unit type byte rather than a missing probe bit.
+        elif device_type == AsekoDeviceType.HOME:
+            if data[4] == UNIT_TYPE_HOME_CLF:
+                return {AsekoProbeType.PH, AsekoProbeType.CLF}
 
-        probes = set()
-        probes.add(AsekoProbeType.PH)
+            elif data[4] == UNIT_TYPE_HOME_REDOX:
+                return {AsekoProbeType.PH, AsekoProbeType.REDOX}
 
-        if (
-            not bool(probe_info & PROBE_REDOX_MISSING)
-            or (data[4] & UNIT_TYPE_HOME) == UNIT_TYPE_HOME
-        ):
-            probes.add(AsekoProbeType.REDOX)
+            else:
+                return {AsekoProbeType.PH, AsekoProbeType.DOSE}
 
-        if not bool(probe_info & PROBE_CLF_MISSING):
-            probes.add(AsekoProbeType.CLF)
+        else:
+            probe_info = data[4]
 
-        if not bool(probe_info & PROBE_OXY_MISSING):
-            probes.add(AsekoProbeType.OXY)
+            probes = set()
+            probes.add(AsekoProbeType.PH)
 
-        if not bool(probe_info & PROBE_DOSE_MISSING):
-            probes.add(AsekoProbeType.DOSE)
+            if not bool(probe_info & PROBE_REDOX_MISSING):
+                probes.add(AsekoProbeType.REDOX)
 
-        return probes
+            if not bool(probe_info & PROBE_CLF_MISSING):
+                probes.add(AsekoProbeType.CLF)
+
+            if device_type != AsekoDeviceType.PROFI and not bool(
+                probe_info & PROBE_DOSE_MISSING
+            ):
+                probes.add(AsekoProbeType.DOSE)
+
+            return probes
 
     @staticmethod
     def _timestamp(data: bytes) -> datetime | None:
@@ -214,8 +237,7 @@ class AsekoDecoder:
         if AsekoProbeType.CLF not in unit.configuration:
             return
         unit.cl_free = int.from_bytes(data[16:18], "big") / 100
-        if unit.device_type != AsekoDeviceType.SALT:
-            unit.cl_free_mv = int.from_bytes(data[20:22], "big")
+        unit.cl_free_mv = int.from_bytes(data[20:22], "big")
 
     @staticmethod
     def _fill_salt_unit_data(unit: AsekoDevice, data: bytes) -> None:

--- a/custom_components/aseko_local/aseko_decoder.py
+++ b/custom_components/aseko_local/aseko_decoder.py
@@ -16,7 +16,6 @@ from .aseko_data import (
 from .const import (
     PROBE_CLF_MISSING,
     PROBE_DOSE_MISSING,
-    PROBE_OXY_MISSING,
     PROBE_REDOX_MISSING,
     UNIT_TYPE_HOME,
     UNIT_TYPE_HOME_CLF,

--- a/custom_components/aseko_local/const.py
+++ b/custom_components/aseko_local/const.py
@@ -24,16 +24,19 @@ READ_TIMEOUT = 30.0
 WATER_FLOW_TO_PROBES = 0xAA
 
 # Probe missing flags
+# (unfortunately seems not to be true for HOME)
 PROBE_REDOX_MISSING = 0x01
 PROBE_CLF_MISSING = 0x02
 PROBE_DOSE_MISSING = 0x04
 PROBE_OXY_MISSING = 0x08  # OXY Pure (H₂O₂) probe present on ASIN AQUA Oxygen
 
+UNIT_TYPE_HOME = 0x02  # HOME can be CLF (0x02) or REDOX (0x03) | posibly DOSE (0x04) - no examples for DOSE
+UNIT_TYPE_HOME_CLF = 0x02
+UNIT_TYPE_HOME_REDOX = 0x03
 UNIT_TYPE_OXY = 0x05  # ASIN AQUA Oxygen – exact match, no overlap with other types
-UNIT_TYPE_SALT = 0x0C  # SALT can be 0x0D or 0x0E
-UNIT_TYPE_HOME = 0x03  # HOME can be CLF or REDOX (CLF version code unknown)
-UNIT_TYPE_NET = 0x08  # NET can be 0x09 or 0x0A
-UNIT_TYPE_PROFI = 0x08  # PROFI is 0x08
+UNIT_TYPE_NET = 0x08  # NET can be CLF (0x09) or REDOX (0x0A) or DOSE (0x0B)
+UNIT_TYPE_SALT = 0x0C  # SALT can be CLF (0x0D) or REDOX (0x0E) or DOSE (0x0F)
+UNIT_TYPE_PROFI = 0x10  # PROFI is 0x10 - not confirmed
 
 UNSPECIFIED_VALUE = 0xFF
 UNSPECIFIED_V8 = -500  # v8 text frame sentinel for absent/unavailable probe readings

--- a/custom_components/aseko_local/manifest.json
+++ b/custom_components/aseko_local/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/hopkins-tk/home-assistant-aseko-local/issues",
   "requirements": [],
-  "version": "v1.5.0"
+  "version": "v1.6.0"
 }

--- a/docs/device analyzes/net_device_analysis.md
+++ b/docs/device analyzes/net_device_analysis.md
@@ -7,7 +7,7 @@
 | Model | ASIN AQUA NET |
 | Firmware | 7.x (120-byte frame); fw 8.x uses a different 463-byte frame structure (not yet implemented) |
 | Source | Issue #66; AquaNET log 2026-04-07 13:15–13:16 (probe-mode switch capture) |
-| byte[4] | `0x09` (CLF active) or `0x0b` (DOSE mode) → `bool(data[4] & 0x08)` → **NET** |
+| byte[4] | `0x09` (CLF active) or `0x0a` (Redox active) or `0x0b` (DOSE mode) → `bool(data[4] & 0x08)` → **NET** |
 
 ---
 

--- a/docs/device analyzes/salt_device_analysis.md
+++ b/docs/device analyzes/salt_device_analysis.md
@@ -7,7 +7,7 @@
 | Model | ASIN AQUA Salt |
 | Firmware | 5.x – 7.x |
 | Source | PR #87 live captures 2026-04-04; earlier frames 2026-04-02, 2026-04-03; Issue #84 |
-| byte[4] | `0x0E` or `0x0D` → `(data[4] & 0x0C) == 0x0C` → **SALT** |
+| byte[4] | `0x0E` (Redox) or `0x0D` (CLF) or `0x0f` (DOSE) → `(data[4] & 0x0C) == 0x0C` → **SALT** |
 
 ---
 

--- a/tests/test_aseko_decoder.py
+++ b/tests/test_aseko_decoder.py
@@ -11,6 +11,7 @@ from custom_components.aseko_local.aseko_data import (
 )
 from custom_components.aseko_local.aseko_decoder import AsekoDecoder
 from custom_components.aseko_local.const import (
+    UNIT_TYPE_PROFI,
     WATER_FLOW_TO_PROBES,
     YEAR_OFFSET,
 )
@@ -104,7 +105,7 @@ def test_decode_home() -> None:
     """Test decoding of HOME device data."""
 
     data = _make_base_bytes()
-    data[4] = 0x03  # HOME with CL probe
+    data[4] = 0x03  # HOME with Redox probe
     data[14:16] = (720).to_bytes(2, "big")  # ph
     data[37] = (
         0xB3  # pump presence/config byte (HOME has independent ports, not routed)
@@ -194,7 +195,7 @@ def test_decode_profi() -> None:
     """Test decoding of PROFI device data."""
 
     data = _make_base_bytes()
-    data[4] = 0x08  # PROFI with Redox & CLF probe
+    data[4] = UNIT_TYPE_PROFI  # PROFI with Redox & CLF probe
     data[16:18] = (100).to_bytes(2, "big")
     data[18:20] = (650).to_bytes(2, "big")
     data[14:16] = (800).to_bytes(2, "big")
@@ -203,6 +204,11 @@ def test_decode_profi() -> None:
 
     device = AsekoDecoder.decode(bytes(data))
     assert device.device_type == AsekoDeviceType.PROFI
+    assert device.configuration == {
+        AsekoProbeType.PH,
+        AsekoProbeType.CLF,
+        AsekoProbeType.REDOX,
+    }
     assert device.ph == 8.0
     assert device.redox == 650
     assert device.cl_free == 1.0
@@ -349,7 +355,9 @@ def test_decode_issue_61() -> None:
     )
 
     device = AsekoDecoder.decode(bytes(data))
+    print(device)
     assert device.device_type == AsekoDeviceType.HOME
+    assert device.configuration == {AsekoProbeType.PH, AsekoProbeType.REDOX}
     assert device.ph is not None
     assert device.redox is not None
     assert device.cl_free is None
@@ -541,7 +549,7 @@ def test_time_invalid() -> None:
 
 
 def test_available_probes_combinations() -> None:
-    from custom_components.aseko_local.aseko_decoder import (
+    from custom_components.aseko_local.const import (
         PROBE_CLF_MISSING,
         PROBE_DOSE_MISSING,
         PROBE_REDOX_MISSING,
@@ -555,6 +563,7 @@ def test_available_probes_combinations() -> None:
     assert probes == {
         AsekoProbeType.PH,
         AsekoProbeType.CLF,
+        AsekoProbeType.CLT,
         AsekoProbeType.REDOX,
         AsekoProbeType.DOSE,
         AsekoProbeType.OXY,
@@ -562,22 +571,22 @@ def test_available_probes_combinations() -> None:
 
     # Just CLF is missing
     data[4] = PROBE_CLF_MISSING
-    probes = AsekoDecoder._configuration(data)
+    probes = AsekoDecoder._configuration(data, AsekoDeviceType.PROFI)
     assert AsekoProbeType.CLF not in probes
 
     # Just REDOX is missing
     data[4] = PROBE_REDOX_MISSING
-    probes = AsekoDecoder._configuration(data)
+    probes = AsekoDecoder._configuration(data, AsekoDeviceType.PROFI)
     assert AsekoProbeType.REDOX not in probes
 
     # Just OXY is missing
     data[4] = PROBE_OXY_MISSING
-    probes = AsekoDecoder._configuration(data)
+    probes = AsekoDecoder._configuration(data, AsekoDeviceType.PROFI)
     assert AsekoProbeType.OXY not in probes
 
     # Just DOSE is missing
     data[4] = PROBE_DOSE_MISSING
-    probes = AsekoDecoder._configuration(data)
+    probes = AsekoDecoder._configuration(data, AsekoDeviceType.PROFI)
     assert AsekoProbeType.DOSE not in probes
 
 
@@ -732,3 +741,38 @@ def test_decode_oxy_ph_minus_pump_running() -> None:
     assert device.required_oxy_dose == 12
     assert device.flowrate_ph_minus == 60
     assert device.flowrate_floc == 10
+
+
+def test_decode_issue_99_home() -> None:
+    """Test decoding data from issue #99 (HOME with CLF - 0x02 - 0010)."""
+
+    data = bytearray.fromhex(
+        "06 90 ff ff 02 01 1a 04 19 0e 13 0a 00 00 02 b7 00 1e 00 1e 00 1f 90 fe 70 01 30 26 aa 08 00 00 00 00 00 00 00 43 0a b3"
+        "06 90 ff ff 02 03 1a 04 19 0e 13 0a 46 03 0a 19 08 00 10 00 12 00 16 00 02 be 01 30 03 15 00 0c 00 28 01 e0 2a 30 a2 55"
+        "06 90 ff ff 02 02 1a 04 19 0e 13 0a 00 3c 00 3c 00 3c 00 3c 00 0a 0d 21 37 64 00 f0 14 02 58 0f 0f 0f 1e 14 ff bc 02 77"
+    )
+
+    device = AsekoDecoder.decode(bytes(data))
+    print(device)
+    assert device.device_type == AsekoDeviceType.HOME
+    assert device.configuration == {AsekoProbeType.PH, AsekoProbeType.CLF}
+    assert device.cl_free is not None
+    assert device.cl_free_mv is not None
+    assert device.redox is None
+
+
+def test_decode_issue_99_salt() -> None:
+    """Test decoding data from issue #99 (SALT with CLF - 0x0d - 1101)."""
+
+    data = bytearray.fromhex(
+        "06 8f ff ff 0d 01 1a 04 19 0e 2d 28 00 20 02 cd 00 00 00 01 1f 00 ff fd c4 00 dd 4e 00 00 00 00 00 00 00 00 00 57 00 3a"
+        "06 8f ff ff 0d 03 1a 04 19 0e 2d 28 49 05 08 19 0a 1e 0e 1e 17 37 01 0a 02 b1 00 dd 07 0a 1e 0a ff 28 01 e0 0e 10 01 e7"
+        "06 8f ff ff 0d 02 1a 04 19 0e 2d 28 00 41 00 3c 19 4c db ff 00 3c 1e 2d 4b 96 00 f0 0a 0b b8 0f 0f 01 7b ff ff 9a 01 bc"
+    )
+
+    device = AsekoDecoder.decode(bytes(data))
+    assert device.device_type == AsekoDeviceType.SALT
+    assert device.configuration == {AsekoProbeType.PH, AsekoProbeType.CLF}
+    assert device.cl_free is not None
+    assert device.cl_free_mv is not None
+    assert device.redox is None

--- a/tests/test_aseko_decoder.py
+++ b/tests/test_aseko_decoder.py
@@ -744,7 +744,7 @@ def test_decode_oxy_ph_minus_pump_running() -> None:
 
 
 def test_decode_issue_99_home() -> None:
-    """Test decoding data from issue #99 (HOME with CLF - 0x02 - 0010)."""
+    """Test decoding data from issue #99 (HOME with CLF - 0x02)."""
 
     data = bytearray.fromhex(
         "06 90 ff ff 02 01 1a 04 19 0e 13 0a 00 00 02 b7 00 1e 00 1e 00 1f 90 fe 70 01 30 26 aa 08 00 00 00 00 00 00 00 43 0a b3"
@@ -762,7 +762,7 @@ def test_decode_issue_99_home() -> None:
 
 
 def test_decode_issue_99_salt() -> None:
-    """Test decoding data from issue #99 (SALT with CLF - 0x0d - 1101)."""
+    """Test decoding data from issue #99 (SALT with CLF - 0x0d)."""
 
     data = bytearray.fromhex(
         "06 8f ff ff 0d 01 1a 04 19 0e 2d 28 00 20 02 cd 00 00 00 01 1f 00 ff fd c4 00 dd 4e 00 00 00 00 00 00 00 00 00 57 00 3a"

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -11,7 +11,7 @@ from custom_components.aseko_local.button import (
 )
 from custom_components.aseko_local.aseko_decoder import AsekoDecoder
 from custom_components.aseko_local.aseko_data import AsekoDeviceType
-from custom_components.aseko_local.const import WATER_FLOW_TO_PROBES
+from custom_components.aseko_local.const import UNIT_TYPE_PROFI, WATER_FLOW_TO_PROBES
 
 
 # ── helpers ────────────────────────────────────────────────────────────────────
@@ -55,7 +55,7 @@ def _make_salt_bytes() -> bytearray:
 def _make_profi_bytes() -> bytearray:
     data = bytearray([0xFF] * 120)
     data[0:4] = (3003).to_bytes(4, "big")
-    data[4] = 0x08  # PROFI with CLF+REDOX
+    data[4] = UNIT_TYPE_PROFI  # PROFI with CLF+REDOX
     data[6:12] = [24, 6, 15, 12, 0, 0]
     data[14:16] = (700).to_bytes(2, "big")
     data[16:18] = (100).to_bytes(2, "big")

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -14,7 +14,7 @@ from custom_components.aseko_local.sensor import (
 )
 from custom_components.aseko_local.aseko_decoder import AsekoDecoder
 
-from custom_components.aseko_local.const import WATER_FLOW_TO_PROBES
+from custom_components.aseko_local.const import UNIT_TYPE_PROFI, WATER_FLOW_TO_PROBES
 from custom_components.aseko_local.aseko_data import AsekoDeviceType
 
 
@@ -170,7 +170,7 @@ def _make_profi_clf_redox_bytes() -> bytearray:
 
     data = bytearray([0xFF] * 120)
     data[0:4] = (1234).to_bytes(4, "big")  # serial_number
-    data[4] = 0x08  # PROFI with CL and REDOX probe
+    data[4] = UNIT_TYPE_PROFI  # PROFI with CL and REDOX probe
     data[6] = 24  # year (2024)
     data[7] = 6  # month
     data[8] = 15  # day
@@ -339,8 +339,6 @@ async def test_async_setup_salt_clf(hass) -> None:
     await async_setup_entry(hass, dummy_entry, mock_add_entities)
     await binary_async_setup_entry(hass, dummy_entry, mock_add_entities)
 
-    print(device.device_type)
-
     for entity in added_entities:
         name = getattr(entity.entity_description, "key", "unknown")
         value = (
@@ -361,9 +359,9 @@ async def test_async_setup_salt_clf(hass) -> None:
         getattr(e.device, "serial_number", None) == device.serial_number
         for e in added_entities
     )
-    # 11 sensors + 4 binary (water_flow, electrolyzer_active, filtration, ph_minus)
+    # 12 sensors + 4 binary (water_flow, electrolyzer_active, filtration, ph_minus)
     # + 2 consumption (ph_minus canister + total) + 1 connection_status
-    assert len(added_entities) == 18
+    assert len(added_entities) == 19
     assert any(
         getattr(e.entity_description, "key", None) != "water_flow_to_probes"
         for e in added_entities


### PR DESCRIPTION
Rework decoder to:
- fix support for `DOSE` mode (without probes)
- add support for `Aseko Asin Aqua HOME` with `CLF` probe
- add support for Free Chlorine (mv) for `Aseko Asin Aqua SALT`