### PR TITLE
feat: add support for ASIN Aqua Salt (v8 header type 105)

### DIFF
--- a/custom_components/aseko_local/aseko_decoder_v8.py
+++ b/custom_components/aseko_local/aseko_decoder_v8.py
@@ -19,6 +19,7 @@ _SECTION_RE = re.compile(r"(\w+):\s*(.*?)(?=\s+\w+:|$)", re.DOTALL)
 # Unknown values are tolerated — the decoder falls back to NET (all
 # V8 frames observed so far use the same layout regardless of f2).
 _V8_DEVICE_TYPE_BY_HEADER: dict[int, AsekoDeviceType] = {
+    105: AsekoDeviceType.SALT,  # ASIN Aqua Salt NET
     804: AsekoDeviceType.NET,
     805: AsekoDeviceType.NET,
     812: AsekoDeviceType.NET,

--- a/tests/test_aseko_decoder_v8.py
+++ b/tests/test_aseko_decoder_v8.py
@@ -56,6 +56,22 @@ REFERENCE_FRAME_812 = (
     b"crc16: C3C8}\n"
 )
 
+# Header type 105 = ASIN Aqua Salt NET. Same body as the 805 reference; only the
+# type field differs, to verify 105 decodes to AsekoDeviceType.SALT.
+REFERENCE_FRAME_105 = (
+    b"{v1 123456789 105 0 27 "
+    b"ins: 314 -500 -500 -500 0 0 0 0 1 -500 -500 -500 0 24 6 29 22 27 0 "
+    b"ains: 708 708 774 7790 0 0 779 779 0 0 0 0 0 0 0 0 "
+    b"outs: 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 "
+    b"areqs: 74 73 4 5 0 36 36 0 0 0 6 0 36 0 45 0 255 2 2 10 0 15 0 0 0 0 "
+    b"reqs: 0 0 0 0 0 0 0 24 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 "
+    b"0 10 10 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 "
+    b"fncs: 0 0 3 0 0 0 2 0 "
+    b"mods: 2 0 0 1 0 0 0 0 "
+    b"flags: 2 0 0 0 0 0 0 0 "
+    b"crc16: C3C8}\n"
+)
+
 # Second reference frame (Apr 13, 2026, 12:27 CEST) — used as cross-check fixture.
 REFERENCE_FRAME_APR = (
     b"{v1 123456789 804 0 27 "
@@ -88,6 +104,11 @@ def device_812():
 
 
 @pytest.fixture
+def device_105():
+    return AsekoV8Decoder.decode(REFERENCE_FRAME_105)
+
+
+@pytest.fixture
 def device_apr():
     return AsekoV8Decoder.decode(REFERENCE_FRAME_APR)
 
@@ -111,6 +132,10 @@ def test_device_805_type_is_net(device_805):
 
 def test_device_812_type_is_net(device_812):
     assert device_812.device_type == AsekoDeviceType.NET
+
+
+def test_device_105_type_is_salt(device_105):
+    assert device_105.device_type == AsekoDeviceType.SALT
 
 
 def test_configuration_contains_ph_and_redox(device_sep):


### PR DESCRIPTION
Adds v8 header type `105` -> `AsekoDeviceType.SALT`, mirroring #116 (which added `805` -> `NET`).

## Device
- Model: **ASIN Aqua Salt NET** - https://www.asekopool.com/en/asin-aqua-salt-net-en/ (low-salt electrolysis unit with networking)
- Reported v8 header type: `105`
- Firmware: v8 text-frame protocol (port 51050)

## Problem
The unit emits valid v8 frames with header type `105`, which was missing from `_V8_DEVICE_TYPE_BY_HEADER`, so every frame failed and no entities were created:

```
v8 decode error: v8 frame: unknown device type 105 -> closing connection
```

## Fix
Map `105 -> AsekoDeviceType.SALT`. For v8 frames the device type only selects the model label - `AsekoV8Decoder.decode()` reads all values positionally - so existing field parsing is unchanged. `AsekoDeviceType.SALT` is the salt-electrolysis model, which matches this unit.

## Verified on a live unit
After the change all entities populate correctly: water temperature, pH (7.33), redox (771 mV), required pH/redox setpoints (7.4 / 770), filtration-pump-running, water-flow-to-probes, chlorine/pH dosing-pump states, flow rates, pH consumed totals, connection status.

Tested on Home Assistant 2026.6.4, integration v1.6.2. Adds `test_device_105_type_is_salt` mirroring the existing `805` test.
