### PR TITLE
fix(decoder): suppress backwash/water_level entities on devices that lack the feature (Issue #129)

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers-extra/features/apt-packages:1": {
+      "version": "1.0.6",
+      "resolved": "ghcr.io/devcontainers-extra/features/apt-packages@sha256:55c54412112da81b9381e470cdbbe55278564950d1ff536ce925b1e8e096babd",
+      "integrity": "sha256:55c54412112da81b9381e470cdbbe55278564950d1ff536ce925b1e8e096babd"
+    }
+  }
+}

--- a/custom_components/aseko_local/aseko_decoder.py
+++ b/custom_components/aseko_local/aseko_decoder.py
@@ -58,6 +58,35 @@ FILTRATION_PERIOD2_FLAG_TYPES = frozenset(
     }
 )
 
+# Device types that have a backwash valve/output and therefore expose a
+# backwash schedule (bytes 68-71) plus a backwash-active bit (byte 29 bit 0x01).
+# NET (Aqua NET) is a measurement + dosing unit only — it has neither a filter
+# nor a backwash valve, so the corresponding sensors must be suppressed.
+# Issue #129: prior to this filter, the decoder blindly read bytes 68-71 on
+# every device type, so a NET frame carrying non-0xFF data in those slots
+# would surface phantom backwash entities.
+BACKWASH_TYPES = frozenset(
+    {
+        AsekoDeviceType.SALT,
+        AsekoDeviceType.HOME,
+        AsekoDeviceType.OXY,
+        AsekoDeviceType.PROFI,
+    }
+)
+
+# Device types that have a water-level probe + filling-valve output and
+# therefore expose the water_level live value plus the four threshold setpoints
+# (bytes 27, 102-105) and the max_filling_time (bytes 94-95).
+# NET (Aqua NET) and PROFI do not have a filling valve → skip the whole group.
+# Mirrors the existing _fill_home_water_level_data() NET early-return.
+WATER_LEVEL_TYPES = frozenset(
+    {
+        AsekoDeviceType.SALT,
+        AsekoDeviceType.HOME,
+        AsekoDeviceType.OXY,
+    }
+)
+
 
 class AsekoDecoder:
     """Decoder of Aseko unit data."""
@@ -209,6 +238,20 @@ class AsekoDecoder:
                 data.hex(),
             )
             return datetime.now(tz=homeassistant.util.dt.get_default_time_zone())
+
+    @staticmethod
+    def _max_filling_time_from_bytes(data: bytes) -> int | None:
+        """Decode max_filling_time (bytes 94-95) as a 2-byte big-endian minute value.
+
+        Returns None for the 0xFFFF sentinel (device does not implement the
+        feature) so that downstream consumers see ``None`` instead of ``65535``.
+        Issue #129: a bare ``int.from_bytes(...)`` would otherwise turn
+        unspecified frame data into a bogus 65535-minute value on NET/PROFI.
+        """
+        value = int.from_bytes(data, "big")
+        if value == 0xFFFF:
+            return None
+        return value
 
     @staticmethod
     def _time(data: bytes) -> time | None:
