### PR TITLE
Fix: Handle multiple devices, missing device registrations (instances)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The Aseko unit and your Home Assistant need to run on the same network or traffi
 | ASIN Aqua Net | 8.x | ✅ | ✅ Filtration, cl, PH− | ✅ cl, PH− |
 | ASIN Aqua Salt | ≤ 7.x | ✅ | ✅ Filtration, Electrolyzer, Algicide, Flocculant, pH− | ✅ Algicide, Flocculant, pH− |
 | ASIN Aqua Oxy | ≤ 7.x | ✅ | ✅ Filtration, Oxy, Algicide, Flocculant, pH− | ✅ Oxy,Algicide, Flocculant, pH− |
+| ASIN Aqua Home | ≤ 7.x | ✅ | ✅ Filtration, cl, Algicide, Flocculant, pH− | ✅ Algicide, Flocculant, pH− |
 > **Firmware note:** This integration supports both the **120-byte binary protocol** (firmware ≤ 7.x, port **47524**) and the **text-frame protocol** (firmware 8.x, port **51050**). The port can be changed in the integration settings to match your device.
 
 ### Partially supported / untested devices
@@ -30,8 +31,6 @@ The following devices are likely compatible but the byte mapping for pump states
 
 | Device | Status | Known unknowns |
 |---|---|---|
-| ASIN Aqua Home | ⚠️ Untested | Pump state bits uncertain; algicide/floc may share a single bit |
-| ASIN Salt | ⚠️ Untested | |
 | ASIN Aqua Pro | ⚠️ Untested | Pump state bits uncertain; pH+ pump bit position unknown |
 | ASIN Aqua Home Pro (07.2026) | ⚠️ Untested | Pump state bits uncertain; pH+ pump bit position unknown |
 | ASIN Aqua Salt Pro (07.2026) | ⚠️ Untested | Pump state bits uncertain; pH+ pump bit position unknown |

