### PR TITLE
fix: V8 - fw version 8.12 added, warning instead of blocking

### DIFF
--- a/custom_components/aseko_local/aseko_decoder_v8.py
+++ b/custom_components/aseko_local/aseko_decoder_v8.py
@@ -15,10 +15,13 @@ _LOGGER = logging.getLogger(__name__)
 # Matches "sectionname: <values>" up to the next section keyword or end of string.
 _SECTION_RE = re.compile(r"(\w+):\s*(.*?)(?=\s+\w+:|$)", re.DOTALL)
 
-# Maps the header type field (f2) to the corresponding device type.
+# Maps known header type fields (f2) to their device type.
+# Unknown values are tolerated — the decoder falls back to NET (all
+# V8 frames observed so far use the same layout regardless of f2).
 _V8_DEVICE_TYPE_BY_HEADER: dict[int, AsekoDeviceType] = {
     804: AsekoDeviceType.NET,
     805: AsekoDeviceType.NET,
+    812: AsekoDeviceType.NET,
 }
 
 
@@ -78,7 +81,13 @@ class AsekoV8Decoder:
         header_type = int(header_match.group(2))
         device_type = _V8_DEVICE_TYPE_BY_HEADER.get(header_type)
         if device_type is None:
-            raise ValueError(f"v8 frame: unknown device type {header_type}")
+            _LOGGER.warning(
+                "Unknown V8 header type %s for serial %s — falling back to NET. "
+                "Please report this at https://github.com/hopkins-tk/home-assistant-aseko-local/issues",
+                header_type,
+                serial_number,
+            )
+            device_type = AsekoDeviceType.NET
 
         # Parse all sections into a dict of {name: [int, ...]}
         sections: dict[str, list[int]] = {}

--- a/custom_components/aseko_local/manifest.json
+++ b/custom_components/aseko_local/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/hopkins-tk/home-assistant-aseko-local/issues",
   "requirements": [],
-  "version": "v1.6.2"
+  "version": "v1.6.3"
 }

--- a/tests/test_aseko_decoder_v8.py
+++ b/tests/test_aseko_decoder_v8.py
@@ -42,6 +42,20 @@ REFERENCE_FRAME_805 = (
     b"crc16: C3C8}\n"
 )
 
+REFERENCE_FRAME_812 = (
+    b"{v1 123456789 812 0 27 "
+    b"ins: 314 -500 -500 -500 0 0 0 0 1 -500 -500 -500 0 24 6 29 22 27 0 "
+    b"ains: 708 708 774 7790 0 0 779 779 0 0 0 0 0 0 0 0 "
+    b"outs: 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 "
+    b"areqs: 74 73 4 5 0 36 36 0 0 0 6 0 36 0 45 0 255 2 2 10 0 15 0 0 0 0 "
+    b"reqs: 0 0 0 0 0 0 0 24 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 "
+    b"0 10 10 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 "
+    b"fncs: 0 0 3 0 0 0 2 0 "
+    b"mods: 2 0 0 1 0 0 0 0 "
+    b"flags: 2 0 0 0 0 0 0 0 "
+    b"crc16: C3C8}\n"
+)
+
 # Second reference frame (Apr 13, 2026, 12:27 CEST) — used as cross-check fixture.
 REFERENCE_FRAME_APR = (
     b"{v1 123456789 804 0 27 "
@@ -69,6 +83,11 @@ def device_805():
 
 
 @pytest.fixture
+def device_812():
+    return AsekoV8Decoder.decode(REFERENCE_FRAME_812)
+
+
+@pytest.fixture
 def device_apr():
     return AsekoV8Decoder.decode(REFERENCE_FRAME_APR)
 
@@ -88,6 +107,10 @@ def test_device_type_is_net(device_sep):
 
 def test_device_805_type_is_net(device_805):
     assert device_805.device_type == AsekoDeviceType.NET
+
+
+def test_device_812_type_is_net(device_812):
+    assert device_812.device_type == AsekoDeviceType.NET
 
 
 def test_configuration_contains_ph_and_redox(device_sep):
@@ -251,6 +274,21 @@ def test_missing_braces_raises():
 def test_bad_header_raises():
     with pytest.raises(ValueError, match="header"):
         AsekoV8Decoder.decode(b"{not a valid v8 header}\n")
+
+
+def test_unknown_header_type_is_tolerated():
+    """Unknown f2 values must not raise — they fall back to NET."""
+    device = AsekoV8Decoder.decode(
+        b"{v1 123456789 999 0 27 "
+        b"ins: 314 -500 -500 -500 0 0 0 0 1 -500 -500 -500 0 24 6 29 22 27 0 "
+        b"ains: 708 708 774 7790 0 0 779 779 0 0 0 0 0 0 0 0 "
+        b"outs: 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 "
+        b"areqs: 74 73 4 5 0 36 36 0 0 0 6 0 36 0 45 0 255 2 2 10 0 15 0 0 0 0 "
+        b"crc16: C3C8}\n"
+    )
+    assert device.device_type == AsekoDeviceType.NET
+    assert device.serial_number == 123456789
+    assert device.ph == pytest.approx(7.08)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fix for issue #118 

It seems that there are a lot of detailed firmware version for V8 in general.

The issue #118 has no effective change to 8.04 and 8.05 version. Therefore I removed the blocking error for such version. I just throw a warning in there log.

This distinction is only necessary if the content of the record changes.