@@ -480,6 +523,11 @@ class AsekoDecoder:
 
         See ``backwash_tracker.py`` for the live-tracking implementation.
         """
+        # Defensive: the schedule fields are already gated on BACKWASH_TYPES in
+        # decode(), but we re-check the device type here so this method stays
+        # safe even if it is ever called from a code path that didn't pre-filter.
+        if unit.device_type is None or unit.device_type not in BACKWASH_TYPES:
+            return
         if (
             unit.backwash_every_n_days is None
             or unit.backwash_time is None
@@ -590,6 +638,11 @@ class AsekoDecoder:
             if unit_type in FILTRATION_PERIOD2_FLAG_TYPES
             else True
         )
+        # Issue #129: gate backwash schedule + active bit on device type so
+        # measurement-only units (NET) do not surface phantom backwash entities
+        # from non-0xFF frame data.
+        has_backwash = unit_type in BACKWASH_TYPES
+        has_water_level = unit_type in WATER_LEVEL_TYPES
 
         device = AsekoDevice(
             serial_number=int.from_bytes(data[0:4], "big"),
@@ -603,9 +656,15 @@ class AsekoDecoder:
             stop1=AsekoDecoder._time(data[58:60]) if has_filtration else None,
             start2=AsekoDecoder._time(data[60:62]) if filtration2_enabled else None,
             stop2=AsekoDecoder._time(data[62:64]) if filtration2_enabled else None,
-            backwash_every_n_days=AsekoDecoder._normalize_value(data[68], int),
-            backwash_time=AsekoDecoder._time(data[69:71]),
-            backwash_duration=data[71] * 10 if data[71] != UNSPECIFIED_VALUE else None,
+            backwash_every_n_days=(
+                AsekoDecoder._normalize_value(data[68], int) if has_backwash else None
+            ),
+            backwash_time=(AsekoDecoder._time(data[69:71]) if has_backwash else None),
+            backwash_duration=(
+                data[71] * 10
+                if has_backwash and data[71] != UNSPECIFIED_VALUE
+                else None
+            ),
             pool_volume=int.from_bytes(data[92:94], "big"),
             # max_filling_time is stored in minutes (verified against Aseko Live
             # app for serial 110071590: raw bytes 94:95 = 0x003c = 60, app shows
@@ -613,7 +672,16 @@ class AsekoDecoder:
             # See water_level_backwash_analysis.md and home_device_analysis.md
             # (Bug 1, the 30 s hypothesis from DomSchCoding #100 was rejected by
             # the live app screenshot).
-            max_filling_time=int.from_bytes(data[94:96], "big"),
+            #
+            # Gated on WATER_LEVEL_TYPES: NET (Aqua NET) and PROFI have no filling
+            # valve, so bytes 94-95 either carry unrelated data or are 0xFFFF.
+            # A bare int.from_bytes(..., "big") would otherwise turn 0xFFFF into
+            # 65535 — fix that by normalising to None on 0xFFFF as well.
+            max_filling_time=(
+                AsekoDecoder._max_filling_time_from_bytes(data[94:96])
+                if has_water_level
+                else None
+            ),
             delay_after_startup=int.from_bytes(data[74:76], "big"),
             delay_after_dose=int.from_bytes(data[106:108], "big"),
         )

--- a/custom_components/aseko_local/manifest.json
+++ b/custom_components/aseko_local/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/hopkins-tk/home-assistant-aseko-local/issues",
   "requirements": [],
-  "version": "v1.7.0"
+  "version": "v1.7.1"
 }

--- a/tests/test_aseko_decoder.py
+++ b/tests/test_aseko_decoder.py
@@ -272,6 +272,22 @@ def test_decode_net() -> None:
     assert device.stop1 is None
     assert device.start2 is None
     assert device.stop2 is None
+    # Issue #129: NET has no backwash valve, so the schedule must stay None
+    # regardless of what the frame carries in bytes 68-71.
+    assert device.backwash_every_n_days is None
+    assert device.backwash_time is None
+    assert device.backwash_duration is None
+    assert device.last_backwash is None
+    assert device.next_backwash is None
+    assert device.backwash_active is None
+    # NET has no filling valve, so the water_level group is empty too.
+    assert device.water_level is None
+    assert device.water_level_low_alarm is None
+    assert device.water_level_filling_on is None
+    assert device.water_level_filling_off is None
+    assert device.water_level_high_alarm is None
+    assert device.water_filling_active is None
+    assert device.max_filling_time is None
     # Pool volume and dosing delays are still available on NET.
     assert device.pool_volume == 5000
     assert device.delay_after_dose == 30
@@ -318,6 +334,85 @@ def test_decode_unknown_unit_type() -> None:
     # Must not raise – decoder returns a device with device_type=None
     device = AsekoDecoder.decode(bytes(data))
     assert device.device_type is None
+
+
+def test_decode_net_no_backwash_with_garbage_bytes() -> None:
+    """Issue #129: A NET frame carrying non-0xFF data in the backwash/water-level
+    byte slots must not surface phantom backwash or water-level entities.
+
+    Pre-fix behaviour: the decoder blindly read bytes 68-71, 27, 102-105 and
+    94-95 on every device type. When a NET device happened to send non-0xFF
+    values in those slots, the integration created disabled backwash /
+    water-level entities with semantically meaningless numbers (e.g.
+    max_filling_time=65535 from bytes 0xFFFF being decoded as a 16-bit int).
+
+    Post-fix behaviour: device-type gating on BACKWASH_TYPES / WATER_LEVEL_TYPES
+    forces the corresponding device fields to None on NET, which causes
+    _build_sensor_entities() in sensor.py to skip the entity altogether.
+    """
+    data = _make_base_bytes()
+    data[4] = 0x09  # NET (CLF probe, default for _make_base_bytes is SALT)
+    # Garbage values in the slots that belong to backwash / water-level.
+    # These mimic the real-world case where a measurement-only device
+    # reports random non-0xFF data in slots it does not implement.
+    data[27] = 53  # would-be water_level (cm)
+    data[68] = 7  # would-be backwash_every_n_days
+    data[69] = 9  # would-be backwash_time hour
+    data[70] = 30  # would-be backwash_time min
+    data[71] = 12  # would-be backwash_duration (×10 s)
+    data[102] = 13  # would-be water_level_low_alarm
+    data[103] = 21  # would-be water_level_filling_on
+    data[104] = 60  # would-be water_level_filling_off
+    data[105] = 100  # would-be water_level_high_alarm
+    data[94:96] = bytes([0xFF, 0xFF])  # would-be max_filling_time → must be None
+
+    device = AsekoDecoder.decode(bytes(data))
+    assert device.device_type == AsekoDeviceType.NET
+    # None of these may leak through on a NET device, no matter what the frame carries.
+    assert device.backwash_every_n_days is None
+    assert device.backwash_time is None
+    assert device.backwash_duration is None
+    assert device.last_backwash is None
+    assert device.next_backwash is None
+    assert device.backwash_active is None
+    assert device.water_level is None
+    assert device.water_level_low_alarm is None
+    assert device.water_level_filling_on is None
+    assert device.water_level_filling_off is None
+    assert device.water_level_high_alarm is None
+    assert device.water_filling_active is None
+    assert device.max_filling_time is None
+
+
+def test_max_filling_time_unspecified_sentinel() -> None:
+    """Issue #129: 0xFFFF in bytes 94-95 must decode to None, not 65535.
+
+    Pre-fix behaviour: a bare ``int.from_bytes(data[94:96], "big")`` returned
+    65535 for the 0xFFFF sentinel, surfacing a nonsensical "max filling time
+    = 65535 min" sensor on devices that do not implement filling (NET, PROFI).
+    """
+    data = _make_base_bytes()  # default SALT — has max_filling_time
+    data[4] = 0x09  # but flip to NET
+    data[94:96] = bytes([0xFF, 0xFF])  # UNSPECIFIED sentinel
+    device = AsekoDecoder.decode(bytes(data))
+    assert device.device_type == AsekoDeviceType.NET
+    assert device.max_filling_time is None
+
+
+def test_max_filling_time_real_value_home() -> None:
+    """Sanity check: on a HOME device, a real value still decodes correctly.
+
+    This guards against an accidental regression where the new
+    _max_filling_time_from_bytes() helper breaks the verified
+    "60 min from 0x003c" mapping (Issue #110).
+    """
+    data = _make_base_bytes()
+    data[4] = 0x02  # UNIT_TYPE_HOME_CLF — any HOME subtype works
+    data[6:12] = bytes([24, 6, 15, 12, 34, 56])
+    data[94:96] = (60).to_bytes(2, "big")  # 60 min
+    device = AsekoDecoder.decode(bytes(data))
+    assert device.device_type == AsekoDeviceType.HOME
+    assert device.max_filling_time == 60
 
 
 def test_decode_issue_17() -> None:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -471,12 +471,42 @@ async def test_async_setup_net_clf(hass) -> None:
     # + 4 consumption (ph_minus canister + total, cl canister + total) + 1 connection_status
     # note: required_algicide/required_floc are absent because byte[37]=0xFF (undefined)
     # note: filtration sensors skipped because start/stop times are None in NET test data
-    # + 1 new backwash_active binary sensor
-    # + 1 new heating_active binary sensor
-    # + 3 new backwash config sensors (every_n_days, time, duration)
-    # + 2 new backwash schedule sensors (last_backwash, next_backwash)
-    # + 1 max_filling_time sensor (NET exposes it via data[94:96])
-    assert len(added_entities) == 24
+    # + 1 heating_active binary sensor
+    # Issue #129: NET has no backwash valve and no filling valve, so the
+    # backwash / water_level / max_filling_time groups are *all* suppressed.
+    # The 5 backwash config + schedule sensors that the old code created
+    # (every_n_days, time, duration, last_backwash, next_backwash) plus
+    # max_filling_time are no longer created for NET, even when the frame
+    # carries non-0xFF data in those byte slots.
+    assert len(added_entities) == 23
+    assert not any(
+        getattr(e.entity_description, "key", None) == "backwash_every_n_days"
+        for e in added_entities
+    )
+    assert not any(
+        getattr(e.entity_description, "key", None) == "backwash_time"
+        for e in added_entities
+    )
+    assert not any(
+        getattr(e.entity_description, "key", None) == "backwash_duration"
+        for e in added_entities
+    )
+    assert not any(
+        getattr(e.entity_description, "key", None) == "last_backwash"
+        for e in added_entities
+    )
+    assert not any(
+        getattr(e.entity_description, "key", None) == "next_backwash"
+        for e in added_entities
+    )
+    assert not any(
+        getattr(e.entity_description, "key", None) == "max_filling_time"
+        for e in added_entities
+    )
+    assert not any(
+        getattr(e.entity_description, "key", None) == "water_level"
+        for e in added_entities
+    )
     assert any(
         getattr(e.entity_description, "key", None) == "free_chlorine"
         for e in added_entities
@@ -568,7 +598,7 @@ async def test_async_setup_profi_clf_redox(hass) -> None:
     #
     # Regular sensors (16): free_chlorine, required_free_chlorine,
     #   free_chlorine_mv, ph, required_ph, rx, water_temp, required_water_temp,
-    #   max_filling_time, flowrate_ph_minus, flowrate_floc,
+    #   flowrate_ph_minus, flowrate_floc,
     #   backwash_every_n_days, backwash_time, backwash_duration,
     #   last_backwash, next_backwash
     # Binary sensors (6): water_flow_to_probes, pump_running, cl_pump_running,
@@ -585,7 +615,12 @@ async def test_async_setup_profi_clf_redox(hass) -> None:
     # was widened from a {HOME, SALT, OXY} whitelist to a {NET} blacklist (see
     # PR #120 review comment by hopkins-tk).  PROFI does have a water-level input
     # (confirmed via the Aseko Profi manual), so it must be decoded.
-    assert len(added_entities) == 42
+    #
+    # Issue #129: PROFI has no filling valve (it has 5+ independent pump ports
+    # but no documented filling input), so max_filling_time is suppressed even
+    # though bytes 94-95 carry a real value. -1 entity compared to the PR #120
+    # baseline.
+    assert len(added_entities) == 41
     assert any(
         getattr(e.entity_description, "key", None) == "free_chlorine"
         for e in added_entities
@@ -615,5 +650,11 @@ async def test_async_setup_profi_clf_redox(hass) -> None:
     # still be registered.
     assert any(
         getattr(e.entity_description, "key", None) == "water_filling_active"
+        for e in added_entities
+    )
+    # Issue #129: PROFI has no filling valve, so max_filling_time stays None
+    # and no entity is created even though bytes 94-95 carry a real value.
+    assert not any(
+        getattr(e.entity_description, "key", None) == "max_filling_time"
         for e in added_entities
     )


### PR DESCRIPTION
## Summary

Fixes [Issue #129](https://github.com/hopkins-tk/home-assistant-aseko-local/issues/129).

The decoder introduced in PR #120 reads the backwash schedule (bytes 68-71),
`max_filling_time` (bytes 94-95) and the water-level threshold setpoints
(bytes 27, 102-105) on **every** device type. For a measurement-only device
like the Aqua NET (no filter pump, no backwash valve, no filling valve) those
slots are usually `0xFF` and the corresponding fields land on `None`, which
makes the existing `_build_sensor_entities()` skip logic work correctly.

But the filter is fragile: when a NET frame happens to carry non-`0xFF` data
in those slots — as it can do on firmware variants or with leftover bytes from
a different layout — the decoder happily surfaces the value and the
integration creates **disabled** phantom entities with garbage numbers. The
classic example is `max_filling_time = 65535` from `0xFFFF` being decoded as
a 16-bit int.

This is exactly what @dtpugh saw in Issue #129: backwash entities were
present but disabled, with values that did not match his actual device
configuration. The maintainer's reply ("you can enable them and check the
values") is technically correct, but it treats a symptom rather than the
root cause: the integration was creating entities it should never have
created in the first place.

## Changes

- Introduce two capability frozensets, mirroring the existing
  `FILTRATION_TYPES` pattern:
  - `BACKWASH_TYPES = {SALT, HOME, OXY, PROFI}` (excludes NET)
  - `WATER_LEVEL_TYPES = {SALT, HOME, OXY}` (excludes NET and PROFI)
- Gate the corresponding fields in `AsekoDevice.__init__` on these sets.
- Add a defensive `device_type` check in `_fill_backwash_schedule()` so the
  schedule helpers stay safe even if they are ever called from a code path
  that did not pre-filter.
- Extract a small `_max_filling_time_from_bytes()` helper that returns
  `None` for the `0xFFFF` sentinel, consistent with the other "unspecified"
  markers in the codebase.


## Testing

- `test_decode_net` extended to assert that `backwash_*`, `water_level_*`,
  `max_filling_time` and `last/next_backwash` all stay `None` on NET.
- `test_decode_net_no_backwash_with_garbage_bytes` mimics the real-world
  failure mode (NET frame carrying non-`0xFF` data in the
  backwash/water_level byte slots) and locks in that the corresponding
  fields stay `None`.
- `test_max_filling_time_unspecified_sentinel` pins the `0xFFFF` → `None`
  contract.
- `test_max_filling_time_real_value_home` guards the verified
  "60 min from `0x003c`" mapping (Issue #110) against a regression in the
  new helper.
- `test_async_setup_net_clf` and `test_async_setup_profi_clf_redox` updated
  to reflect the now-correct entity counts (24 → 23 on NET, 42 → 41 on
  PROFI because `max_filling_time` is no longer created).