--- a/custom_components/aseko_local/__init__.py
+++ b/custom_components/aseko_local/__init__.py
@@ -82,8 +82,8 @@ async def async_setup_entry(
             _LOGGER.debug("Deferring platform setup; first snapshot not ready yet.")
             return
 
-        await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
         rd.device_discovered = True
+        await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
         _LOGGER.info("New Aseko device registered: %s", device.serial_number)
 
     coordinator = AsekoLocalDataUpdateCoordinator(

--- a/custom_components/aseko_local/__init__.py
+++ b/custom_components/aseko_local/__init__.py
@@ -84,7 +84,9 @@ async def async_setup_entry(
 
         rd.device_discovered = True  # set early to prevent concurrent calls
         try:
-            await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
+            await hass.config_entries.async_forward_entry_setups(
+                config_entry, PLATFORMS
+            )
         except Exception:
             rd.device_discovered = False  # allow retry on next device callback
             raise

--- a/custom_components/aseko_local/__init__.py
+++ b/custom_components/aseko_local/__init__.py
@@ -82,8 +82,12 @@ async def async_setup_entry(
             _LOGGER.debug("Deferring platform setup; first snapshot not ready yet.")
             return
 
-        rd.device_discovered = True
-        await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
+        rd.device_discovered = True  # set early to prevent concurrent calls
+        try:
+            await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
+        except Exception:
+            rd.device_discovered = False  # allow retry on next device callback
+            raise
         _LOGGER.info("New Aseko device registered: %s", device.serial_number)
 
     coordinator = AsekoLocalDataUpdateCoordinator(

--- a/custom_components/aseko_local/aseko_decoder.py
+++ b/custom_components/aseko_local/aseko_decoder.py
@@ -260,8 +260,10 @@ class AsekoDecoder:
             required_cl_free          CLF probe
             required_cl_dose          DOSE probe without CLF (pure dosing mode)
             required_redox            REDOX probe, not on PROFI (× 10)
-        byte[54] → required_algicide or required_floc
-                   (byte[37] routing, only on devices with a shared pump port)
+        byte[54] → required_floc      (OXY and HOME: independent pump ports)
+                 → required_algicide or required_floc
+                   (SALT: shared pump port, routed via byte[37])
+        byte[72] → required_algicide  (OXY and HOME: independent pump ports)
         """
         # byte[52]: pH setpoint — present on all devices with a pH probe.
         if AsekoProbeType.PH in unit.configuration:
@@ -276,6 +278,15 @@ class AsekoDecoder:
             unit.required_floc = AsekoDecoder._normalize_value(data[54], int)
             unit.required_algicide = AsekoDecoder._normalize_value(data[72], int)
             return
+
+        # HOME devices have independent pump ports for algicide and flocculant
+        # (same layout as OXY Pure for these two setpoints).
+        # byte[54] = required_floc (ml/h)         confirmed: 2026-04-28, serial 110128063, value=10
+        # byte[72] = required_algicide (ml/m³/d)  confirmed: 2026-04-28, serial 110128063, value=0
+        # Fall through so byte[53] is still decoded as required_cl_free / required_redox below.
+        if unit.device_type == AsekoDeviceType.HOME:
+            unit.required_floc = AsekoDecoder._normalize_value(data[54], int)
+            unit.required_algicide = AsekoDecoder._normalize_value(data[72], int)
 
         # byte[53]: mutually exclusive interpretations determined by probe/device type.
         if AsekoProbeType.CLF in unit.configuration:

--- a/custom_components/aseko_local/aseko_server.py
+++ b/custom_components/aseko_local/aseko_server.py
@@ -345,24 +345,34 @@ class AsekoDeviceServer:
         starts at an offset. This function searches for the correct
         start position and rewinds the frame accordingly.
 
+        The search is bounded by the actual frame length so that devices
+        sending frames shorter than MESSAGE_SIZE (e.g. pre-2021 hardware,
+        see issue #86) are handled gracefully: alignment is attempted within
+        whatever buffer was received, and a ValueError is raised — causing a
+        clean disconnect — only if no valid position can be found.
+
         Returns:
             tuple[bytes, int]: (rewound_frame, offset)
         """
+        # Alignment check requires at least bytes [offset+0 .. offset+85].
+        # max_offset is the last offset at which data[offset+85] is still valid.
+        max_offset = len(data) - 86
+        if max_offset < 0:
+            raise ValueError(f"Binary frame too short to align: {len(data)} bytes")
 
         offset = 0
         while (
-            offset + 85 >= len(data)
-            or data[offset + 5] != 0x01
+            data[offset + 5] != 0x01
             or data[offset + 45] != 0x03
             or data[offset + 85] != 0x02
             or data[offset : offset + 4] != data[offset + 40 : offset + 44]
             or data[offset + 40 : offset + 44] != data[offset + 80 : offset + 84]
         ):
-            if offset + 85 >= len(data):
+            offset += 1
+            if offset > max_offset:
                 raise ValueError(
                     f"No valid binary frame alignment found in {len(data)}-byte buffer"
                 )
-            offset += 1
 
         if offset == 0:
             _LOGGER.debug(

--- a/custom_components/aseko_local/aseko_server.py
+++ b/custom_components/aseko_local/aseko_server.py
@@ -345,20 +345,9 @@ class AsekoDeviceServer:
         starts at an offset. This function searches for the correct
         start position and rewinds the frame accordingly.
 
-        The search is bounded by the actual frame length so that devices
-        sending frames shorter than MESSAGE_SIZE (e.g. pre-2021 hardware,
-        see issue #86) are handled gracefully: alignment is attempted within
-        whatever buffer was received, and a ValueError is raised — causing a
-        clean disconnect — only if no valid position can be found.
-
         Returns:
             tuple[bytes, int]: (rewound_frame, offset)
         """
-        # Alignment check requires at least bytes [offset+0 .. offset+85].
-        # max_offset is the last offset at which data[offset+85] is still valid.
-        max_offset = len(data) - 86
-        if max_offset < 0:
-            raise ValueError(f"Binary frame too short to align: {len(data)} bytes")
 
         offset = 0
         while (
@@ -369,10 +358,6 @@ class AsekoDeviceServer:
             or data[offset + 40 : offset + 44] != data[offset + 80 : offset + 84]
         ):
             offset += 1
-            if offset > max_offset:
-                raise ValueError(
-                    f"No valid binary frame alignment found in {len(data)}-byte buffer"
-                )
 
         if offset == 0:
             _LOGGER.debug(

--- a/custom_components/aseko_local/aseko_server.py
+++ b/custom_components/aseko_local/aseko_server.py
@@ -351,12 +351,17 @@ class AsekoDeviceServer:
 
         offset = 0
         while (
-            data[offset + 5] != 0x01
+            offset + 85 >= len(data)
+            or data[offset + 5] != 0x01
             or data[offset + 45] != 0x03
             or data[offset + 85] != 0x02
             or data[offset : offset + 4] != data[offset + 40 : offset + 44]
             or data[offset + 40 : offset + 44] != data[offset + 80 : offset + 84]
         ):
+            if offset + 85 >= len(data):
+                raise ValueError(
+                    f"No valid binary frame alignment found in {len(data)}-byte buffer"
+                )
             offset += 1
 
         if offset == 0:

--- a/custom_components/aseko_local/binary_sensor.py
+++ b/custom_components/aseko_local/binary_sensor.py
@@ -8,11 +8,12 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import AsekoLocalConfigEntry
 from .aseko_data import AsekoDevice
+from .coordinator import AsekoLocalDataUpdateCoordinator
 from .entity import AsekoLocalEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -99,6 +100,31 @@ async def async_setup_entry(
         [d.serial_number for d in devices],
     )
 
+    entities = _build_binary_sensor_entities(devices, coordinator)
+    _LOGGER.debug(">>> [sensor] Adding %s binary sensors", len(entities))
+    async_add_entities(entities)
+
+    @callback
+    def _async_add_new_device(device: AsekoDevice) -> None:
+        new_entities = _build_binary_sensor_entities([device], coordinator)
+        if new_entities:
+            _LOGGER.debug(
+                ">>> [sensor] Adding %s binary sensors for new device %s",
+                len(new_entities),
+                device.serial_number,
+            )
+            async_add_entities(new_entities)
+
+    config_entry.async_on_unload(
+        coordinator.async_add_new_device_listener(_async_add_new_device)
+    )
+
+
+def _build_binary_sensor_entities(
+    devices: list[AsekoDevice],
+    coordinator: AsekoLocalDataUpdateCoordinator,
+) -> list[BinarySensorEntity]:
+    """Create binary sensor entities for the given list of devices."""
     entities: list[BinarySensorEntity] = []
 
     for device in devices:
@@ -131,8 +157,7 @@ async def async_setup_entry(
                 entity.unique_id,
             )
 
-    _LOGGER.debug(">>> [sensor] Adding %s binary sensors", len(entities))
-    async_add_entities(entities)
+    return entities
 
 
 class AsekoLocalBinarySensorEntity(AsekoLocalEntity, BinarySensorEntity):

--- a/custom_components/aseko_local/button.py
+++ b/custom_components/aseko_local/button.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import AsekoLocalConfigEntry
@@ -71,6 +71,25 @@ async def async_setup_entry(
 
     coordinator = config_entry.runtime_data.coordinator
     devices = coordinator.get_devices()
+    entities = _build_button_entities(devices, coordinator)
+    async_add_entities(entities)
+
+    @callback
+    def _async_add_new_device(device: AsekoDevice) -> None:
+        new_entities = _build_button_entities([device], coordinator)
+        if new_entities:
+            async_add_entities(new_entities)
+
+    config_entry.async_on_unload(
+        coordinator.async_add_new_device_listener(_async_add_new_device)
+    )
+
+
+def _build_button_entities(
+    devices: list[AsekoDevice],
+    coordinator: AsekoLocalDataUpdateCoordinator,
+) -> list[ButtonEntity]:
+    """Create button entities for the given list of devices."""
     entities: list[ButtonEntity] = []
 
     for device in devices:
@@ -88,7 +107,7 @@ async def async_setup_entry(
                 continue  # decoder determined pump absent on this specific unit
             entities.append(AsekoResetButtonEntity(device, coordinator, description))
 
-    async_add_entities(entities)
+    return entities
 
 
 class AsekoResetButtonEntity(AsekoLocalEntity, ButtonEntity):

--- a/custom_components/aseko_local/coordinator.py
+++ b/custom_components/aseko_local/coordinator.py
@@ -118,7 +118,14 @@ class AsekoLocalDataUpdateCoordinator(DataUpdateCoordinator[AsekoData]):
             if self.cb_new_device is not None:
                 self.hass.loop.create_task(self.cb_new_device(device))
             for listener in list(self._new_device_listeners):
-                listener(device)
+                try:
+                    listener(device)
+                except Exception:
+                    _LOGGER.exception(
+                        "❌ New-device listener %r failed for device serial=%s",
+                        listener,
+                        device.serial_number,
+                    )
 
     def async_add_new_device_listener(
         self, listener: Callable[[AsekoDevice], None]

--- a/custom_components/aseko_local/coordinator.py
+++ b/custom_components/aseko_local/coordinator.py
@@ -51,6 +51,8 @@ class AsekoLocalDataUpdateCoordinator(DataUpdateCoordinator[AsekoData]):
         self._last_v8_frames: dict[int, bytes] = {}
         # Unsubscribe handle for the periodic stale-check
         self._stale_check_unsub: Callable[[], None] | None = None
+        # Per-platform listeners called whenever a brand-new device is discovered
+        self._new_device_listeners: list[Callable[[AsekoDevice], None]] = []
 
     def devices_update_callback(self, device: AsekoDevice) -> None:
         """Receive callback with device update."""
@@ -115,6 +117,24 @@ class AsekoLocalDataUpdateCoordinator(DataUpdateCoordinator[AsekoData]):
             _LOGGER.debug("🆕 NEW DEVICE DISCOVERED: %s", device.serial_number)
             if self.cb_new_device is not None:
                 self.hass.loop.create_task(self.cb_new_device(device))
+            for listener in list(self._new_device_listeners):
+                listener(device)
+
+    def async_add_new_device_listener(
+        self, listener: Callable[[AsekoDevice], None]
+    ) -> Callable[[], None]:
+        """Register a callback invoked whenever a brand-new device is discovered.
+
+        Returns an unsubscribe callable that removes the listener.
+        Platforms call this in async_setup_entry and pass the result to
+        config_entry.async_on_unload() so the listener is removed on unload.
+        """
+        self._new_device_listeners.append(listener)
+
+        def _unsub() -> None:
+            self._new_device_listeners.remove(listener)
+
+        return _unsub
 
     def store_raw_frame(self, raw_frame: bytes) -> None:
         """Cache the last raw frame, keyed by serial number (bytes 0-3).

--- a/custom_components/aseko_local/manifest.json
+++ b/custom_components/aseko_local/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/hopkins-tk/home-assistant-aseko-local/issues",
   "requirements": [],
-  "version": "v1.6.0"
+  "version": "v1.6.1"
 }

--- a/custom_components/aseko_local/sensor.py
+++ b/custom_components/aseko_local/sensor.py
@@ -14,7 +14,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.const import UnitOfElectricPotential, UnitOfTemperature, UnitOfVolume
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
@@ -453,6 +453,31 @@ async def async_setup_entry(
         [d.serial_number for d in devices],
     )
 
+    entities: list[SensorEntity] = _build_sensor_entities(devices, coordinator)
+    _LOGGER.debug(">>> [sensor] Adding %s sensors", len(entities))
+    async_add_entities(entities)
+
+    @callback
+    def _async_add_new_device(device: AsekoDevice) -> None:
+        new_entities = _build_sensor_entities([device], coordinator)
+        if new_entities:
+            _LOGGER.debug(
+                ">>> [sensor] Adding %s sensors for new device %s",
+                len(new_entities),
+                device.serial_number,
+            )
+            async_add_entities(new_entities)
+
+    config_entry.async_on_unload(
+        coordinator.async_add_new_device_listener(_async_add_new_device)
+    )
+
+
+def _build_sensor_entities(
+    devices: list[AsekoDevice],
+    coordinator: AsekoLocalDataUpdateCoordinator,
+) -> list[SensorEntity]:
+    """Create sensor entities for the given list of devices."""
     entities: list[SensorEntity] = []
 
     for device in devices:
@@ -512,8 +537,7 @@ async def async_setup_entry(
             )
         )
 
-    _LOGGER.debug(">>> [sensor] Adding %s sensors", len(entities))
-    async_add_entities(entities)
+    return entities
 
 
 class AsekoConsumptionSensorEntity(AsekoLocalEntity, RestoreSensor):

--- a/docs/device analyzes/home_device_analysis.md
+++ b/docs/device analyzes/home_device_analysis.md
@@ -1,0 +1,255 @@
+# ASIN AQUA Home — Device Analysis
+
+**Model**: ASIN AQUA HOME (CLF variant)
+**Serial**: 110128063 (`0x06906bbf`)
+**Device type byte**: `0x02` → `UNIT_TYPE_HOME_CLF`
+**Source frame timestamp**: 2026-04-28 08:27:07
+**Ground truth**: Aseko Live app screenshots (Status, Consumption, Config pages)
+
+---
+
+## Raw Frame (120 bytes)
+
+The Aseko protocol sends 3×40-byte segments in a single TCP payload.
+Each segment header: `[0-3]` serial (big-endian), `[4]` device type, `[5]` segment marker (`0x01 / 0x03 / 0x02`), `[6-11]` timestamp.
+
+```
+Seg1 (bytes   0–39): 06 90 6b bf  02 01  1a 04 1c 08 1b 07
+                     00 28 02 75 00 00 00 00 00 02 90 fe 70 01 7b 08 00 00 ff ff 00 00 00 00 00 43 0a 85
+
+Seg2 (bytes  40–79): 06 90 6b bf  02 03  1a 04 1c 08 1b 07
+                     46 03 0a 19 08 00 10 00 12 00 16 00 02 7c 01 7b 03 15 00 0c 00 28 01 e0 2a 30 a0 d8
+
+Seg3 (bytes 80–119): 06 90 6b bf  02 02  1a 04 1c 08 1b 07
+                     00 3c 00 3c 00 3c 00 3c 00 0a 0d 21 37 64 00 f0 14 02 58 0f 0f 0f 1e 14 ff bc 02 71
+```
+
+---
+
+## Byte-by-Byte Analysis
+
+### Segment 1 (bytes 0–39) — real-time sensor data
+
+| Byte(s) | Hex      | Decimal | Field                    | Decoded value        | App value     | Status |
+|---------|----------|---------|--------------------------|----------------------|---------------|--------|
+| 0–3     | `06906bbf` | —     | Serial number (big-endian) | 110,128,063         | —             | ✓      |
+| 4       | `02`     | 2       | Device type              | HOME (CLF variant)   | —             | ✓      |
+| 5       | `01`     | 1       | Segment marker           | Segment 1            | —             | ✓      |
+| 6–11    | `1a 04 1c 08 1b 07` | — | Timestamp           | 2026-04-28 08:27:07  | —             | ✓      |
+| 12      | `00`     | 0       | Unknown                  | —                    | —             | ?      |
+| 13      | `28`     | 40      | Unknown                  | —                    | —             | ?      |
+| 14–15   | `0275`   | 629     | pH (÷100)                | **6.29**             | 6.56†         | ✓†     |
+| 16–17   | `0000`   | 0       | Cl free (÷100)           | **0.00 mg/l**        | 0.00 mg/l     | ✓      |
+| 18–19   | `0000`   | 0       | Unused (no REDOX probe)  | —                    | —             | —      |
+| 20–21   | `0002`   | 2       | Cl free mV (big-endian)  | **2 mV**             | —             | ✓      |
+| 22–23   | `90fe`   | 37118   | Unknown (internal probe?) | —                   | —             | ?      |
+| 24      | `70`     | 112     | Unknown                  | —                    | —             | ?      |
+| 25–26   | `017b`   | 379     | Water temp (÷10)         | **37.9°C**           | 38.2°C†       | ✓†     |
+| 27      | `08`     | 8       | Unknown                  | —                    | —             | ?      |
+| 28      | `00`     | 0       | Water flow to probes     | **False** (≠ 0xAA)   | NO            | ✓      |
+| 29      | `00`     | 0       | Actuator bits            | all pumps stopped    | STOP          | ✓      |
+| 30–31   | `ffff`   | —       | UNSPECIFIED / padding    | —                    | —             | —      |
+| 32–36   | `00…00`  | 0       | Unknown                  | —                    | —             | ?      |
+| 37      | `43`     | 67      | Pump presence bitmap     | see note §           | —             | §      |
+| 38      | `0a`     | 10      | Unknown                  | —                    | —             | ?      |
+| 39      | `85`     | 133     | Unknown (checksum?)      | —                    | —             | ?      |
+
+† pH 6.29 vs 6.56 and water temp 37.9 vs 38.2 are explained by different timestamps (frame: 08:27:07, screenshot: later that day). Not a decoding bug.
+
+§ **byte[37] = `0x43`**: For SALT devices this is the algicide/flocculant routing byte. For HOME devices `byte37_routes_pump_type = False`, so routing logic is skipped. However the flowrate code (mistakenly) falls through to the SALT routing path and reads bit 7 (= 0) → flocculant branch → correctly yields `flowrate_floc = data[101] = 10`. This works by coincidence for this frame but the semantic is wrong. A HOME-specific flowrate branch (similar to OXY) is the correct long-term fix.
+
+#### Actuator byte[29] — HOME masks (uncertain)
+
+| Bit   | Mask   | Field                  | Value (0x00) |
+|-------|--------|------------------------|-------------|
+| bit 3 | `0x08` | filtration_pump_running | False ✓     |
+| bit 6 | `0x40` | cl_pump_running        | False ✓     |
+| bit 7 | `0x80` | ph_minus_pump_running  | False ✓     |
+| bit 5 | `0x20` | algicide / floc running | False ✓    |
+
+All masks marked **uncertain** — confirmed only from their absence (byte[29]=0x00 when nothing is running). Need frames captured while individual pumps are active to confirm per-pump bits.
+
+---
+
+### Segment 2 (bytes 40–79) — setpoints and schedule
+
+| Byte(s) | Hex      | Decimal | Field                         | Decoded value  | App value         | Status |
+|---------|----------|---------|-------------------------------|----------------|-------------------|--------|
+| 40–43   | `06906bbf` | —     | Serial (repeated)             | 110,128,063    | —                 | ✓      |
+| 44      | `02`     | 2       | Device type (repeated)        | HOME           | —                 | ✓      |
+| 45      | `03`     | 3       | Segment marker                | Segment 2      | —                 | ✓      |
+| 46–51   | `1a 04 1c 08 1b 07` | — | Timestamp (repeated)       | 2026-04-28 08:27:07 | —            | ✓      |
+| 52      | `46`     | 70      | required_ph (÷10)             | **7.0**        | 7.0               | ✓      |
+| 53      | `03`     | 3       | required_cl_free (÷10)        | **0.3 mg/l**   | 0.3               | ✓      |
+| 54      | `0a`     | 10      | required_floc                 | **10 ml/h** ✓  | 10 ml/h           | ✓ (fixed) |
+| 55      | `19`     | 25      | required_water_temperature    | 25°C ⚠️        | — (disabled)      | ⚠️     |
+| 56–57   | `08 00`  | —       | start1                        | 08:00          | NONSTOP 24H ⚠️    | ⚠️     |
+| 58–59   | `10 00`  | —       | stop1                         | 16:00          | NONSTOP 24H ⚠️    | ⚠️     |
+| 60–61   | `12 00`  | —       | start2                        | 18:00          | NONSTOP 24H ⚠️    | ⚠️     |
+| 62–63   | `16 00`  | —       | stop2                         | 22:00          | NONSTOP 24H ⚠️    | ⚠️     |
+| 64–65   | `027c`   | 636     | Unknown                       | —              | —                 | ?      |
+| 66–67   | `017b`   | 379     | Unknown (= water temp raw)    | —              | —                 | ?      |
+| 68      | `03`     | 3       | backwash_every_n_days         | **3 days**     | every 3 days      | ✓      |
+| 69–70   | `15 00`  | —       | backwash_time                 | **21:00**      | starts at 21:00   | ✓      |
+| 71      | `0c`     | 12      | backwash_duration (×10 s)     | **120 s = 2 min** | takes 02:00 min | ✓    |
+| 72      | `00`     | 0       | required_algicide             | **0 ml/m³/day** ✓ | 0 ml/m³/day    | ✓ (fixed) |
+| 73      | `28`     | 40      | Unknown                       | —              | —                 | ?      |
+| 74–75   | `01e0`   | 480     | delay_after_startup (s)       | **480 s = 8 min** | 8 min          | ✓      |
+| 76      | `2a`     | 42      | Unknown                       | —              | —                 | ?      |
+| 77      | `30`     | 48      | Unknown                       | —              | —                 | ?      |
+| 78      | `a0`     | 160     | Unknown                       | —              | —                 | ?      |
+| 79      | `d8`     | 216     | Unknown                       | —              | —                 | ?      |
+
+---
+
+### Segment 3 (bytes 80–119) — pool parameters and flowrates
+
+| Byte(s) | Hex      | Decimal | Field                        | Decoded value  | App value         | Status |
+|---------|----------|---------|------------------------------|----------------|-------------------|--------|
+| 80–83   | `06906bbf` | —     | Serial (repeated)            | 110,128,063    | —                 | ✓      |
+| 84      | `02`     | 2       | Device type (repeated)       | HOME           | —                 | ✓      |
+| 85      | `02`     | 2       | Segment marker               | Segment 3      | —                 | ✓      |
+| 86–91   | `1a 04 1c 08 1b 07` | — | Timestamp (repeated)      | 2026-04-28 08:27:07 | —            | ✓      |
+| 92–93   | `003c`   | 60      | pool_volume (big-endian)     | **60 m³**      | 60 m³             | ✓      |
+| 94–95   | `003c`   | 60      | max_filling_time (big-endian) | **60 min**    | —                 | ✓      |
+| 96      | `00`     | 0       | Unknown                      | —              | —                 | ?      |
+| 97      | `3c`     | 60      | flowrate_ph_plus? (unconf.)  | —              | —                 | ?      |
+| 98      | `00`     | 0       | Unknown                      | —              | —                 | ?      |
+| 99      | `3c`     | 60      | flowrate_chlor               | **60 ml/min**  | Chlor Pure listed | ✓      |
+| 100     | `00`     | 0       | Unknown                      | —              | —                 | ?      |
+| 101     | `0a`     | 10      | flowrate_floc (via routing)  | **10 ml/min**  | Floc+c listed     | ✓      |
+| 102     | `0d`     | 13      | Unknown                      | —              | —                 | ?      |
+| 103     | `21`     | 33      | flowrate_algicide? (unconf.) | —              | Algicide listed   | ?      |
+| 104     | `37`     | 55      | Unknown                      | —              | —                 | ?      |
+| 105     | `64`     | 100     | Unknown                      | —              | —                 | ?      |
+| 106–107 | `00f0`   | 240     | delay_after_dose (s)         | **240 s = 4 min** | 4 min          | ✓      |
+| 108     | `14`     | 20      | Unknown                      | —              | —                 | ?      |
+| 109–110 | `0258`   | 600     | Unknown                      | —              | —                 | ?      |
+| 111–113 | `0f 0f 0f` | 15, 15, 15 | Unknown                | —              | —                 | ?      |
+| 114     | `1e`     | 30      | Unknown                      | —              | —                 | ?      |
+| 115     | `14`     | 20      | Unknown                      | —              | —                 | ?      |
+| 116     | `ff`     | —       | UNSPECIFIED / padding        | —              | —                 | —      |
+| 117     | `bc`     | 188     | Unknown                      | —              | —                 | ?      |
+| 118–119 | `0271`   | 625     | Unknown (checksum?)          | —              | —                 | ?      |
+
+Note on **bytes 94–95**: `max_filling_time` reads bytes[94:96] as a big-endian 16-bit value = `0x003c` = 60. `flowrate_ph_minus` independently reads byte[95] = `0x3c` = 60. They overlap but coincidentally produce the same result because the high byte (94) is 0x00. If byte[94] ever becomes non-zero the max_filling_time would be inflated; however for HOME this is expected to fit in one byte (max ~255 min).
+
+---
+
+## Decoded Values vs Ground Truth Summary
+
+| Field                     | Decoded          | Aseko Live        | Match |
+|---------------------------|------------------|-------------------|-------|
+| pH                        | 6.29             | 6.56              | ✓ (Δt)|
+| Cl free                   | 0.00 mg/l        | 0.00 mg/l         | ✓     |
+| Water temperature         | 37.9°C           | 38.2°C            | ✓ (Δt)|
+| Water flow to probes      | False            | NO                | ✓     |
+| Filtration pump running   | False            | STOP              | ✓     |
+| required_ph               | 7.0              | 7.0               | ✓     |
+| required_cl_free          | 0.3 mg/l         | 0.3               | ✓     |
+| required_floc             | 10 ml/h          | 10 ml/h           | ✓ (fixed) |
+| required_algicide         | 0 ml/m³/day      | 0 ml/m³/day       | ✓ (fixed) |
+| required_water_temperature | 25°C            | --- (disabled)    | ⚠️ see Issue 3 |
+| Filtration schedule       | 08:00–16:00 / 18:00–22:00 | NONSTOP 24H | ⚠️ see Issue 4 |
+| backwash_every_n_days     | 3                | every 3 days      | ✓     |
+| backwash_time             | 21:00            | starts at 21:00   | ✓     |
+| backwash_duration         | 120 s            | 02:00 min         | ✓     |
+| pool_volume               | 60 m³            | 60 m³             | ✓     |
+| delay_after_startup       | 480 s (8 min)    | 8 min             | ✓     |
+| delay_after_dose          | 240 s (4 min)    | 4 min             | ✓     |
+| flowrate_ph_minus         | 60               | pH- listed        | ✓     |
+| flowrate_chlor            | 60               | Chlor Pure listed | ✓     |
+| flowrate_floc             | 10               | Floc+c listed     | ✓     |
+| flowrate_algicide         | None             | Algicide listed   | ⚠️    |
+
+---
+
+## Bugs Found
+
+### Bug 1 (Fixed) — `required_floc` not decoded for HOME devices
+
+**Root cause**: `_fill_required_data` decodes byte[54] as either `required_floc` or `required_algicide` only when `masks.byte37_routes_pump_type is True`. For HOME devices `byte37_routes_pump_type = False` (correct — HOME has independent pump ports), so the entire byte[54] block was silently skipped.
+
+**Evidence**: byte[54] = `0x0a` = 10 → required_floc = 10 ml/h. Aseko Live Config confirms **Flocc: 10 ml/hour**.
+
+**Fix applied** (`aseko_decoder.py`): Added a HOME-specific branch (parallel to OXY) that unconditionally decodes byte[54] as `required_floc`. Test: `test_decode_home_clf_real_frame`.
+
+---
+
+### Bug 2 (Fixed) — `required_algicide` not decoded for HOME devices
+
+**Root cause**: Same as Bug 1 — the byte[54]/byte[72] routing block was skipped for HOME. HOME uses the same byte positions as OXY Pure.
+
+**Evidence**: Aseko Live Config shows **Algicide: 0 ml/m³/day**. Frame byte[72] = `0x00` = 0.
+
+**Fix applied** (`aseko_decoder.py`): The same HOME branch also decodes byte[72] as `required_algicide` (identical to OXY layout). Test: `test_decode_home_clf_real_frame`.
+
+---
+
+### Issue 3 (Pending — low-water condition at capture time)
+
+**Observation**: byte[55] = `0x19` = 25 → decoded as 25°C. Aseko Live shows "---" for Water temp (disabled/not configured).
+
+**Context**: The frame was captured while Aseko Live was showing an error, most likely caused by insufficient water in the pool (evidenced by cl_free = 0 and filtration pump stopped). The device may report a placeholder/default value in certain fields during an error or standby state, which would explain the "---" in the app despite byte[55] being non-zero.
+
+**Action needed**: Request a new frame when the pool is running normally and compare byte[55] — if the water temperature control feature is enabled and active, the decoded value should match the app. Until then this issue remains unresolved.
+
+---
+
+### Issue 4 (Pending — low-water condition at capture time)
+
+**Observation**: Aseko Live Config shows **FILTRATION NONSTOP 24H**. The decoder produces start1=08:00, stop1=16:00, start2=18:00, stop2=22:00 (12 h total — inconsistent with nonstop mode).
+
+**Context**: The frame was captured while the pool had an error (likely too little water). The filtration pump was stopped and byte[29] = 0x00, consistent with an active alarm suppressing normal operation. It is possible that in a normal-operation frame the scheduled times look different, or that a separate flag byte signals "nonstop" mode.
+
+**Hypothesis**: A "nonstop mode" flag byte exists somewhere in the frame. The scheduled times in bytes 56–63 may store the last manually-configured schedule as a fallback, even when nonstop mode is active.
+
+**Action needed**: Request a new frame captured during normal (nonstop) operation and compare bytes 52–79 to identify the nonstop flag. Ideally also a second frame with timed schedule mode active.
+
+---
+
+### Issue 5 (Pending — algicide configured but not active)
+
+**Observation**: Aseko Live Consumption page shows **Algicide** as a tracked chemical. `flowrate_algicide` is `None` in the decoded output.
+
+**Context**: `required_algicide` = 0 ml/m³/day (byte[72] = 0x00). When the algicide dose is configured as zero the pump is effectively disabled and the device likely transmits 0 or UNSPECIFIED (0xFF) for the corresponding flowrate byte. This would explain why no valid flowrate is seen in the frame.
+
+**Hypothesis re byte[103]**: byte[103] = `0x21` = 33 is a candidate for the algicide flowrate position (independent port, same layout as OXY). However, with dose = 0 the expected flowrate would be 0 — not 33 — so byte[103] is more likely an unrelated field. The actual algicide flowrate may be 0x00 or 0xFF at a yet-unidentified byte position when the pump is inactive.
+
+**Current code path**: HOME falls through to the SALT routing logic in `_fill_flowrate_data`. Since byte[37] bit 7 = 0, the flocculant branch fires and byte[101] = 10 is correctly assigned to `flowrate_floc`. byte[103] is never read.
+
+**Action needed**: Ask the user whether they plan to activate algicide dosing. If yes, request a frame captured while algicide is actively being dosed (dose > 0), then compare bytes 95–115 to locate the flowrate byte. Once confirmed, add a HOME-specific branch in `_fill_flowrate_data` mirroring the OXY branch.
+
+---
+
+## Applied Fixes
+
+1. **`aseko_decoder.py` → `_fill_required_data`** — added HOME device branch (parallel to OXY, no early return so `required_cl_free` / `required_redox` are still decoded via the CLF branch):
+   - byte[54] → `required_floc` (ml/h)
+   - byte[72] → `required_algicide` (ml/m³/day)
+
+```python
+# HOME: has both CLF/REDOX setpoint at byte[53] AND independent floc/algicide setpoints.
+# Same byte layout as OXY Pure for these two fields (confirmed 2026-04-28, frame analysis).
+if unit.device_type == AsekoDeviceType.HOME:
+    unit.required_floc = AsekoDecoder._normalize_value(data[54], int)
+    unit.required_algicide = AsekoDecoder._normalize_value(data[72], int)
+    # Fall through to decode required_cl_free (byte[53]) via the CLF branch below.
+```
+
+## Open Items
+
+| # | Status | Description |
+|---|--------|-------------|
+| 3 | Pending | `required_water_temperature` vs app "---" — need normal-operation frame |
+| 4 | Pending | Filtration NONSTOP 24H flag byte — need normal-operation frame |
+| 5 | Pending | `flowrate_algicide` byte position — need frame with algicide dose > 0 |
+
+---
+
+## Cross-References
+
+- Related decoder file: `custom_components/aseko_local/aseko_decoder.py`
+- Actuator masks: `custom_components/aseko_local/aseko_data.py` → `ACTUATOR_MASKS[AsekoDeviceType.HOME]`
+- OXY analysis (reference for shared byte layout): `docs/device analyzes/oxy_device_analysis.md`
+- NET v8 analysis: `docs/device analyzes/net_v8_device_analysis.md`

--- a/tests/test_aseko_decoder.py
+++ b/tests/test_aseko_decoder.py
@@ -796,8 +796,12 @@ def test_decode_home_clf_real_frame() -> None:
     # Setpoints — all confirmed against Aseko Live Config page
     assert device.required_ph == pytest.approx(7.0)
     assert device.required_cl_free == pytest.approx(0.3)
-    assert device.required_floc == 10       # byte[54] = 0x0a = 10 ml/h  (was None before fix)
-    assert device.required_algicide == 0    # byte[72] = 0x00 = 0 ml/m³/d (was None before fix)
+    assert (
+        device.required_floc == 10
+    )  # byte[54] = 0x0a = 10 ml/h  (was None before fix)
+    assert (
+        device.required_algicide == 0
+    )  # byte[72] = 0x00 = 0 ml/m³/d (was None before fix)
     assert device.required_water_temperature == 25
     # Schedule
     assert device.start1 == time(8, 0)

--- a/tests/test_aseko_decoder.py
+++ b/tests/test_aseko_decoder.py
@@ -132,9 +132,10 @@ def test_decode_home() -> None:
     assert device.backwash_time == time(2, 30)
     assert device.backwash_duration == 20
     # HOME has 4 independent pump ports — byte[37] routing does not apply.
-    # Setpoint byte positions for algicide/floc are unconfirmed; both must be None.
-    assert device.required_algicide is None
-    assert device.required_floc is None
+    # byte[54] = required_floc, byte[72] = required_algicide (same layout as OXY).
+    # Base bytes: data[54]=5, data[72]=0 (default zero).
+    assert device.required_floc == 5
+    assert device.required_algicide == 0
     assert device.required_water_temperature == 28
     assert device.timestamp is not None
     assert device.timestamp.year == YEAR_OFFSET + 24
@@ -759,6 +760,63 @@ def test_decode_issue_99_home() -> None:
     assert device.cl_free is not None
     assert device.cl_free_mv is not None
     assert device.redox is None
+    # Bug fix: required_floc and required_algicide must be decoded for HOME devices.
+    # byte[54] = 0x0a = 10 → required_floc = 10 ml/h
+    # byte[72] = 0x00 = 0  → required_algicide = 0 ml/m³/day
+    assert device.required_floc == 10
+    assert device.required_algicide == 0
+
+
+def test_decode_home_clf_real_frame() -> None:
+    """Real-world frame from serial 110128063 (ASIN AQUA Home, CLF variant).
+
+    Frame captured 2026-04-28 08:27:07.  Verified against Aseko Live app.
+    Confirms fix: required_floc (byte[54]) and required_algicide (byte[72])
+    are now correctly decoded for HOME devices.
+    """
+
+    data = bytearray.fromhex(
+        # Segment 1: real-time sensor data
+        "06906bbf02011a041c081b070028027500000000000290fe70017b080000ffff0000000000430a85"
+        # Segment 2: setpoints and schedule
+        "06906bbf02031a041c081b0746030a190800100012001600027c017b0315000c002801e02a30a0d8"
+        # Segment 3: pool parameters and flowrates
+        "06906bbf02021a041c081b07003c003c003c003c000a0d21376400f01402580f0f0f1e14ffbc0271"
+    )
+
+    device = AsekoDecoder.decode(bytes(data))
+    assert device.device_type == AsekoDeviceType.HOME
+    assert device.configuration == {AsekoProbeType.PH, AsekoProbeType.CLF}
+    # Probe readings
+    assert device.ph == pytest.approx(6.29)
+    assert device.cl_free == pytest.approx(0.0)
+    assert device.cl_free_mv == 2
+    assert device.water_temperature == pytest.approx(37.9)
+    assert device.water_flow_to_probes is False
+    # Setpoints — all confirmed against Aseko Live Config page
+    assert device.required_ph == pytest.approx(7.0)
+    assert device.required_cl_free == pytest.approx(0.3)
+    assert device.required_floc == 10       # byte[54] = 0x0a = 10 ml/h  (was None before fix)
+    assert device.required_algicide == 0    # byte[72] = 0x00 = 0 ml/m³/d (was None before fix)
+    assert device.required_water_temperature == 25
+    # Schedule
+    assert device.start1 == time(8, 0)
+    assert device.stop1 == time(16, 0)
+    assert device.start2 == time(18, 0)
+    assert device.stop2 == time(22, 0)
+    # Backwash
+    assert device.backwash_every_n_days == 3
+    assert device.backwash_time == time(21, 0)
+    assert device.backwash_duration == 120
+    # Pool parameters
+    assert device.pool_volume == 60
+    assert device.max_filling_time == 60
+    assert device.delay_after_startup == 480
+    assert device.delay_after_dose == 240
+    # Flowrates
+    assert device.flowrate_chlor == 60
+    assert device.flowrate_ph_minus == 60
+    assert device.flowrate_floc == 10
 
 
 def test_decode_issue_99_salt() -> None:

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -82,9 +82,6 @@ def _dummy_entry(device):
         def async_add_new_device_listener(self, listener):
             return lambda: None
 
-        def async_add_new_device_listener(self, listener):
-            return lambda: None
-
     entry = MagicMock(spec=ConfigEntry)
     entry.runtime_data = type("RuntimeData", (), {"coordinator": DummyCoordinator()})()
     return entry

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -79,6 +79,12 @@ def _dummy_entry(device):
         def get_tracker(self, serial_number):
             return None
 
+        def async_add_new_device_listener(self, listener):
+            return lambda: None
+
+        def async_add_new_device_listener(self, listener):
+            return lambda: None
+
     entry = MagicMock(spec=ConfigEntry)
     entry.runtime_data = type("RuntimeData", (), {"coordinator": DummyCoordinator()})()
     return entry

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -196,3 +196,106 @@ async def test_device_recognition(monkeypatch) -> None:
     assert len(devices) == 1
     assert 110200612 in devices  # Example serial number from frame
     await server.stop()
+
+
+# ---------------------------------------------------------------------------
+# Multi-device listener tests (fix for issue #99)
+# ---------------------------------------------------------------------------
+
+
+def _make_device(serial: int) -> AsekoDevice:
+    """Return a minimal AsekoDevice with the given serial number."""
+    from custom_components.aseko_local.aseko_data import AsekoDeviceType
+
+    device = AsekoDevice()
+    device.serial_number = serial
+    device.device_type = AsekoDeviceType.NET
+    return device
+
+
+@pytest.mark.asyncio
+async def test_coordinator_new_device_listener_called_for_new_device(hass) -> None:
+    """Listener is called exactly once when a brand-new device arrives."""
+    from custom_components.aseko_local.coordinator import (
+        AsekoLocalDataUpdateCoordinator,
+    )
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+    from custom_components.aseko_local.const import DOMAIN
+    from tests.const import MOCK_CONFIG
+
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="test_listener")
+    entry.add_to_hass(hass)
+
+    coordinator = AsekoLocalDataUpdateCoordinator(hass, entry)
+    discovered: list[AsekoDevice] = []
+
+    unsub = coordinator.async_add_new_device_listener(discovered.append)
+
+    device = _make_device(111)
+    coordinator.devices_update_callback(device)
+
+    assert len(discovered) == 1
+    assert discovered[0].serial_number == 111
+
+    # Second update for the SAME device must NOT trigger the listener again
+    coordinator.devices_update_callback(device)
+    assert len(discovered) == 1
+
+    unsub()
+
+
+@pytest.mark.asyncio
+async def test_coordinator_new_device_listener_unsub(hass) -> None:
+    """Unsubscribing the listener stops it from receiving future discoveries."""
+    from custom_components.aseko_local.coordinator import (
+        AsekoLocalDataUpdateCoordinator,
+    )
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+    from custom_components.aseko_local.const import DOMAIN
+    from tests.const import MOCK_CONFIG
+
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="test_unsub")
+    entry.add_to_hass(hass)
+
+    coordinator = AsekoLocalDataUpdateCoordinator(hass, entry)
+    discovered: list[AsekoDevice] = []
+
+    unsub = coordinator.async_add_new_device_listener(discovered.append)
+    unsub()  # unsubscribe immediately
+
+    coordinator.devices_update_callback(_make_device(222))
+    assert len(discovered) == 0
+
+
+@pytest.mark.asyncio
+async def test_coordinator_multiple_listeners(hass) -> None:
+    """All registered listeners receive the new-device notification."""
+    from custom_components.aseko_local.coordinator import (
+        AsekoLocalDataUpdateCoordinator,
+    )
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+    from custom_components.aseko_local.const import DOMAIN
+    from tests.const import MOCK_CONFIG
+
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="test_multi_cb")
+    entry.add_to_hass(hass)
+
+    coordinator = AsekoLocalDataUpdateCoordinator(hass, entry)
+    bucket_a: list[int] = []
+    bucket_b: list[int] = []
+
+    unsub_a = coordinator.async_add_new_device_listener(
+        lambda d: bucket_a.append(d.serial_number)
+    )
+    unsub_b = coordinator.async_add_new_device_listener(
+        lambda d: bucket_b.append(d.serial_number)
+    )
+
+    coordinator.devices_update_callback(_make_device(333))
+    coordinator.devices_update_callback(_make_device(444))
+
+    assert bucket_a == [333, 444]
+    assert bucket_b == [333, 444]
+
+    unsub_a()
+    unsub_b()

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -227,6 +227,9 @@ async def test_async_setup_salt_redox(hass) -> None:
         def get_tracker(self, serial_number):
             return None
 
+        def async_add_new_device_listener(self, listener):
+            return lambda: None
+
     # Create a MagicMock for ConfigEntry with runtime_data attribute
     dummy_entry = MagicMock(spec=ConfigEntry)
     dummy_entry.runtime_data = type(
@@ -322,6 +325,9 @@ async def test_async_setup_salt_clf(hass) -> None:
         def last_update_success(self):
             return True
 
+        def async_add_new_device_listener(self, listener):
+            return lambda: None
+
     # Create a MagicMock for ConfigEntry with runtime_data attribute
     dummy_entry = MagicMock(spec=ConfigEntry)
     dummy_entry.runtime_data = type(
@@ -411,6 +417,9 @@ async def test_async_setup_net_clf(hass) -> None:
         def get_tracker(self, serial_number):
             return None
 
+        def async_add_new_device_listener(self, listener):
+            return lambda: None
+
     # Create a MagicMock for ConfigEntry with runtime_data attribute
     dummy_entry = MagicMock(spec=ConfigEntry)
     dummy_entry.runtime_data = type(
@@ -491,6 +500,9 @@ async def test_async_setup_profi_clf_redox(hass) -> None:
 
         def get_tracker(self, serial_number):
             return None
+
+        def async_add_new_device_listener(self, listener):
+            return lambda: None
 
     # Create a MagicMock for ConfigEntry with runtime_data attribute
     dummy_entry = MagicMock(spec=ConfigEntry)


### PR DESCRIPTION
A first user has more than one device. We have never seen this before.

The Aseko_local integration reported device already registered even if it was a second device. At the end all devices where offline. Issue: #99 

We had to integrate a new device listener which builds an instance. The issue of sensors, button, etc. need to use the correct instance. So all entities must be added within the function `_async_add_new_device`.

I switched the device `Aseko Home` from untested to supported in readme.