### PR TITLE
Fix/issues 133, 136, 138, 139, 140, 151

### DIFF
--- a/custom_components/aseko_local/aseko_data.py
+++ b/custom_components/aseko_local/aseko_data.py
@@ -216,9 +216,14 @@ class AsekoDevice:
     # Alarm/error bitmasks — bytes [12] (HOME dosing warnings) and [13]
     # byte [12] 0x20 = chlorine/disinfection dosing warning (HOME ✅, issue #134)
     # byte [12] 0x40 = pH dosing warning (HOME ✅, issue #134)
-    # byte [13] 0x01 / 0x02 / 0x04 / 0x08 = legacy bitmask (NET no-flow ✅)
-    alarm_ph_too_many_doses: bool | None = None  # byte [13] 0x01 | byte [12] 0x40
-    alarm_orp_too_many_doses: bool | None = None  # byte [13] 0x02 | byte [12] 0x20
+    # byte [13] 0x01 = disinfection/ORP dose fault (Issue #151, HOME serial 110175608;
+    #                  config48 frame byte[13]=0x01 during "Maximum disinfection dose
+    #                  exceeded" — same fault as v8 ins[12] bit 0x80)
+    # byte [13] 0x02 = pH dose fault (inferred, symmetric to 0x01 — no direct capture yet)
+    # byte [13] 0x04 = no flow to probes (confirmed)
+    # byte [13] 0x08 = rapid pH change (error_codes.md, unconfirmed by capture)
+    alarm_ph_too_many_doses: bool | None = None  # byte [13] 0x02 | byte [12] 0x40
+    alarm_orp_too_many_doses: bool | None = None  # byte [13] 0x01 | byte [12] 0x20
     alarm_no_flow_to_probes: bool | None = None  # byte [13] bit 0x04 (confirmed)
     alarm_rapid_ph_change: bool | None = (
         None  # byte [13] bit 0x08 (error_codes.md, unconfirmed by capture)

--- a/custom_components/aseko_local/aseko_data.py
+++ b/custom_components/aseko_local/aseko_data.py
@@ -1,4 +1,17 @@
-"""Data model for Aseko pool devices."""
+"""Data model for Aseko pool devices.
+
+This module defines the **protocol-agnostic target schema** (``AsekoDevice``)
+that the entity layer (sensors, binary sensors, buttons, …) consumes.  It
+also defines the device-type enum, the probe-type enum, the electrolyser
+direction enum, and the filtration-mode enum.
+
+Decoder-specific byte-level knowledge (v7 ``byte[29]`` masks, v8 ``fncs:``
+capability codes, ``byte[37]`` routing constants, etc.) lives in
+``aseko_v7_helpers.py`` and ``aseko_v8_helpers.py`` next to the corresponding
+decoder.  The v7 constants ``AsekoActuatorMasks``, ``ACTUATOR_MASKS``, and
+``AsekoThirdPumpSlot`` are re-exported at the bottom of this file for
+backwards compatibility with existing import sites.
+"""
 
 from dataclasses import dataclass, field, fields
 from datetime import datetime, time, timedelta
@@ -53,104 +66,22 @@ class AsekoFiltrationMode(Enum):
     OFF_MANUAL = "off_manual"
 
 
-class AsekoThirdPumpSlot:
-    """Semantics of byte[37] differ by device type.
-
-    SALT (shared physical port): routing indicator.
-        Bit 7 (0x80) set → algicide configured in the single port.
-        Bit 7 (0x80) clear → flocculant configured.
-        Confirmed by @hopkins-tk (SALT v7.x frames, 2025) and consistent with
-        @jmnemonicj (SALT v5.0, Issue #84) where 0x03 & 0x80 == 0 → flocculant.
-
-    OXY (two independent ports): suspected pump-presence bitmap.
-        Bit 0 (0x01) = flocculant pump module connected.  # unconfirmed hypothesis
-        Bit 1 (0x02) = algicide pump module connected.    # unconfirmed hypothesis
-        Observed 0x03 on Winnetoux's OXY (both pumps present). Requires a frame
-        with only one pump connected to confirm.
-        TODO: confirm OXY semantics with an asymmetric frame.
-
-    NET / PROFI / HOME: 0xFF (UNSPECIFIED) = no third-pump port, routing not applicable.
-    """
-
-    # SALT: bit 7 → algicide in the shared port; clear → flocculant
-    SALT_ALGICIDE_ROUTING: int = 0x80
-
-    # OXY: presence bits – which pump modules are physically connected.
-    # UNCONFIRMED: based solely on the single observed value 0x03 (both present).
-    OXY_FLOC_PRESENT: int = 0x01
-    OXY_ALGICIDE_PRESENT: int = 0x02
-
-
-@dataclass(frozen=True)
-class AsekoActuatorMasks:
-    """Byte 29 bit masks for actuator state detection (pumps + electrolyzer), per device type."""
-
-    filtration: int = 0x00
-    cl: int = 0x00
-    ph_minus: int = 0x00
-    algicide: int = 0x00
-    flocculant: int = 0x00
-    oxy: int = 0x00  # unconfirmed – awaiting frame with OXY Pure pump active
-    electrolyzer_running: int = 0x00
-    electrolyzer_running_right: int = 0x00
-    electrolyzer_running_left: int = 0x00
-    # On devices with a single shared physical pump port (SALT and similar 2–3-pump
-    # units), byte[37] carries a routing indicator: bit 7 set → algicide setpoint;
-    # clear → flocculant setpoint (AsekoThirdPumpSlot.SALT_ALGICIDE_ROUTING).
-    # Devices with 4+ independent pump ports (OXY, HOME, PROFI) do NOT use this
-    # routing — algicide and flocculant have separate physical connections whose
-    # setpoint byte positions are not yet confirmed from frames.
-    # Set False for those devices so decode() skips the routing logic entirely.
-    byte37_routes_pump_type: bool = True
-
-
-ACTUATOR_MASKS: dict[AsekoDeviceType, AsekoActuatorMasks] = {
-    AsekoDeviceType.OXY: AsekoActuatorMasks(
-        filtration=0x08,  # confirmed: all captured frames
-        algicide=0x10,  # confirmed: 2026-04-11 Winnetoux log – byte[29] 0x08→0x18 at algicide pump on
-        flocculant=0x20,  # confirmed: toggles exactly at 19:33:52 floc event
-        oxy=0x40,  # confirmed: 2026-04-11 Winnetoux log – byte[29] 0x08→0x48 at OXY pump on
-        ph_minus=0x80,  # confirmed: 2026-04-12 Winnetoux log – byte[29] 0x08→0x88 at pH− pump on
-        byte37_routes_pump_type=False,  # OXY byte[37] = pump-presence bitmap, not routing
-    ),
-    AsekoDeviceType.NET: AsekoActuatorMasks(
-        # Aqua NET has no filtration output — confirmed: Issue #66
-        cl=0x02,  # confirmed: Issue #66 (Aqua NET)
-        ph_minus=0x01,  # confirmed: Issue #66 (Aqua NET)
-    ),
-    AsekoDeviceType.SALT: AsekoActuatorMasks(
-        filtration=0x08,  # confirmed: April 4, 2026 – set in all active phases (PR #87)
-        ph_minus=0x80,  # unconfirmed – no frame captured with pH− pump running
-        # SALT third-pump slot: one physical pump, configured as algicide OR flocculant.
-        # Both chemicals use the same bit: byte[29] bit 5 (0x20) when running.
-        # Routing: byte[37] & 0x80 set = algicide; clear = flocculant.
-        # Confirmed by @hopkins-tk 2026-04-04: 27 algicide frames (no electrolyzer) → 0x28=0x08|0x20 (PR #87).
-        algicide=0x20,  # confirmed: 27 frames, PR #87
-        flocculant=0x20,  # confirmed: Apr 3 frames, same bit as algicide
-        electrolyzer_running=0x10,  # confirmed: 25 frames → 0x18=0x08|0x10 (PR #87)
-        electrolyzer_running_right=0x10,  # confirmed: same dataset
-        electrolyzer_running_left=0x50,  # tentative: Apr 2 single frame 0x58=0x08|0x10|0x40
-    ),
-    AsekoDeviceType.HOME: AsekoActuatorMasks(
-        filtration=0x08,  # uncertain
-        # HOME "chlorine" pump port can be configured as Chlorine OR OXY Pure
-        # (same physical port, same bit in byte[29] – routing by an unknown byte).
-        # TODO: confirm which byte carries the cl/oxy routing and add oxy mask once known.
-        #       Waiting for a frame with OXY pump running from a HOME device.
-        cl=0x40,  # uncertain – assumed same bit for both cl and oxy variants
-        ph_minus=0x80,  # uncertain
-        algicide=0x20,  # uncertain
-        flocculant=0x20,  # uncertain
-        byte37_routes_pump_type=False,  # HOME has independent pump ports (cl/oxy, ph-, alg, floc)
-    ),
-    AsekoDeviceType.PROFI: AsekoActuatorMasks(
-        filtration=0x08,  # uncertain
-        cl=0x40,  # uncertain
-        ph_minus=0x80,  # uncertain
-        flocculant=0x20,  # uncertain
-        byte37_routes_pump_type=False,  # PROFI has 5 independent pump ports (cl, ph-, ph+, alg, floc)
-    ),
-}
+# ---------------------------------------------------------------------------
+# Re-exports for backwards compatibility
+# ---------------------------------------------------------------------------
+#
+# ``AsekoActuatorMasks``, ``ACTUATOR_MASKS``, and ``AsekoThirdPumpSlot`` are
+# **v7-decoder specific** (byte[29] bit masks, byte[37] routing constants).
+# They used to live in this module, but they belong in ``aseko_v7_helpers.py``
+# next to the v7 decoder.  We re-export them here so existing import sites
+# (``aseko_decoder.py``, ``button.py``, ``sensor.py``, …) keep working without
+# a global rename.  New code should import them from ``aseko_v7_helpers`` directly.
+from .aseko_v7_helpers import (  # noqa: E402, F401
+    ACTUATOR_MASKS,
+    AsekoActuatorMasks,
+    AsekoByte37Masks,
+    AsekoThirdPumpSlot,
+)
 
 
 @dataclass
@@ -176,6 +107,7 @@ class AsekoDevice:
     water_flow_to_probes: bool | None = None  # byte 28 == aah
     filtration_pump_running: bool | None = None  # byte 29 (3-rd bit)
     heating_active: bool | None = None  # byte 29 (2-nd bit, 0x04)
+    heating_control_enabled: bool | None = None  # byte 37 bit 3 (0x08) on HOME
     cl_pump_running: bool | None = None  # byte 29 (6-th bit)
     ph_minus_pump_running: bool | None = None  # byte 29 (7-th bit)
     ph_plus_pump_running: bool | None = (

--- a/custom_components/aseko_local/aseko_data.py
+++ b/custom_components/aseko_local/aseko_data.py
@@ -63,7 +63,7 @@ class AsekoFiltrationMode(Enum):
     NONSTOP_24H = "nonstop_24h"
     TIMER_PERIOD_1 = "timer_period_1"
     TIMER_PERIOD_1_AND_2 = "timer_period_1_and_2"
-    MANUAL = "off_manual"
+    MANUAL = "manual"
 
 
 # ---------------------------------------------------------------------------

--- a/custom_components/aseko_local/aseko_data.py
+++ b/custom_components/aseko_local/aseko_data.py
@@ -253,20 +253,29 @@ class AsekoDevice:
     filtration_nonstop24: bool | None = None
 
     # Filtration mode — 4-state enum (Issue #133).
-    # Decoded from byte[37] on HOME v7 devices. Two encodings exist:
+    # Set for every device type in FILTRATION_TYPES = {SALT, HOME, OXY, PROFI}.
+    # NET is excluded — no filtration output (see Issue #66).
+    #
+    # HOME v7 devices encode the 4-state mode directly in byte[37] with two
+    # firmware variants:
     #   Firmware A (serial 110128063, byte 4 = 0x02): high nibble 0x4 / 0x5
     #     0x43 → NONSTOP_24H
     #     0x53 → TIMER_PERIOD_1_AND_2 (cannot distinguish P1 vs P1&P2)
-    #     0x47 / 0x57 → transitional edit state, leave as None
+    #     0x47 / 0x57 → leave as None (transitional edit state)
     #   Firmware B (serial 110169464, byte 4 = 0x03): high nibble 0x0 / 0x1 / 0x3
     #     0x01 → NONSTOP_24H
     #     0x11 → TIMER_PERIOD_1
     #     0x31 → TIMER_PERIOD_1_AND_2
     #     0x15 → OFF_MANUAL (P1 + manual override, bit 0x04 set)
     #     0x35 → OFF_MANUAL (P1&P2 + manual override, bit 0x04 set)
-    # For SALT / OXY / PROFI the mode is derived from schedule bytes 56-63
-    # and the period-2 enable bit (byte[37] bit 0x20).
-    # NET is excluded — no filtration output (see Issue #66).
+    #
+    # SALT / OXY / PROFI do not put a filtration mode flag in byte[37]
+    # (SALT: algicide/flocculant routing + dosage encoding; OXY: pump-
+    # presence bitmap; PROFI: no live frame captured). For those types
+    # the mode is derived from the schedule bytes 56-63 and the period-2
+    # enable bit (byte 37 bit 0x20, already covered by FILTRATION_PERIOD2_FLAG_TYPES).
+    # This guarantees that a single `filtration_mode` sensor shows the
+    # same 4 states on every filtration-capable device.
     filtration_mode: AsekoFiltrationMode | None = None
 
     # Alarm/error bitmasks — bytes [12] (HOME dosing warnings) and [13]

--- a/custom_components/aseko_local/aseko_data.py
+++ b/custom_components/aseko_local/aseko_data.py
@@ -108,6 +108,7 @@ class AsekoDevice:
     filtration_pump_running: bool | None = None  # byte 29 (3-rd bit)
     heating_active: bool | None = None  # byte 29 (2-nd bit, 0x04)
     heating_control_enabled: bool | None = None  # byte 37 bit 3 (0x08) on HOME
+    antifreeze_enabled: bool | None = None  # byte 37 bit 7 (0x80) on HOME
     cl_pump_running: bool | None = None  # byte 29 (6-th bit)
     ph_minus_pump_running: bool | None = None  # byte 29 (7-th bit)
     ph_plus_pump_running: bool | None = (

--- a/custom_components/aseko_local/aseko_data.py
+++ b/custom_components/aseko_local/aseko_data.py
@@ -109,6 +109,7 @@ class AsekoDevice:
     heating_active: bool | None = None  # byte 29 (2-nd bit, 0x04)
     heating_control_enabled: bool | None = None  # byte 37 bit 3 (0x08) on HOME
     antifreeze_enabled: bool | None = None  # byte 37 bit 7 (0x80) on HOME
+    vsp_pump_running: bool | None = None  # byte 22 bit 3 (0x08) on HOME
     cl_pump_running: bool | None = None  # byte 29 (6-th bit)
     ph_minus_pump_running: bool | None = None  # byte 29 (7-th bit)
     ph_plus_pump_running: bool | None = (

--- a/custom_components/aseko_local/aseko_data.py
+++ b/custom_components/aseko_local/aseko_data.py
@@ -36,6 +36,23 @@ class AsekoElectrolyzerDirection(Enum):
     WAITING = "waiting"
 
 
+class AsekoFiltrationMode(Enum):
+    """Enumeration of the 4 filtration schedule states.
+
+    Surfaced by the new `filtration_mode` sensor (Issue #133) and used
+    internally to override `filtration_pump_running` when the user has
+    manually switched the pump off on a HOME v7 device (firmware B).
+
+    Enum values map directly to the translation keys in
+    translations/{en,de,cs,fr}.json under entity.sensor.filtration_mode.state.
+    """
+
+    NONSTOP_24H = "nonstop_24h"
+    TIMER_PERIOD_1 = "timer_period_1"
+    TIMER_PERIOD_1_AND_2 = "timer_period_1_and_2"
+    OFF_MANUAL = "off_manual"
+
+
 class AsekoThirdPumpSlot:
     """Semantics of byte[37] differ by device type.
 
@@ -234,6 +251,23 @@ class AsekoDevice:
     # Filtration mode — byte [37]
     # True = nonstop 24 h (0x43), False = timer (0x53), None = transitional/unknown
     filtration_nonstop24: bool | None = None
+
+    # Filtration mode — 4-state enum (Issue #133).
+    # Decoded from byte[37] on HOME v7 devices. Two encodings exist:
+    #   Firmware A (serial 110128063, byte 4 = 0x02): high nibble 0x4 / 0x5
+    #     0x43 → NONSTOP_24H
+    #     0x53 → TIMER_PERIOD_1_AND_2 (cannot distinguish P1 vs P1&P2)
+    #     0x47 / 0x57 → transitional edit state, leave as None
+    #   Firmware B (serial 110169464, byte 4 = 0x03): high nibble 0x0 / 0x1 / 0x3
+    #     0x01 → NONSTOP_24H
+    #     0x11 → TIMER_PERIOD_1
+    #     0x31 → TIMER_PERIOD_1_AND_2
+    #     0x15 → OFF_MANUAL (P1 + manual override, bit 0x04 set)
+    #     0x35 → OFF_MANUAL (P1&P2 + manual override, bit 0x04 set)
+    # For SALT / OXY / PROFI the mode is derived from schedule bytes 56-63
+    # and the period-2 enable bit (byte[37] bit 0x20).
+    # NET is excluded — no filtration output (see Issue #66).
+    filtration_mode: AsekoFiltrationMode | None = None
 
     # Alarm/error bitmasks — bytes [12] (HOME dosing warnings) and [13]
     # byte [12] 0x20 = chlorine/disinfection dosing warning (HOME ✅, issue #134)

--- a/custom_components/aseko_local/aseko_data.py
+++ b/custom_components/aseko_local/aseko_data.py
@@ -63,7 +63,7 @@ class AsekoFiltrationMode(Enum):
     NONSTOP_24H = "nonstop_24h"
     TIMER_PERIOD_1 = "timer_period_1"
     TIMER_PERIOD_1_AND_2 = "timer_period_1_and_2"
-    OFF_MANUAL = "off_manual"
+    MANUAL = "off_manual"
 
 
 # ---------------------------------------------------------------------------
@@ -191,8 +191,8 @@ class AsekoDevice:
     # Set for every device type in FILTRATION_TYPES = {SALT, HOME, OXY, PROFI}.
     # NET is excluded — no filtration output (see Issue #66).
     #
-    # HOME v7 devices encode the 4-state mode directly in byte[37] with two
-    # firmware variants:
+    # Every device type in FILTRATION_TYPES encodes the 4-state mode directly
+    # in byte[37] with two firmware variants:
     #   Firmware A (serial 110128063, byte 4 = 0x02): high nibble 0x4 / 0x5
     #     0x43 → NONSTOP_24H
     #     0x53 → TIMER_PERIOD_1_AND_2 (cannot distinguish P1 vs P1&P2)
@@ -201,14 +201,9 @@ class AsekoDevice:
     #     0x01 → NONSTOP_24H
     #     0x11 → TIMER_PERIOD_1
     #     0x31 → TIMER_PERIOD_1_AND_2
-    #     0x15 → OFF_MANUAL (P1 + manual override, bit 0x04 set)
-    #     0x35 → OFF_MANUAL (P1&P2 + manual override, bit 0x04 set)
+    #     0x15 → MANUAL (P1 + manual override, bit 0x04 set)
+    #     0x35 → MANUAL (P1&P2 + manual override, bit 0x04 set)
     #
-    # SALT / OXY / PROFI do not put a filtration mode flag in byte[37]
-    # (SALT: algicide/flocculant routing + dosage encoding; OXY: pump-
-    # presence bitmap; PROFI: no live frame captured). For those types
-    # the mode is derived from the schedule bytes 56-63 and the period-2
-    # enable bit (byte 37 bit 0x20, already covered by FILTRATION_PERIOD2_FLAG_TYPES).
     # This guarantees that a single `filtration_mode` sensor shows the
     # same 4 states on every filtration-capable device.
     filtration_mode: AsekoFiltrationMode | None = None

--- a/custom_components/aseko_local/aseko_data.py
+++ b/custom_components/aseko_local/aseko_data.py
@@ -110,6 +110,7 @@ class AsekoDevice:
     heating_control_enabled: bool | None = None  # byte 37 bit 3 (0x08) on HOME
     antifreeze_enabled: bool | None = None  # byte 37 bit 7 (0x80) on HOME
     vsp_pump_running: bool | None = None  # byte 22 bit 3 (0x08) on HOME
+    ph_minus_concentration: int | None = None  # byte 112 (%) on HOME (Issue #139)
     cl_pump_running: bool | None = None  # byte 29 (6-th bit)
     ph_minus_pump_running: bool | None = None  # byte 29 (7-th bit)
     ph_plus_pump_running: bool | None = (

--- a/custom_components/aseko_local/aseko_decoder.py
+++ b/custom_components/aseko_local/aseko_decoder.py
@@ -606,23 +606,34 @@ class AsekoDecoder:
         """Decode alarm bitmasks (bytes [12] and [13]) for all device types.
 
         byte [13] bitmask (multiple bits can be set simultaneously):
-          0x01 = pH alarm: too many doses, no value change   (error_codes.md)
-          0x02 = ORP/clf alarm: 30 doses, no value change    (error_codes.md)
+          0x01 = ORP / disinfection (chlorine) dose fault: max dose exceeded
+                 (Issue #151, HOME serial 110175608: config48 frame byte[13]=0x01
+                  while the controller showed "Maximum disinfection dose exceeded";
+                  same fault as v8 ins[12] bit 0x80)
+          0x02 = pH dose fault: too many doses, no value change
+                 (inferred — symmetric to 0x01; dtpugh expected 0x02 for a pH
+                  fault, but his pH fault was captured via byte [12] 0x40)
           0x04 = no flow to probes                           (DomSchCoding ✅, NET frame ✅)
           0x08 = rapid pH change, stops regulation ~2 h      (error_codes.md, unconfirmed)
 
-        byte [12] dosing-warning bitmask (HOME ✅, issue #134 before/after captures):
+        byte [12] dosing-warning bitmask (HOME ✅, issues #134 / #151 before/after
+        captures, serial 110175608):
           0x20 = disinfection / chlorine dosing warning
                  (Pool Live: MAXIMUM_DISINFECTION_DOSE_EXCEEDED)
           0x40 = pH dosing warning
                  (Pool Live: TOO_MANY_PH_DOSING_ATTEMPTS_WITHOUT_CHANGE)
 
+        Note on byte [13] 0x01 vs byte [12] 0x20: both encode the disinfection
+        dosing fault.  Issue #134 (2026-07-05) showed it in byte [12] 0x20,
+        Issue #151 (2026-08-06) in byte [13] 0x01 — likely a firmware change on
+        the Home.  The decoder ORs both paths so either encoding is detected.
+
         On NET, byte [12] is typically 0x00 while no-flow lives in byte [13]
         (byte [13] = 0x04). HOME dosing lockouts set byte [12] and leave
         byte [13] at 0x00, so both bytes must be consulted.
         """
-        unit.alarm_ph_too_many_doses = bool(data[13] & 0x01) or bool(data[12] & 0x40)
-        unit.alarm_orp_too_many_doses = bool(data[13] & 0x02) or bool(data[12] & 0x20)
+        unit.alarm_ph_too_many_doses = bool(data[13] & 0x02) or bool(data[12] & 0x40)
+        unit.alarm_orp_too_many_doses = bool(data[13] & 0x01) or bool(data[12] & 0x20)
         unit.alarm_no_flow_to_probes = bool(data[13] & 0x04)
         unit.alarm_rapid_ph_change = bool(data[13] & 0x08)
 

--- a/custom_components/aseko_local/aseko_decoder.py
+++ b/custom_components/aseko_local/aseko_decoder.py
@@ -584,57 +584,79 @@ class AsekoDecoder:
 
     @staticmethod
     def _fill_filtration_mode(unit: AsekoDevice, data: bytes) -> None:
-        """Decode filtration mode from byte[37] into `filtration_mode` (enum).
+        """Decode filtration mode into `filtration_mode` (enum).
 
-        Two encodings are observed on HOME v7 devices (firmware-dependent).
-        For all other device types, byte[37] is used for different purposes
-        (SALT: algicide routing, OXY: pump-presence bitmap, NET: always 0xFF),
-        so the field stays None.
+        Runs for every device type in FILTRATION_TYPES = {SALT, HOME, OXY, PROFI}.
+        NET is excluded — it has no filtration output (see Issue #66).
 
-        Old encoding (home_device_analysis.md, serial 110128063, byte 4 = 0x02):
-          high nibble 0x4 / 0x5
-          0x43 = nonstop 24h
-          0x53 = timer
-          0x47 / 0x57 = transitional edit state — leave as None
-          Old encoding cannot distinguish P1 vs P1&P2 — we default to
-          TIMER_PERIOD_1_AND_2 (the period-2 bit 0x20 is set in the
-          observed 0x53 value).
+        HOME v7 devices encode the full 4-state mode in byte[37] with two
+        firmware variants (Issue #133):
 
-        New encoding (Issue #133, serial 110169464, byte 4 = 0x03):
-          high nibble 0x0 / 0x1 / 0x3
-          0x01 = nonstop 24h
-          0x11 = P1 only
-          0x31 = P1 & P2
-          0x35 = OFF (manual override) — bit 0x04 set
+          Old encoding (home_device_analysis.md, serial 110128063, byte 4 = 0x02):
+            high nibble 0x4 / 0x5
+            0x43 = nonstop 24h
+            0x53 = timer (P1 or P1&P2, indistinguishable)
+            0x47 / 0x57 = transitional edit state — leave as None
 
-        The legacy `filtration_nonstop24` boolean field is kept for backwards
-        compatibility and is derived from `filtration_mode` here.
+          New encoding (Issue #133, serial 110169464, byte 4 = 0x03):
+            high nibble 0x0 / 0x1 / 0x3
+            0x01 = nonstop 24h
+            0x11 = P1 only
+            0x31 = P1 & P2
+            0x35 = OFF (manual override) — bit 0x04 set
+
+        SALT / OXY / PROFI do not put a filtration mode flag in byte[37]
+        (SALT uses it for algicide/flocculant routing + dosage encoding,
+        OXY uses it for the pump-presence bitmap, PROFI has no live frame
+        captured yet). For those device types the mode is derived from
+        the schedule fields that are already decoded:
+
+          NONSTOP_24H           ⇔ start1 is None (no schedule)
+          TIMER_PERIOD_1        ⇔ start1 set, period-2 byte 0x20 clear
+          TIMER_PERIOD_1_AND_2  ⇔ start1 set, period-2 byte 0x20 set
+          OFF_MANUAL            ⇔ only HOME firmware B (0x35)
+
+        The legacy `filtration_nonstop24` boolean field is kept for
+        backwards compatibility and is derived from `filtration_mode` here.
         """
-        if unit.device_type != AsekoDeviceType.HOME:
-            return
-
-        b = data[37]
-        if b == UNSPECIFIED_VALUE:
+        if unit.device_type is None or unit.device_type not in FILTRATION_TYPES:
             return
 
         mode: AsekoFiltrationMode | None = None
-        # Old encoding: high nibble 0x4 / 0x5
-        if b == 0x43:
-            mode = AsekoFiltrationMode.NONSTOP_24H
-        elif b == 0x53:
-            mode = AsekoFiltrationMode.TIMER_PERIOD_1_AND_2
-        # 0x47 / 0x57 are documented as "transitional edit state" in
-        # home_device_analysis.md Issue 4 — leave as None.
-        # New encoding: high nibble 0x0 / 0x1 / 0x3
-        elif b == 0x01:
-            mode = AsekoFiltrationMode.NONSTOP_24H
-        elif b == 0x11:
-            mode = AsekoFiltrationMode.TIMER_PERIOD_1
-        elif b == 0x31:
-            mode = AsekoFiltrationMode.TIMER_PERIOD_1_AND_2
-        elif b == 0x35:
-            mode = AsekoFiltrationMode.OFF_MANUAL
-        # else: leave as None (transitional / unrecognised HOME value)
+        b = data[37]
+
+        if unit.device_type == AsekoDeviceType.HOME:
+            # HOME: byte[37] carries the mode flag (two firmware variants).
+            if b != UNSPECIFIED_VALUE:
+                if b == 0x43 or b == 0x01:
+                    mode = AsekoFiltrationMode.NONSTOP_24H
+                elif b == 0x53:
+                    mode = AsekoFiltrationMode.TIMER_PERIOD_1_AND_2
+                elif b == 0x11:
+                    mode = AsekoFiltrationMode.TIMER_PERIOD_1
+                elif b == 0x31:
+                    mode = AsekoFiltrationMode.TIMER_PERIOD_1_AND_2
+                elif b == 0x35:
+                    mode = AsekoFiltrationMode.OFF_MANUAL
+                # 0x47 / 0x57 are documented as "transitional edit state"
+                # in home_device_analysis.md Issue 4 — leave as None.
+        else:
+            # SALT / OXY / PROFI: byte[37] does not encode filtration mode.
+            # Derive from the raw schedule bytes 56-63 (read here directly
+            # because this function runs before the schedule is decoded into
+            # `unit.start1` / `unit.start2`).
+            p1_set = data[56] != UNSPECIFIED_VALUE and data[57] != UNSPECIFIED_VALUE
+            p2_set = data[60] != UNSPECIFIED_VALUE and data[61] != UNSPECIFIED_VALUE
+            if not p1_set:
+                # No period 1 schedule → device is in NONSTOP_24H mode
+                # (or filtration is not actually configured on PROFI).
+                mode = AsekoFiltrationMode.NONSTOP_24H
+            elif p2_set or bool(b & FILTRATION_PERIOD2_ENABLED_MASK):
+                # Period 2 enabled (per byte 37 bit 0x20) or period 2 times
+                # are present in bytes 60-63.
+                mode = AsekoFiltrationMode.TIMER_PERIOD_1_AND_2
+            else:
+                mode = AsekoFiltrationMode.TIMER_PERIOD_1
 
         if mode is None:
             return

--- a/custom_components/aseko_local/aseko_decoder.py
+++ b/custom_components/aseko_local/aseko_decoder.py
@@ -737,7 +737,9 @@ class AsekoDecoder:
                 # No period 1 schedule → device is in NONSTOP_24H mode
                 # (or filtration is not actually configured on PROFI).
                 mode = AsekoFiltrationMode.NONSTOP_24H
-            elif b != UNSPECIFIED_VALUE and not bool(b & FILTRATION_PERIOD2_ENABLED_MASK):
+            elif b != UNSPECIFIED_VALUE and not bool(
+                b & FILTRATION_PERIOD2_ENABLED_MASK
+            ):
                 # byte[37] is well-defined and bit 0x20 is clear → the
                 # controller has disabled Period 2 in the UI, regardless of
                 # what bytes 60-63 still report.

--- a/custom_components/aseko_local/aseko_decoder.py
+++ b/custom_components/aseko_local/aseko_decoder.py
@@ -5,14 +5,17 @@ from typing import Type, TypeVar
 
 
 from .aseko_data import (
-    AsekoActuatorMasks,
     AsekoDevice,
     AsekoDeviceType,
     AsekoElectrolyzerDirection,
     AsekoFiltrationMode,
     AsekoProbeType,
-    AsekoThirdPumpSlot,
+)
+from .aseko_v7_helpers import (
     ACTUATOR_MASKS,
+    AsekoActuatorMasks,
+    AsekoByte37Masks,
+    AsekoThirdPumpSlot,
 )
 from .const import (
     FILTRATION_PERIOD2_ENABLED_MASK,
@@ -469,11 +472,24 @@ class AsekoDecoder:
 
         The bit-0x04 mapping is the same one JS-DE-Tech uses and was
         independently listed by the prior Node-RED decoder.
+
+        Additionally decodes the heating control master enable from
+        byte[37] (HOME v7 devices, Issue #135).  Diagnostics from serial
+        110175608 (ASIN AQUA Home, byte 4 = 0x03, firmware A high nibble
+        0x4) show bit 3 (0x08) set when heating control is ON (0x49) and
+        clear when OFF (0x41).  The initial unconfigured state (0x45) also
+        has bit 3 clear.
         """
         if unit.device_type == AsekoDeviceType.NET:
-            # NET has no heating output.
             return
         unit.heating_active = bool(data[29] & 0x04)
+
+        # byte[37] bit 3 = heating control master enable (HOME only).
+        # Gated on HOME so SALT / OXY / NET / PROFI behaviour is unchanged.
+        if unit.device_type == AsekoDeviceType.HOME and data[37] != UNSPECIFIED_VALUE:
+            unit.heating_control_enabled = bool(
+                data[37] & AsekoByte37Masks.HOME_FWA_HEATING_ENABLED
+            )
 
     @staticmethod
     def _fill_backwash_active(unit: AsekoDevice, data: bytes) -> None:
@@ -655,6 +671,25 @@ class AsekoDecoder:
                         mode = AsekoFiltrationMode.TIMER_PERIOD_1
                     elif (b & 0x30) == 0x30:
                         mode = AsekoFiltrationMode.TIMER_PERIOD_1_AND_2
+            # Fallback for unrecognised HOME firmware A values (Issue #135):
+            # serial 110175608 (byte 4=0x03 REDOX HOME) has values 0x45/0x49/0x41
+            # that don't match the known CLF HOME patterns (0x43/0x53/0x47/0x57).
+            # Transitional edit states (0x47, 0x57) have bit 1 set — keep them
+            # as None.  All other unrecognised firmware A values fall back to
+            # schedule-derived mode.
+            if (
+                mode is None
+                and b & 0x40
+                and not (b & AsekoByte37Masks.HOME_FWA_TRANSITIONAL_MASK)
+            ):
+                p1_set = data[56] != UNSPECIFIED_VALUE and data[57] != UNSPECIFIED_VALUE
+                p2_set = data[60] != UNSPECIFIED_VALUE and data[61] != UNSPECIFIED_VALUE
+                if not p1_set:
+                    mode = AsekoFiltrationMode.NONSTOP_24H
+                elif p2_set or bool(b & FILTRATION_PERIOD2_ENABLED_MASK):
+                    mode = AsekoFiltrationMode.TIMER_PERIOD_1_AND_2
+                else:
+                    mode = AsekoFiltrationMode.TIMER_PERIOD_1
         else:
             # SALT / OXY / PROFI: byte[37] does not encode filtration mode.
             # Derive from the raw schedule bytes 56-63 (read here directly

--- a/custom_components/aseko_local/aseko_decoder.py
+++ b/custom_components/aseko_local/aseko_decoder.py
@@ -9,6 +9,7 @@ from .aseko_data import (
     AsekoDevice,
     AsekoDeviceType,
     AsekoElectrolyzerDirection,
+    AsekoFiltrationMode,
     AsekoProbeType,
     AsekoThirdPumpSlot,
     ACTUATOR_MASKS,
@@ -583,20 +584,64 @@ class AsekoDecoder:
 
     @staticmethod
     def _fill_filtration_mode(unit: AsekoDevice, data: bytes) -> None:
-        """Decode filtration mode (byte [37]) for all device types.
+        """Decode filtration mode from byte[37] into `filtration_mode` (enum).
 
-        byte [37]:
-          0x43 = nonstop 24 h active   (confirmed: HOME ✅)
-          0x53 = timer mode active     (confirmed: HOME ✅, issue #110 ✅)
-          0x47 / 0x57 = transitional edit state → leave as None
-          other values → None (SALT uses 0xb7/0xb3/0x37/0x13 for pump routing;
-                               OXY uses 0x03; NET = 0xFF always → all give None)
+        Two encodings are observed on HOME v7 devices (firmware-dependent).
+        For all other device types, byte[37] is used for different purposes
+        (SALT: algicide routing, OXY: pump-presence bitmap, NET: always 0xFF),
+        so the field stays None.
+
+        Old encoding (home_device_analysis.md, serial 110128063, byte 4 = 0x02):
+          high nibble 0x4 / 0x5
+          0x43 = nonstop 24h
+          0x53 = timer
+          0x47 / 0x57 = transitional edit state — leave as None
+          Old encoding cannot distinguish P1 vs P1&P2 — we default to
+          TIMER_PERIOD_1_AND_2 (the period-2 bit 0x20 is set in the
+          observed 0x53 value).
+
+        New encoding (Issue #133, serial 110169464, byte 4 = 0x03):
+          high nibble 0x0 / 0x1 / 0x3
+          0x01 = nonstop 24h
+          0x11 = P1 only
+          0x31 = P1 & P2
+          0x35 = OFF (manual override) — bit 0x04 set
+
+        The legacy `filtration_nonstop24` boolean field is kept for backwards
+        compatibility and is derived from `filtration_mode` here.
         """
-        if data[37] == 0x43:
-            unit.filtration_nonstop24 = True
-        elif data[37] == 0x53:
-            unit.filtration_nonstop24 = False
-        # all other values (including 0xFF, 0x03, 0x37, 0xb7 …) → leave as None
+        if unit.device_type != AsekoDeviceType.HOME:
+            return
+
+        b = data[37]
+        if b == UNSPECIFIED_VALUE:
+            return
+
+        mode: AsekoFiltrationMode | None = None
+        # Old encoding: high nibble 0x4 / 0x5
+        if b == 0x43:
+            mode = AsekoFiltrationMode.NONSTOP_24H
+        elif b == 0x53:
+            mode = AsekoFiltrationMode.TIMER_PERIOD_1_AND_2
+        # 0x47 / 0x57 are documented as "transitional edit state" in
+        # home_device_analysis.md Issue 4 — leave as None.
+        # New encoding: high nibble 0x0 / 0x1 / 0x3
+        elif b == 0x01:
+            mode = AsekoFiltrationMode.NONSTOP_24H
+        elif b == 0x11:
+            mode = AsekoFiltrationMode.TIMER_PERIOD_1
+        elif b == 0x31:
+            mode = AsekoFiltrationMode.TIMER_PERIOD_1_AND_2
+        elif b == 0x35:
+            mode = AsekoFiltrationMode.OFF_MANUAL
+        # else: leave as None (transitional / unrecognised HOME value)
+
+        if mode is None:
+            return
+
+        unit.filtration_mode = mode
+        # Mirror onto the legacy boolean for backwards compatibility.
+        unit.filtration_nonstop24 = mode == AsekoFiltrationMode.NONSTOP_24H
 
     @staticmethod
     def _fill_consumable_data(unit: AsekoDevice, data: bytes) -> None:
@@ -626,6 +671,23 @@ class AsekoDecoder:
 
         if masks.oxy and unit.flowrate_oxy is not None:
             unit.oxy_pump_running = bool(data[29] & masks.oxy)
+
+        # Issue #133: on HOME v7 firmware B, byte[29] bit 3 stays set even
+        # when the user has manually switched the pump off on the unit
+        # (the override state lives in byte[37], not byte[29]). Trust the
+        # explicit OFF_MANUAL mode flag instead of the schedule-driven bit.
+        # Gated on HOME so SALT / OXY / NET / PROFI behaviour is unchanged.
+        if (
+            unit.device_type == AsekoDeviceType.HOME
+            and unit.filtration_mode == AsekoFiltrationMode.OFF_MANUAL
+            and unit.filtration_pump_running is True
+        ):
+            _LOGGER.debug(
+                "Manual OFF override active (filtration_mode=OFF_MANUAL) — "
+                "forcing filtration_pump_running to False (byte[29]=0x%02x)",
+                data[29],
+            )
+            unit.filtration_pump_running = False
 
     @staticmethod
     def decode(data: bytes) -> AsekoDevice:
@@ -701,10 +763,13 @@ class AsekoDecoder:
         # Flowrate must be decoded before consumable data: pump presence for
         # algicide/flocculant is determined by whether the flowrate byte is set (≠ 0xFF).
         AsekoDecoder._fill_flowrate_data(device, data)
+        # Filtration mode must be decoded before consumable data (Issue #133):
+        # the OFF_MANUAL state in byte[37] short-circuits
+        # `filtration_pump_running` in `_fill_consumable_data`.
+        AsekoDecoder._fill_filtration_mode(device, data)
         AsekoDecoder._fill_consumable_data(device, data)
         AsekoDecoder._fill_home_water_level_data(device, data)
         AsekoDecoder._fill_alarm_data(device, data)
-        AsekoDecoder._fill_filtration_mode(device, data)
         AsekoDecoder._fill_heating_demand(device, data)
         AsekoDecoder._fill_backwash_active(device, data)
         AsekoDecoder._fill_backwash_schedule(device)

--- a/custom_components/aseko_local/aseko_decoder.py
+++ b/custom_components/aseko_local/aseko_decoder.py
@@ -50,18 +50,6 @@ FILTRATION_TYPES = frozenset(
     }
 )
 
-# Device types verified to encode the second-filtration-period enable flag in
-# byte 37 bit 0x20: SALT (on/off frame diff), HOME and OXY (maintainer feedback,
-# PR #122). For any other type the second period is reported as before, because
-# its enable mechanism is unverified — never assume this bit for a new type.
-FILTRATION_PERIOD2_FLAG_TYPES = frozenset(
-    {
-        AsekoDeviceType.SALT,
-        AsekoDeviceType.HOME,
-        AsekoDeviceType.OXY,
-    }
-)
-
 # Device types that have a backwash valve/output and therefore expose a
 # backwash schedule (bytes 68-71) plus a backwash-active bit (byte 29 bit 0x01).
 # NET (Aqua NET) is a measurement + dosing unit only — it has neither a filter
@@ -735,15 +723,28 @@ class AsekoDecoder:
             # Derive from the raw schedule bytes 56-63 (read here directly
             # because this function runs before the schedule is decoded into
             # `unit.start1` / `unit.start2`).
+            #
+            # Issue #133: bytes 60-63 stay populated by the controller even
+            # after the user disables Period 2 (verified on dtpugh's serial
+            # 110169464: same 12:00-16:00 in all four modes).  Therefore the
+            # presence of period-2 bytes alone is NOT enough to claim
+            # TIMER_PERIOD_1_AND_2 — the byte[37] enable flag (bit 0x20) is
+            # authoritative when present.  When byte[37] is 0xFF (UNSPECIFIED,
+            # e.g. NET) the schedule bytes are the only signal we have.
             p1_set = data[56] != UNSPECIFIED_VALUE and data[57] != UNSPECIFIED_VALUE
             p2_set = data[60] != UNSPECIFIED_VALUE and data[61] != UNSPECIFIED_VALUE
             if not p1_set:
                 # No period 1 schedule → device is in NONSTOP_24H mode
                 # (or filtration is not actually configured on PROFI).
                 mode = AsekoFiltrationMode.NONSTOP_24H
+            elif b != UNSPECIFIED_VALUE and not bool(b & FILTRATION_PERIOD2_ENABLED_MASK):
+                # byte[37] is well-defined and bit 0x20 is clear → the
+                # controller has disabled Period 2 in the UI, regardless of
+                # what bytes 60-63 still report.
+                mode = AsekoFiltrationMode.TIMER_PERIOD_1
             elif p2_set or bool(b & FILTRATION_PERIOD2_ENABLED_MASK):
                 # Period 2 enabled (per byte 37 bit 0x20) or period 2 times
-                # are present in bytes 60-63.
+                # are present in bytes 60-63 and byte[37] is unspecified.
                 mode = AsekoFiltrationMode.TIMER_PERIOD_1_AND_2
             else:
                 mode = AsekoFiltrationMode.TIMER_PERIOD_1
@@ -810,15 +811,16 @@ class AsekoDecoder:
 
         # Filtration schedule, by device type (PR #122):
         #  - NET / unknown types have no filtration → no schedule reported.
-        #  - The second period can be switched off on the unit while it keeps
-        #    reporting the last-configured start2/stop2 times (bytes 60-63);
-        #    byte 37 bit 0x20 is the enable flag on the verified types.
+        #  - Period 1 + Period 2 share the same byte range 56-63 on every
+        #    FILTRATION_TYPES device.  The device keeps sending the last
+        #    configured start2/stop2 times even when Period 2 is disabled
+        #    (Issue #133 — verified on serial 110169464, firmware B: bytes
+        #    60-63 are stable across P1 only / P1&P2 / 24h / OFF_MANUAL
+        #    modes).  Reading them unconditionally is therefore safe; the
+        #    *_time helpers normalise 0xFF bytes to None and the lazy-
+        #    creation guard in sensor.py skips the entity when no value is
+        #    available.
         has_filtration = unit_type in FILTRATION_TYPES
-        filtration2_enabled = has_filtration and (
-            bool(data[37] & FILTRATION_PERIOD2_ENABLED_MASK)
-            if unit_type in FILTRATION_PERIOD2_FLAG_TYPES
-            else True
-        )
         # Issue #129: gate backwash schedule + active bit on device type so
         # measurement-only units (NET) do not surface phantom backwash entities
         # from non-0xFF frame data.
@@ -835,8 +837,15 @@ class AsekoDecoder:
             required_water_temperature=AsekoDecoder._normalize_value(data[55], int),
             start1=AsekoDecoder._time(data[56:58]) if has_filtration else None,
             stop1=AsekoDecoder._time(data[58:60]) if has_filtration else None,
-            start2=AsekoDecoder._time(data[60:62]) if filtration2_enabled else None,
-            stop2=AsekoDecoder._time(data[62:64]) if filtration2_enabled else None,
+            # Issue #133: always read bytes 60-63 for start2/stop2 when the
+            # device has a filtration output.  The device keeps reporting the
+            # last-configured Period 2 times even after the user disables
+            # Period 2 on the controller — verified on dtpugh's serial
+            # 110169464 (firmware B).  For device types without a filtration
+            # output (NET / unknown) we still return None so the entity is
+            # not registered at all (lazy-creation in sensor.py).
+            start2=AsekoDecoder._time(data[60:62]) if has_filtration else None,
+            stop2=AsekoDecoder._time(data[62:64]) if has_filtration else None,
             backwash_every_n_days=(
                 AsekoDecoder._normalize_value(data[68], int) if has_backwash else None
             ),

--- a/custom_components/aseko_local/aseko_decoder.py
+++ b/custom_components/aseko_local/aseko_decoder.py
@@ -603,7 +603,8 @@ class AsekoDecoder:
             0x01 = nonstop 24h
             0x11 = P1 only
             0x31 = P1 & P2
-            0x35 = OFF (manual override) — bit 0x04 set
+            0x15 = P1 + manual override     → OFF_MANUAL (bit 0x04 set)
+            0x35 = P1 & P2 + manual override → OFF_MANUAL (bit 0x04 set)
 
         SALT / OXY / PROFI do not put a filtration mode flag in byte[37]
         (SALT uses it for algicide/flocculant routing + dosage encoding,
@@ -627,19 +628,33 @@ class AsekoDecoder:
 
         if unit.device_type == AsekoDeviceType.HOME:
             # HOME: byte[37] carries the mode flag (two firmware variants).
+            # Firmware A (high nibble 0x4/0x5, serial 110128063, byte 4 = 0x02)
+            # uses exact byte values. Firmware B (high nibble 0x0/0x1/0x3,
+            # serial 110169464, byte 4 = 0x03) uses bit flags:
+            #   bit 2 (0x04) = manual override active
+            #   bit 4 (0x10) = period 1 enabled
+            #   bit 5 (0x20) = period 2 enabled
             if b != UNSPECIFIED_VALUE:
-                if b == 0x43 or b == 0x01:
-                    mode = AsekoFiltrationMode.NONSTOP_24H
-                elif b == 0x53:
-                    mode = AsekoFiltrationMode.TIMER_PERIOD_1_AND_2
-                elif b == 0x11:
-                    mode = AsekoFiltrationMode.TIMER_PERIOD_1
-                elif b == 0x31:
-                    mode = AsekoFiltrationMode.TIMER_PERIOD_1_AND_2
-                elif b == 0x35:
-                    mode = AsekoFiltrationMode.OFF_MANUAL
-                # 0x47 / 0x57 are documented as "transitional edit state"
-                # in home_device_analysis.md Issue 4 — leave as None.
+                if b & 0x40:
+                    # Firmware A: high nibble 0x4/0x5.
+                    if b == 0x43:
+                        mode = AsekoFiltrationMode.NONSTOP_24H
+                    elif b == 0x53:
+                        mode = AsekoFiltrationMode.TIMER_PERIOD_1_AND_2
+                    # 0x47 / 0x57 → transitional edit state, leave as None.
+                else:
+                    # Firmware B: high nibble 0x0/0x1/0x3.
+                    if b & 0x04:
+                        # Manual override active — bit 2 set.
+                        # Observed values: 0x15 (P1 + override),
+                        # 0x35 (P1&P2 + override).
+                        mode = AsekoFiltrationMode.OFF_MANUAL
+                    elif (b & 0x30) == 0x00:
+                        mode = AsekoFiltrationMode.NONSTOP_24H
+                    elif (b & 0x30) == 0x10:
+                        mode = AsekoFiltrationMode.TIMER_PERIOD_1
+                    elif (b & 0x30) == 0x30:
+                        mode = AsekoFiltrationMode.TIMER_PERIOD_1_AND_2
         else:
             # SALT / OXY / PROFI: byte[37] does not encode filtration mode.
             # Derive from the raw schedule bytes 56-63 (read here directly

--- a/custom_components/aseko_local/aseko_decoder.py
+++ b/custom_components/aseko_local/aseko_decoder.py
@@ -516,6 +516,22 @@ class AsekoDecoder:
         unit.vsp_pump_running = bool(data[22] & 0x08)
 
     @staticmethod
+    def _fill_ph_minus_concentration(unit: AsekoDevice, data: bytes) -> None:
+        """Decode the pH- acid concentration percentage.
+
+        byte[112] = concentration in percent (e.g. 5 → 5%, 10 → 10%).
+        Confirmed on serial 110175608 (ASIN AQUA Home REDOX, Issue #139).
+
+        Only decoded for HOME. Other device types may use byte[112] for
+        a different purpose, so the field stays None.
+        """
+        if unit.device_type != AsekoDeviceType.HOME:
+            return
+        if data[112] == UNSPECIFIED_VALUE:
+            return
+        unit.ph_minus_concentration = data[112]
+
+    @staticmethod
     def _fill_backwash_active(unit: AsekoDevice, data: bytes) -> None:
         """Decode the backwash relay state from byte[29] bit 0x01.
 
@@ -868,6 +884,7 @@ class AsekoDecoder:
         AsekoDecoder._fill_alarm_data(device, data)
         AsekoDecoder._fill_heating_demand(device, data)
         AsekoDecoder._fill_vsp_pump(device, data)
+        AsekoDecoder._fill_ph_minus_concentration(device, data)
         AsekoDecoder._fill_backwash_active(device, data)
         AsekoDecoder._fill_backwash_schedule(device)
 

--- a/custom_components/aseko_local/aseko_decoder.py
+++ b/custom_components/aseko_local/aseko_decoder.py
@@ -499,6 +499,23 @@ class AsekoDecoder:
             )
 
     @staticmethod
+    def _fill_vsp_pump(unit: AsekoDevice, data: bytes) -> None:
+        """Decode the variable-speed filtration pump running state.
+
+        byte[22] bit 3 (0x08) = variable-speed pump ON/OFF.
+        Confirmed on serial 110175608 (ASIN AQUA Home REDOX, byte 4 = 0x03):
+        0x83 → pump OFF, 0x8b → pump ON (any brand).
+
+        Only decoded for HOME. Other device types (SALT, OXY, PROFI, NET)
+        may use byte[22] for a different purpose, so the field stays None.
+        """
+        if unit.device_type != AsekoDeviceType.HOME:
+            return
+        if data[22] == UNSPECIFIED_VALUE:
+            return
+        unit.vsp_pump_running = bool(data[22] & 0x08)
+
+    @staticmethod
     def _fill_backwash_active(unit: AsekoDevice, data: bytes) -> None:
         """Decode the backwash relay state from byte[29] bit 0x01.
 
@@ -850,6 +867,7 @@ class AsekoDecoder:
         AsekoDecoder._fill_home_water_level_data(device, data)
         AsekoDecoder._fill_alarm_data(device, data)
         AsekoDecoder._fill_heating_demand(device, data)
+        AsekoDecoder._fill_vsp_pump(device, data)
         AsekoDecoder._fill_backwash_active(device, data)
         AsekoDecoder._fill_backwash_schedule(device)
 

--- a/custom_components/aseko_local/aseko_decoder.py
+++ b/custom_components/aseko_local/aseko_decoder.py
@@ -460,25 +460,24 @@ class AsekoDecoder:
 
     @staticmethod
     def _fill_heating_demand(unit: AsekoDevice, data: bytes) -> None:
-        """Decode the heating demand relay state from byte[29] bit 0x04.
+        """Decode heating-related fields from byte[29] and byte[37].
 
         byte[29] bit 0x04 = heating demand relay (JS-DE-Tech "relay_byte"
         bit 2).  Set whenever the pool controller is requesting heat from
         the configured heater source (heat pump, electric heater, etc.).
-
         Available on HOME, SALT, OXY.  NET does not have a heating output,
         so the field stays None for NET (and no binary sensor is
         registered).
 
-        The bit-0x04 mapping is the same one JS-DE-Tech uses and was
-        independently listed by the prior Node-RED decoder.
+        byte[37] bit 3 (0x08) = heating control master enable (HOME only,
+        Issue #135).  Diagnostics from serial 110175608 (ASIN AQUA Home,
+        byte 4 = 0x03, firmware A high nibble 0x4) show bit 3 set when
+        heating control is ON (0x49) and clear when OFF (0x41).
 
-        Additionally decodes the heating control master enable from
-        byte[37] (HOME v7 devices, Issue #135).  Diagnostics from serial
-        110175608 (ASIN AQUA Home, byte 4 = 0x03, firmware A high nibble
-        0x4) show bit 3 (0x08) set when heating control is ON (0x49) and
-        clear when OFF (0x41).  The initial unconfigured state (0x45) also
-        has bit 3 clear.
+        byte[37] bit 7 (0x80) = antifreeze master enable (HOME only,
+        Issue #136).  On the same device, 0x81 → antifreeze ON, 0x41 →
+        antifreeze OFF.  When enabled, byte[55] shows the antifreeze
+        temperature threshold (4°C) instead of the normal heating setpoint.
         """
         if unit.device_type == AsekoDeviceType.NET:
             return
@@ -489,6 +488,14 @@ class AsekoDecoder:
         if unit.device_type == AsekoDeviceType.HOME and data[37] != UNSPECIFIED_VALUE:
             unit.heating_control_enabled = bool(
                 data[37] & AsekoByte37Masks.HOME_FWA_HEATING_ENABLED
+            )
+
+        # byte[37] bit 7 = antifreeze master enable (HOME only, Issue #136).
+        # Confirmed on serial 110175608 (ASIN AQUA Home REDOX, byte 4 = 0x03):
+        #   0x81 → antifreeze ON, 0x41 → antifreeze OFF.
+        if unit.device_type == AsekoDeviceType.HOME and data[37] != UNSPECIFIED_VALUE:
+            unit.antifreeze_enabled = bool(
+                data[37] & AsekoByte37Masks.HOME_FWA_ANTIFREEZE_ENABLED
             )
 
     @staticmethod

--- a/custom_components/aseko_local/aseko_decoder.py
+++ b/custom_components/aseko_local/aseko_decoder.py
@@ -494,10 +494,9 @@ class AsekoDecoder:
         Confirmed on serial 110175608 (ASIN AQUA Home REDOX, byte 4 = 0x03):
         0x83 → pump OFF, 0x8b → pump ON (any brand).
 
-        Only decoded for HOME. Other device types (SALT, OXY, PROFI, NET)
-        may use byte[22] for a different purpose, so the field stays None.
+        Decoded for HOME, SALT, OXY, PROFI. NET not supported.
         """
-        if unit.device_type != AsekoDeviceType.HOME:
+        if unit.device_type == AsekoDeviceType.NET:
             return
         if data[22] == UNSPECIFIED_VALUE:
             return
@@ -510,10 +509,9 @@ class AsekoDecoder:
         byte[112] = concentration in percent (e.g. 5 → 5%, 10 → 10%).
         Confirmed on serial 110175608 (ASIN AQUA Home REDOX, Issue #139).
 
-        Only decoded for HOME. Other device types may use byte[112] for
-        a different purpose, so the field stays None.
+        Decoded for HOME, SALT, OXY, PROFI. NET not supported.
         """
-        if unit.device_type != AsekoDeviceType.HOME:
+        if unit.device_type == AsekoDeviceType.NET:
             return
         if data[112] == UNSPECIFIED_VALUE:
             return
@@ -644,8 +642,8 @@ class AsekoDecoder:
         Runs for every device type in FILTRATION_TYPES = {SALT, HOME, OXY, PROFI}.
         NET is excluded — it has no filtration output (see Issue #66).
 
-        HOME v7 devices encode the full 4-state mode in byte[37] with two
-        firmware variants (Issue #133):
+        Every device type in FILTRATION_TYPES encodes the full 4-state mode in
+        byte[37] with two firmware variants (Issue #133):
 
           Old encoding (home_device_analysis.md, serial 110128063, byte 4 = 0x02):
             high nibble 0x4 / 0x5
@@ -658,19 +656,8 @@ class AsekoDecoder:
             0x01 = nonstop 24h
             0x11 = P1 only
             0x31 = P1 & P2
-            0x15 = P1 + manual override     → OFF_MANUAL (bit 0x04 set)
-            0x35 = P1 & P2 + manual override → OFF_MANUAL (bit 0x04 set)
-
-        SALT / OXY / PROFI do not put a filtration mode flag in byte[37]
-        (SALT uses it for algicide/flocculant routing + dosage encoding,
-        OXY uses it for the pump-presence bitmap, PROFI has no live frame
-        captured yet). For those device types the mode is derived from
-        the schedule fields that are already decoded:
-
-          NONSTOP_24H           ⇔ start1 is None (no schedule)
-          TIMER_PERIOD_1        ⇔ start1 set, period-2 byte 0x20 clear
-          TIMER_PERIOD_1_AND_2  ⇔ start1 set, period-2 byte 0x20 set
-          OFF_MANUAL            ⇔ only HOME firmware B (0x35)
+            0x15 = P1 + manual override     → MANUAL (bit 0x04 set)
+            0x35 = P1 & P2 + manual override → MANUAL (bit 0x04 set)
 
         The legacy `filtration_nonstop24` boolean field is kept for
         backwards compatibility and is derived from `filtration_mode` here.
@@ -681,83 +668,51 @@ class AsekoDecoder:
         mode: AsekoFiltrationMode | None = None
         b = data[37]
 
-        if unit.device_type == AsekoDeviceType.HOME:
-            # HOME: byte[37] carries the mode flag (two firmware variants).
-            # Firmware A (high nibble 0x4/0x5, serial 110128063, byte 4 = 0x02)
-            # uses exact byte values. Firmware B (high nibble 0x0/0x1/0x3,
-            # serial 110169464, byte 4 = 0x03) uses bit flags:
-            #   bit 2 (0x04) = manual override active
-            #   bit 4 (0x10) = period 1 enabled
-            #   bit 5 (0x20) = period 2 enabled
-            if b != UNSPECIFIED_VALUE:
-                if b & 0x40:
-                    # Firmware A: high nibble 0x4/0x5.
-                    if b == 0x43:
-                        mode = AsekoFiltrationMode.NONSTOP_24H
-                    elif b == 0x53:
-                        mode = AsekoFiltrationMode.TIMER_PERIOD_1_AND_2
-                    # 0x47 / 0x57 → transitional edit state, leave as None.
-                else:
-                    # Firmware B: high nibble 0x0/0x1/0x3.
-                    if b & 0x04:
-                        # Manual override active — bit 2 set.
-                        # Observed values: 0x15 (P1 + override),
-                        # 0x35 (P1&P2 + override).
-                        mode = AsekoFiltrationMode.OFF_MANUAL
-                    elif (b & 0x30) == 0x00:
-                        mode = AsekoFiltrationMode.NONSTOP_24H
-                    elif (b & 0x30) == 0x10:
-                        mode = AsekoFiltrationMode.TIMER_PERIOD_1
-                    elif (b & 0x30) == 0x30:
-                        mode = AsekoFiltrationMode.TIMER_PERIOD_1_AND_2
-            # Fallback for unrecognised HOME firmware A values (Issue #135):
-            # serial 110175608 (byte 4=0x03 REDOX HOME) has values 0x45/0x49/0x41
-            # that don't match the known CLF HOME patterns (0x43/0x53/0x47/0x57).
-            # Transitional edit states (0x47, 0x57) have bit 1 set — keep them
-            # as None.  All other unrecognised firmware A values fall back to
-            # schedule-derived mode.
-            if (
-                mode is None
-                and b & 0x40
-                and not (b & AsekoByte37Masks.HOME_FWA_TRANSITIONAL_MASK)
-            ):
-                p1_set = data[56] != UNSPECIFIED_VALUE and data[57] != UNSPECIFIED_VALUE
-                p2_set = data[60] != UNSPECIFIED_VALUE and data[61] != UNSPECIFIED_VALUE
-                if not p1_set:
+        # byte[37] carries the mode flag for every FILTRATION_TYPES device
+        # (SALT, HOME, OXY, PROFI).  Firmware A (high nibble 0x4/0x5,
+        # serial 110128063, byte 4 = 0x02) uses exact byte values.
+        # Firmware B (high nibble 0x0/0x1/0x3, serial 110169464, byte 4 = 0x03)
+        # uses bit flags:
+        #   bit 2 (0x04) = manual override active
+        #   bit 4 (0x10) = period 1 enabled
+        #   bit 5 (0x20) = period 2 enabled
+        if b != UNSPECIFIED_VALUE:
+            if b & 0x40:
+                # Firmware A: high nibble 0x4/0x5.
+                if b == 0x43:
                     mode = AsekoFiltrationMode.NONSTOP_24H
-                elif p2_set or bool(b & FILTRATION_PERIOD2_ENABLED_MASK):
+                elif b == 0x53:
                     mode = AsekoFiltrationMode.TIMER_PERIOD_1_AND_2
-                else:
+                # 0x47 / 0x57 → transitional edit state, leave as None.
+            else:
+                # Firmware B: high nibble 0x0/0x1/0x3.
+                if b & 0x04:
+                    # Manual override active — bit 2 set.
+                    # Observed values: 0x15 (P1 + override),
+                    # 0x35 (P1&P2 + override).
+                    mode = AsekoFiltrationMode.MANUAL
+                elif (b & 0x30) == 0x00:
+                    mode = AsekoFiltrationMode.NONSTOP_24H
+                elif (b & 0x30) == 0x10:
                     mode = AsekoFiltrationMode.TIMER_PERIOD_1
-        else:
-            # SALT / OXY / PROFI: byte[37] does not encode filtration mode.
-            # Derive from the raw schedule bytes 56-63 (read here directly
-            # because this function runs before the schedule is decoded into
-            # `unit.start1` / `unit.start2`).
-            #
-            # Issue #133: bytes 60-63 stay populated by the controller even
-            # after the user disables Period 2 (verified on dtpugh's serial
-            # 110169464: same 12:00-16:00 in all four modes).  Therefore the
-            # presence of period-2 bytes alone is NOT enough to claim
-            # TIMER_PERIOD_1_AND_2 — the byte[37] enable flag (bit 0x20) is
-            # authoritative when present.  When byte[37] is 0xFF (UNSPECIFIED,
-            # e.g. NET) the schedule bytes are the only signal we have.
+                elif (b & 0x30) == 0x30:
+                    mode = AsekoFiltrationMode.TIMER_PERIOD_1_AND_2
+        # Fallback for unrecognised firmware A values (Issue #135):
+        # serial 110175608 (byte 4=0x03 REDOX HOME) has values 0x45/0x49/0x41
+        # that don't match the known CLF HOME patterns (0x43/0x53/0x47/0x57).
+        # Transitional edit states (0x47, 0x57) have bit 1 set — keep them
+        # as None.  All other unrecognised firmware A values fall back to
+        # schedule-derived mode.
+        if (
+            mode is None
+            and b & 0x40
+            and not (b & AsekoByte37Masks.HOME_FWA_TRANSITIONAL_MASK)
+        ):
             p1_set = data[56] != UNSPECIFIED_VALUE and data[57] != UNSPECIFIED_VALUE
             p2_set = data[60] != UNSPECIFIED_VALUE and data[61] != UNSPECIFIED_VALUE
             if not p1_set:
-                # No period 1 schedule → device is in NONSTOP_24H mode
-                # (or filtration is not actually configured on PROFI).
                 mode = AsekoFiltrationMode.NONSTOP_24H
-            elif b != UNSPECIFIED_VALUE and not bool(
-                b & FILTRATION_PERIOD2_ENABLED_MASK
-            ):
-                # byte[37] is well-defined and bit 0x20 is clear → the
-                # controller has disabled Period 2 in the UI, regardless of
-                # what bytes 60-63 still report.
-                mode = AsekoFiltrationMode.TIMER_PERIOD_1
             elif p2_set or bool(b & FILTRATION_PERIOD2_ENABLED_MASK):
-                # Period 2 enabled (per byte 37 bit 0x20) or period 2 times
-                # are present in bytes 60-63 and byte[37] is unspecified.
                 mode = AsekoFiltrationMode.TIMER_PERIOD_1_AND_2
             else:
                 mode = AsekoFiltrationMode.TIMER_PERIOD_1
@@ -801,15 +756,15 @@ class AsekoDecoder:
         # Issue #133: on HOME v7 firmware B, byte[29] bit 3 stays set even
         # when the user has manually switched the pump off on the unit
         # (the override state lives in byte[37], not byte[29]). Trust the
-        # explicit OFF_MANUAL mode flag instead of the schedule-driven bit.
+        # explicit MANUAL mode flag instead of the schedule-driven bit.
         # Gated on HOME so SALT / OXY / NET / PROFI behaviour is unchanged.
         if (
             unit.device_type == AsekoDeviceType.HOME
-            and unit.filtration_mode == AsekoFiltrationMode.OFF_MANUAL
+            and unit.filtration_mode == AsekoFiltrationMode.MANUAL
             and unit.filtration_pump_running is True
         ):
             _LOGGER.debug(
-                "Manual OFF override active (filtration_mode=OFF_MANUAL) — "
+                "Manual OFF override active (filtration_mode=MANUAL) — "
                 "forcing filtration_pump_running to False (byte[29]=0x%02x)",
                 data[29],
             )
@@ -828,7 +783,7 @@ class AsekoDecoder:
         #    FILTRATION_TYPES device.  The device keeps sending the last
         #    configured start2/stop2 times even when Period 2 is disabled
         #    (Issue #133 — verified on serial 110169464, firmware B: bytes
-        #    60-63 are stable across P1 only / P1&P2 / 24h / OFF_MANUAL
+        #    60-63 are stable across P1 only / P1&P2 / 24h / MANUAL
         #    modes).  Reading them unconditionally is therefore safe; the
         #    *_time helpers normalise 0xFF bytes to None and the lazy-
         #    creation guard in sensor.py skips the entity when no value is
@@ -898,7 +853,7 @@ class AsekoDecoder:
         # algicide/flocculant is determined by whether the flowrate byte is set (≠ 0xFF).
         AsekoDecoder._fill_flowrate_data(device, data)
         # Filtration mode must be decoded before consumable data (Issue #133):
-        # the OFF_MANUAL state in byte[37] short-circuits
+        # the MANUAL state in byte[37] short-circuits
         # `filtration_pump_running` in `_fill_consumable_data`.
         AsekoDecoder._fill_filtration_mode(device, data)
         AsekoDecoder._fill_consumable_data(device, data)

--- a/custom_components/aseko_local/aseko_v7_helpers.py
+++ b/custom_components/aseko_local/aseko_v7_helpers.py
@@ -1,0 +1,193 @@
+"""v7 (binary 120-byte frame) decoder-specific helpers.
+
+This module contains all knowledge that is specific to the Aseko **v7
+binary frame protocol** (120 bytes, used by SALT, OXY, HOME, PROFI, NET).
+It is the home of:
+
+- ``AsekoActuatorMasks``: byte[29] bit masks per device type (pumps,
+  electrolyser, backwash relay, etc.).
+- ``ACTUATOR_MASKS``: the per-device-type mapping.
+- ``AsekoThirdPumpSlot``: byte[37] routing constants for SALT's
+  shared-port architecture.
+- ``AsekoByte37Masks``: all known bitmask constants for byte[37].
+
+The v7 decoder (``aseko_decoder.py``) imports these constants directly.
+The v8 decoder (``aseko_decoder_v8.py``) **does not** use any of this
+module — v8 has no byte[29] actuator bitmask.
+
+The ``AsekoDevice`` data model in ``aseko_data.py`` is the
+**protocol-agnostic target schema** consumed by the entity layer
+(``sensor.py``, ``binary_sensor.py``, etc.). It must not import
+byte-level knowledge from this module — see ``sensor.py``'s
+``_device_has_pump`` helper for the protocol-aware pump-presence check.
+
+See ``aseko_v8_helpers.py`` for the v8-side counterpart.
+"""
+
+from dataclasses import dataclass
+
+from .aseko_data import AsekoDeviceType
+
+
+class AsekoThirdPumpSlot:
+    """Semantics of byte[37] differ by device type.
+
+    SALT (shared physical port): routing indicator.
+        Bit 7 (0x80) set → algicide configured in the single port.
+        Bit 7 (0x80) clear → flocculant configured.
+        Confirmed by @hopkins-tk (SALT v7.x frames, 2025) and consistent with
+        @jmnemonicj (SALT v5.0, Issue #84) where 0x03 & 0x80 == 0 → flocculant.
+
+    OXY (two independent ports): suspected pump-presence bitmap.
+        Bit 0 (0x01) = flocculant pump module connected.  # unconfirmed hypothesis
+        Bit 1 (0x02) = algicide pump module connected.    # unconfirmed hypothesis
+        Observed 0x03 on Winnetoux's OXY (both pumps present). Requires a frame
+        with only one pump connected to confirm.
+        TODO: confirm OXY semantics with an asymmetric frame.
+
+    NET / PROFI / HOME: 0xFF (UNSPECIFIED) = no third-pump port, routing not applicable.
+    """
+
+    # SALT: bit 7 → algicide in the shared port; clear → flocculant
+    SALT_ALGICIDE_ROUTING: int = 0x80
+
+    # OXY: presence bits – which pump modules are physically connected.
+    # UNCONFIRMED: based solely on the single observed value 0x03 (both present).
+    OXY_FLOC_PRESENT: int = 0x01
+    OXY_ALGICIDE_PRESENT: int = 0x02
+
+
+class AsekoByte37Masks:
+    """All known bitmask constants for byte[37].
+
+    Byte [37] is a multi-purpose configuration / status byte whose bits
+    have different meanings depending on device type and firmware variant.
+
+    Bit layout (by convention, not all bits apply to every device):
+
+    Bit 0 (0x01): OXY flocculant-pump presence / general flag.
+    Bit 1 (0x02): OXY algicide-pump presence.
+    Bit 2 (0x04): HOME firmware B → manual-override active;
+                  HOME firmware A → unknown / initial-state indicator.
+    Bit 3 (0x08): HOME firmware A → heating-control master enable (Issue #135).
+    Bit 4 (0x10): HOME firmware B → period-1 enabled.
+    Bit 5 (0x20): Second filtration period enabled
+                  (see ``FILTRATION_PERIOD2_ENABLED_MASK`` in const.py).
+                  Also HOME firmware B → period-2 enabled.
+    Bit 6 (0x40): HOME firmware A high-nibble indicator
+                  (set: firmware-A encoding; clear: firmware-B encoding).
+    Bit 7 (0x80): SALT shared-port routing indicator
+                  (see ``AsekoThirdPumpSlot.SALT_ALGICIDE_ROUTING``).
+
+    Constants are grouped by device family below.
+    """
+
+    # ── Masks applicable across multiple device types ────────────────────
+
+    PERIOD_2_ENABLED: int = 0x20  # second filtration period enabled
+
+    # ── HOME firmware A (high nibble 0x4/0x5, serial 110128063 ff.) ──────
+
+    HOME_FWA_MODE_NONSTOP: int = 0x43  # nonstop 24h (exact value)
+    HOME_FWA_MODE_TIMER: int = 0x53  # timer (P1 & P2, exact value)
+    # 0x47 / 0x57 are transitional edit states (bit 1 set) → leave as None
+    HOME_FWA_TRANSITIONAL_MASK: int = 0x02  # bit 1 → transitional
+
+    # Heating control master enable (Issue #135).
+    # Confirmed on serial 110175608 (ASIN AQUA Home REDOX, byte 4 = 0x03):
+    #   0x49 → heating ON, 0x41 → heating OFF.
+    HOME_FWA_HEATING_ENABLED: int = 0x08
+
+    # ── HOME firmware B (high nibble 0x0/0x1/0x3, serial 110169464) ─────
+
+    HOME_FWB_MANUAL_OVERRIDE: int = 0x04  # manual override active
+    HOME_FWB_PERIOD_1_ENABLED: int = 0x10  # period 1 enabled
+    HOME_FWB_PERIOD_2_ENABLED: int = 0x20  # period 2 enabled
+
+    # ── SALT exclusive ──────────────────────────────────────────────────
+
+    SALT_ALGICIDE_ROUTING: int = 0x80  # same as AsekoThirdPumpSlot
+
+    # ── OXY exclusive (unconfirmed) ─────────────────────────────────────
+
+    OXY_FLOC_PRESENT: int = 0x01
+    OXY_ALGICIDE_PRESENT: int = 0x02
+
+
+@dataclass(frozen=True)
+class AsekoActuatorMasks:
+    """Byte 29 bit masks for actuator state detection (pumps + electrolyser), per device type.
+
+    **v7 only.** The v8 frame does not have a ``byte[29]`` actuator bitmask —
+    v8 pump running states are exposed via the ``outs:`` section, and the
+    v8 device-type capability is derived from the ``fncs:`` section. See
+    ``aseko_v8_helpers.py`` for the v8-side counterpart.
+    """
+
+    filtration: int = 0x00
+    cl: int = 0x00
+    ph_minus: int = 0x00
+    algicide: int = 0x00
+    flocculant: int = 0x00
+    oxy: int = 0x00  # unconfirmed – awaiting frame with OXY Pure pump active
+    electrolyzer_running: int = 0x00
+    electrolyzer_running_right: int = 0x00
+    electrolyzer_running_left: int = 0x00
+    # On devices with a single shared physical pump port (SALT and similar 2-3-pump
+    # units), byte[37] carries a routing indicator: bit 7 set → algicide setpoint;
+    # clear → flocculant setpoint (AsekoThirdPumpSlot.SALT_ALGICIDE_ROUTING).
+    # Devices with 4+ independent pump ports (OXY, HOME, PROFI) do NOT use this
+    # routing — algicide and flocculant have separate physical connections whose
+    # setpoint byte positions are not yet confirmed from frames.
+    # Set False for those devices so decode() skips the routing logic entirely.
+    byte37_routes_pump_type: bool = True
+
+
+ACTUATOR_MASKS: dict[AsekoDeviceType, AsekoActuatorMasks] = {
+    # Masks only for V7
+    AsekoDeviceType.OXY: AsekoActuatorMasks(
+        filtration=0x08,  # confirmed: all captured frames
+        algicide=0x10,  # confirmed: 2026-04-11 Winnetoux log – byte[29] 0x08→0x18 at algicide pump on
+        flocculant=0x20,  # confirmed: toggles exactly at 19:33:52 floc event
+        oxy=0x40,  # confirmed: 2026-04-11 Winnetoux log – byte[29] 0x08→0x48 at OXY pump on
+        ph_minus=0x80,  # confirmed: 2026-04-12 Winnetoux log – byte[29] 0x08→0x88 at pH- pump on
+        byte37_routes_pump_type=False,  # OXY byte[37] = pump-presence bitmap, not routing
+    ),
+    AsekoDeviceType.NET: AsekoActuatorMasks(
+        # Aqua NET has no filtration output — confirmed: Issue #66
+        cl=0x02,  # confirmed: Issue #66 (Aqua NET)
+        ph_minus=0x01,  # confirmed: Issue #66 (Aqua NET)
+    ),
+    AsekoDeviceType.SALT: AsekoActuatorMasks(
+        filtration=0x08,  # confirmed: April 4, 2026 – set in all active phases (PR #87)
+        ph_minus=0x80,  # unconfirmed – no frame captured with pH- pump running
+        # SALT third-pump slot: one physical pump, configured as algicide OR flocculant.
+        # Both chemicals use the same bit: byte[29] bit 5 (0x20) when running.
+        # Routing: byte[37] & 0x80 set = algicide; clear → flocculant.
+        # Confirmed by @hopkins-tk 2026-04-04: 27 algicide frames (no electrolyser) → 0x28=0x08|0x20 (PR #87).
+        algicide=0x20,  # confirmed: 27 frames, PR #87
+        flocculant=0x20,  # confirmed: Apr 3 frames, same bit as algicide
+        electrolyzer_running=0x10,  # confirmed: 25 frames → 0x18=0x08|0x10 (PR #87)
+        electrolyzer_running_right=0x10,  # confirmed: same dataset
+        electrolyzer_running_left=0x50,  # tentative: Apr 2 single frame 0x58=0x08|0x10|0x40
+    ),
+    AsekoDeviceType.HOME: AsekoActuatorMasks(
+        filtration=0x08,  # uncertain
+        # HOME "chlorine" pump port can be configured as Chlorine OR OXY Pure
+        # (same physical port, same bit in byte[29] – routing by an unknown byte).
+        # TODO: confirm which byte carries the cl/oxy routing and add oxy mask once known.
+        #       Waiting for a frame with OXY pump running from a HOME device.
+        cl=0x40,  # uncertain – assumed same bit for both cl and oxy variants
+        ph_minus=0x80,  # uncertain
+        algicide=0x20,  # uncertain
+        flocculant=0x20,  # uncertain
+        byte37_routes_pump_type=False,  # HOME has independent pump ports (cl/oxy, ph-, alg, floc)
+    ),
+    AsekoDeviceType.PROFI: AsekoActuatorMasks(
+        filtration=0x08,  # uncertain
+        cl=0x40,  # uncertain
+        ph_minus=0x80,  # uncertain
+        flocculant=0x20,  # uncertain
+        byte37_routes_pump_type=False,  # PROFI has 5 independent pump ports (cl, ph-, ph+, alg, floc)
+    ),
+}

--- a/custom_components/aseko_local/aseko_v7_helpers.py
+++ b/custom_components/aseko_local/aseko_v7_helpers.py
@@ -78,6 +78,7 @@ class AsekoByte37Masks:
                   (set: firmware-A encoding; clear: firmware-B encoding).
     Bit 7 (0x80): SALT shared-port routing indicator
                   (see ``AsekoThirdPumpSlot.SALT_ALGICIDE_ROUTING``).
+                  HOME firmware A → antifreeze master enable (Issue #136).
 
     Constants are grouped by device family below.
     """
@@ -97,6 +98,11 @@ class AsekoByte37Masks:
     # Confirmed on serial 110175608 (ASIN AQUA Home REDOX, byte 4 = 0x03):
     #   0x49 → heating ON, 0x41 → heating OFF.
     HOME_FWA_HEATING_ENABLED: int = 0x08
+
+    # Antifreeze master enable (Issue #136).
+    # Confirmed on serial 110175608 (ASIN AQUA Home REDOX, byte 4 = 0x03):
+    #   0x81 → antifreeze ON, 0x41 → antifreeze OFF.
+    HOME_FWA_ANTIFREEZE_ENABLED: int = 0x80
 
     # ── HOME firmware B (high nibble 0x0/0x1/0x3, serial 110169464) ─────
 

--- a/custom_components/aseko_local/binary_sensor.py
+++ b/custom_components/aseko_local/binary_sensor.py
@@ -59,6 +59,12 @@ BINARY_SENSORS: tuple[AsekoLocalBinarySensorEntityDescription, ...] = (
         value_fn=lambda device: device.heating_control_enabled,
     ),
     AsekoLocalBinarySensorEntityDescription(
+        key="antifreeze_enabled",
+        translation_key="antifreeze_enabled",
+        icon="mdi:snowflake-thermometer",
+        value_fn=lambda device: device.antifreeze_enabled,
+    ),
+    AsekoLocalBinarySensorEntityDescription(
         key="cl_pump_running",
         translation_key="cl_pump_running",
         icon="mdi:water-pump",

--- a/custom_components/aseko_local/binary_sensor.py
+++ b/custom_components/aseko_local/binary_sensor.py
@@ -65,6 +65,12 @@ BINARY_SENSORS: tuple[AsekoLocalBinarySensorEntityDescription, ...] = (
         value_fn=lambda device: device.antifreeze_enabled,
     ),
     AsekoLocalBinarySensorEntityDescription(
+        key="vsp_pump_running",
+        translation_key="vsp_pump_running",
+        icon="mdi:pump",
+        value_fn=lambda device: device.vsp_pump_running,
+    ),
+    AsekoLocalBinarySensorEntityDescription(
         key="cl_pump_running",
         translation_key="cl_pump_running",
         icon="mdi:water-pump",

--- a/custom_components/aseko_local/binary_sensor.py
+++ b/custom_components/aseko_local/binary_sensor.py
@@ -53,6 +53,12 @@ BINARY_SENSORS: tuple[AsekoLocalBinarySensorEntityDescription, ...] = (
         value_fn=lambda device: device.heating_active,
     ),
     AsekoLocalBinarySensorEntityDescription(
+        key="heating_control_enabled",
+        translation_key="heating_control_enabled",
+        icon="mdi:radiator-off",
+        value_fn=lambda device: device.heating_control_enabled,
+    ),
+    AsekoLocalBinarySensorEntityDescription(
         key="cl_pump_running",
         translation_key="cl_pump_running",
         icon="mdi:water-pump",

--- a/custom_components/aseko_local/diagnostics.py
+++ b/custom_components/aseko_local/diagnostics.py
@@ -40,7 +40,7 @@ _BYTE_LABELS: dict[int, str] = {
     10: "minute",
     11: "second",
     12: "dosing_warning bitmask (0x20=Cl/disinfectant, 0x40=pH) ← HOME",
-    13: "alarm bitmask (0x01=pH doses, 0x02=Cl/ORP doses, 0x04=no flow, 0x08=rapid pH)",
+    13: "alarm bitmask (0x01=Cl/ORP doses, 0x02=pH doses, 0x04=no flow, 0x08=rapid pH)",
     14: "ph_value[hi]",
     15: "ph_value[lo]  (÷100 = pH)",
     16: "clf_or_redox[hi]",

--- a/custom_components/aseko_local/manifest.json
+++ b/custom_components/aseko_local/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/hopkins-tk/home-assistant-aseko-local/issues",
   "requirements": [],
-  "version": "v1.7.2"
+  "version": "v1.7.3"
 }

--- a/custom_components/aseko_local/sensor.py
+++ b/custom_components/aseko_local/sensor.py
@@ -523,7 +523,7 @@ SENSORS: list[AsekoSensorEntityDescription] = [
             "nonstop_24h",
             "timer_period_1",
             "timer_period_1_and_2",
-            "off_manual",
+            "manual",
         ],
         value_fn=lambda device: (
             device.filtration_mode.value if device.filtration_mode is not None else None

--- a/custom_components/aseko_local/sensor.py
+++ b/custom_components/aseko_local/sensor.py
@@ -261,6 +261,14 @@ SENSORS: list[AsekoSensorEntityDescription] = [
         value_fn=lambda device: device.required_ph,
     ),
     AsekoSensorEntityDescription(
+        key="ph_minus_concentration",
+        translation_key="ph_minus_concentration",
+        native_unit_of_measurement="%",
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:pool",
+        value_fn=lambda device: device.ph_minus_concentration,
+    ),
+    AsekoSensorEntityDescription(
         key="rx",
         translation_key="redox",
         native_unit_of_measurement=UnitOfElectricPotential.MILLIVOLT,

--- a/custom_components/aseko_local/sensor.py
+++ b/custom_components/aseko_local/sensor.py
@@ -241,8 +241,6 @@ SENSORS: list[AsekoSensorEntityDescription] = [
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:pool",
         value_fn=lambda device: device.cl_free_mv,
-        entity_registry_enabled_default=False,
-        entity_registry_visible_default=False,
     ),
     AsekoSensorEntityDescription(
         key="ph",
@@ -324,7 +322,6 @@ SENSORS: list[AsekoSensorEntityDescription] = [
         native_unit_of_measurement=UnitOfLength.CENTIMETERS,
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:waves-arrow-down",
-        entity_registry_enabled_default=False,
         value_fn=lambda device: device.water_level_low_alarm,
     ),
     AsekoSensorEntityDescription(
@@ -333,7 +330,6 @@ SENSORS: list[AsekoSensorEntityDescription] = [
         native_unit_of_measurement=UnitOfLength.CENTIMETERS,
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:waves-arrow-up",
-        entity_registry_enabled_default=False,
         value_fn=lambda device: device.water_level_filling_on,
     ),
     AsekoSensorEntityDescription(
@@ -342,7 +338,6 @@ SENSORS: list[AsekoSensorEntityDescription] = [
         native_unit_of_measurement=UnitOfLength.CENTIMETERS,
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:waves-arrow-up",
-        entity_registry_enabled_default=False,
         value_fn=lambda device: device.water_level_filling_off,
     ),
     AsekoSensorEntityDescription(
@@ -351,7 +346,6 @@ SENSORS: list[AsekoSensorEntityDescription] = [
         native_unit_of_measurement=UnitOfLength.CENTIMETERS,
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:waves-arrow-up",
-        entity_registry_enabled_default=False,
         value_fn=lambda device: device.water_level_high_alarm,
     ),
     AsekoSensorEntityDescription(
@@ -360,7 +354,6 @@ SENSORS: list[AsekoSensorEntityDescription] = [
         native_unit_of_measurement=UnitOfTime.MINUTES,
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:timer",
-        entity_registry_enabled_default=False,
         value_fn=lambda device: device.max_filling_time,
     ),
     AsekoSensorEntityDescription(
@@ -569,14 +562,12 @@ SENSORS: list[AsekoSensorEntityDescription] = [
         translation_key="backwash_every_n_days",
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:calendar-refresh",
-        entity_registry_enabled_default=False,
         value_fn=lambda device: device.backwash_every_n_days,
     ),
     AsekoSensorEntityDescription(
         key="backwash_time",
         translation_key="backwash_time",
         icon="mdi:clock-start",
-        entity_registry_enabled_default=False,
         value_fn=lambda device: (
             device.backwash_time.strftime("%H:%M")
             if device.backwash_time is not None
@@ -589,7 +580,6 @@ SENSORS: list[AsekoSensorEntityDescription] = [
         native_unit_of_measurement=UnitOfTime.SECONDS,
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:timer-sand",
-        entity_registry_enabled_default=False,
         value_fn=lambda device: device.backwash_duration,
     ),
     AsekoSensorEntityDescription(
@@ -597,7 +587,6 @@ SENSORS: list[AsekoSensorEntityDescription] = [
         translation_key="last_backwash",
         device_class=SensorDeviceClass.TIMESTAMP,
         icon="mdi:clock-check-outline",
-        entity_registry_enabled_default=False,
         value_fn=lambda device: device.last_backwash,
     ),
     AsekoSensorEntityDescription(
@@ -605,7 +594,6 @@ SENSORS: list[AsekoSensorEntityDescription] = [
         translation_key="next_backwash",
         device_class=SensorDeviceClass.TIMESTAMP,
         icon="mdi:clock-alert-outline",
-        entity_registry_enabled_default=False,
         value_fn=lambda device: device.next_backwash,
     ),
 ]

--- a/custom_components/aseko_local/sensor.py
+++ b/custom_components/aseko_local/sensor.py
@@ -514,6 +514,21 @@ SENSORS: list[AsekoSensorEntityDescription] = [
         ),
     ),
     AsekoSensorEntityDescription(
+        key="filtration_mode",
+        translation_key="filtration_mode",
+        icon="mdi:pump",
+        device_class=SensorDeviceClass.ENUM,
+        options=[
+            "nonstop_24h",
+            "timer_period_1",
+            "timer_period_1_and_2",
+            "off_manual",
+        ],
+        value_fn=lambda device: (
+            device.filtration_mode.value if device.filtration_mode is not None else None
+        ),
+    ),
+    AsekoSensorEntityDescription(
         key="pool_volume",
         translation_key="pool_volume",
         native_unit_of_measurement=UnitOfVolume.CUBIC_METERS,

--- a/custom_components/aseko_local/translations/cs.json
+++ b/custom_components/aseko_local/translations/cs.json
@@ -108,7 +108,7 @@
           "nonstop_24h": "Nonstop 24 h",
           "timer_period_1": "Časové období 1",
           "timer_period_1_and_2": "Časová období 1 a 2",
-          "off_manual": "Vypnuto (ručně)"
+          "manual": "Ruční režim"
         }
       },
       "pool_volume": { "name": "Objem bazénu" },

--- a/custom_components/aseko_local/translations/cs.json
+++ b/custom_components/aseko_local/translations/cs.json
@@ -93,6 +93,15 @@
       "filtration_1_stop": { "name": "Filtrace 1 konec" },
       "filtration_2_start": { "name": "Filtrace 2 začátek" },
       "filtration_2_stop": { "name": "Filtrace 2 konec" },
+      "filtration_mode": {
+        "name": "Režim filtrace",
+        "state": {
+          "nonstop_24h": "Nonstop 24 h",
+          "timer_period_1": "Časové období 1",
+          "timer_period_1_and_2": "Časová období 1 a 2",
+          "off_manual": "Vypnuto (ručně)"
+        }
+      },
       "pool_volume": { "name": "Objem bazénu" },
       "delay_after_startup": { "name": "Prodleva po startu" },
       "delay_after_dose": { "name": "Prodleva po dávce" },

--- a/custom_components/aseko_local/translations/cs.json
+++ b/custom_components/aseko_local/translations/cs.json
@@ -51,6 +51,9 @@
       "antifreeze_enabled": {
         "name": "Ochrana proti zamrznutí"
       },
+      "vsp_pump_running": {
+        "name": "Čerpadlo s proměnnými otáčkami"
+      },
       "cl_pump_running": {
         "name": "Čerpadlo chloru běží"
       },

--- a/custom_components/aseko_local/translations/cs.json
+++ b/custom_components/aseko_local/translations/cs.json
@@ -45,6 +45,9 @@
       "heating_active": {
         "name": "Topení aktivní"
       },
+      "heating_control_enabled": {
+        "name": "Ovládání topení"
+      },
       "cl_pump_running": {
         "name": "Čerpadlo chloru běží"
       },

--- a/custom_components/aseko_local/translations/cs.json
+++ b/custom_components/aseko_local/translations/cs.json
@@ -114,6 +114,9 @@
       "pool_volume": { "name": "Objem bazénu" },
       "delay_after_startup": { "name": "Prodleva po startu" },
       "delay_after_dose": { "name": "Prodleva po dávce" },
+      "ph_minus_concentration": {
+        "name": "Koncentrace pH-"
+      },
       "air_temperature": {
         "name": "Teplota vzduchu"
       },

--- a/custom_components/aseko_local/translations/cs.json
+++ b/custom_components/aseko_local/translations/cs.json
@@ -48,6 +48,9 @@
       "heating_control_enabled": {
         "name": "Ovládání topení"
       },
+      "antifreeze_enabled": {
+        "name": "Ochrana proti zamrznutí"
+      },
       "cl_pump_running": {
         "name": "Čerpadlo chloru běží"
       },

--- a/custom_components/aseko_local/translations/de.json
+++ b/custom_components/aseko_local/translations/de.json
@@ -48,6 +48,9 @@
       "heating_control_enabled": {
         "name": "Heizungssteuerung"
       },
+      "antifreeze_enabled": {
+        "name": "Frostschutz"
+      },
       "cl_pump_running": {
         "name": "Chlorpumpe läuft"
       },

--- a/custom_components/aseko_local/translations/de.json
+++ b/custom_components/aseko_local/translations/de.json
@@ -128,6 +128,9 @@
       "delay_after_dose": {
         "name": "Verzögerung nach Dosierung"
       },
+      "ph_minus_concentration": {
+        "name": "pH- Konzentration"
+      },
       "air_temperature": {
         "name": "Lufttemperatur"
       },

--- a/custom_components/aseko_local/translations/de.json
+++ b/custom_components/aseko_local/translations/de.json
@@ -101,6 +101,15 @@
       "filtration_2_stop": {
         "name": "Filtration 2 Stopp"
       },
+      "filtration_mode": {
+        "name": "Filtriermodus",
+        "state": {
+          "nonstop_24h": "24 h durchgehend",
+          "timer_period_1": "Zeitperiode 1",
+          "timer_period_1_and_2": "Zeitperioden 1 & 2",
+          "off_manual": "Aus (manuell)"
+        }
+      },
       "pool_volume": {
         "name": "Poolvolumen"
       },

--- a/custom_components/aseko_local/translations/de.json
+++ b/custom_components/aseko_local/translations/de.json
@@ -116,7 +116,7 @@
           "nonstop_24h": "24 h durchgehend",
           "timer_period_1": "Zeitperiode 1",
           "timer_period_1_and_2": "Zeitperioden 1 & 2",
-          "off_manual": "Aus (manuell)"
+          "manual": "Manueller Betriebsmodus"
         }
       },
       "pool_volume": {

--- a/custom_components/aseko_local/translations/de.json
+++ b/custom_components/aseko_local/translations/de.json
@@ -51,6 +51,9 @@
       "antifreeze_enabled": {
         "name": "Frostschutz"
       },
+      "vsp_pump_running": {
+        "name": "Drehzahlregelpumpe"
+      },
       "cl_pump_running": {
         "name": "Chlorpumpe läuft"
       },

--- a/custom_components/aseko_local/translations/de.json
+++ b/custom_components/aseko_local/translations/de.json
@@ -45,6 +45,9 @@
       "heating_active": {
         "name": "Heizung aktiv"
       },
+      "heating_control_enabled": {
+        "name": "Heizungssteuerung"
+      },
       "cl_pump_running": {
         "name": "Chlorpumpe läuft"
       },

--- a/custom_components/aseko_local/translations/en.json
+++ b/custom_components/aseko_local/translations/en.json
@@ -93,6 +93,15 @@
       "filtration_1_stop": { "name": "Filtration 1 stop" },
       "filtration_2_start": { "name": "Filtration 2 start" },
       "filtration_2_stop": { "name": "Filtration 2 stop" },
+      "filtration_mode": {
+        "name": "Filtration mode",
+        "state": {
+          "nonstop_24h": "24h nonstop",
+          "timer_period_1": "Time period 1",
+          "timer_period_1_and_2": "Time periods 1 & 2",
+          "off_manual": "Off (manual)"
+        }
+      },
       "pool_volume": { "name": "Pool volume" },
       "delay_after_startup": { "name": "Delay after startup" },
       "delay_after_dose": { "name": "Delay after dose" },

--- a/custom_components/aseko_local/translations/en.json
+++ b/custom_components/aseko_local/translations/en.json
@@ -51,6 +51,9 @@
       "antifreeze_enabled": {
         "name": "Antifreeze"
       },
+      "vsp_pump_running": {
+        "name": "Variable speed pump"
+      },
       "cl_pump_running": {
         "name": "Chlorine pump running"
       },

--- a/custom_components/aseko_local/translations/en.json
+++ b/custom_components/aseko_local/translations/en.json
@@ -45,6 +45,9 @@
       "heating_active": {
         "name": "Heating active"
       },
+      "heating_control_enabled": {
+        "name": "Heating control"
+      },
       "cl_pump_running": {
         "name": "Chlorine pump running"
       },

--- a/custom_components/aseko_local/translations/en.json
+++ b/custom_components/aseko_local/translations/en.json
@@ -114,6 +114,9 @@
       "pool_volume": { "name": "Pool volume" },
       "delay_after_startup": { "name": "Delay after startup" },
       "delay_after_dose": { "name": "Delay after dose" },
+      "ph_minus_concentration": {
+        "name": "pH- concentration"
+      },
       "air_temperature": {
         "name": "Air temperature"
       },

--- a/custom_components/aseko_local/translations/en.json
+++ b/custom_components/aseko_local/translations/en.json
@@ -48,6 +48,9 @@
       "heating_control_enabled": {
         "name": "Heating control"
       },
+      "antifreeze_enabled": {
+        "name": "Antifreeze"
+      },
       "cl_pump_running": {
         "name": "Chlorine pump running"
       },

--- a/custom_components/aseko_local/translations/en.json
+++ b/custom_components/aseko_local/translations/en.json
@@ -108,7 +108,7 @@
           "nonstop_24h": "24h nonstop",
           "timer_period_1": "Time period 1",
           "timer_period_1_and_2": "Time periods 1 & 2",
-          "off_manual": "Off (manual)"
+          "manual": "Manual operation mode"
         }
       },
       "pool_volume": { "name": "Pool volume" },

--- a/custom_components/aseko_local/translations/fr.json
+++ b/custom_components/aseko_local/translations/fr.json
@@ -116,7 +116,7 @@
                   "nonstop_24h": "24 h en continu",
                   "timer_period_1": "Plage horaire 1",
                   "timer_period_1_and_2": "Plages horaires 1 et 2",
-                  "off_manual": "Arrêt (manuel)"
+                  "manual": "Mode manuel"
                 }
             },
             "pool_volume": {

--- a/custom_components/aseko_local/translations/fr.json
+++ b/custom_components/aseko_local/translations/fr.json
@@ -45,6 +45,9 @@
             "heating_active": {
                 "name": "Chauffage actif"
             },
+            "heating_control_enabled": {
+                "name": "Contrôle du chauffage"
+            },
             "cl_pump_running": {
                 "name": "Pompe à chlore en marche"
             },

--- a/custom_components/aseko_local/translations/fr.json
+++ b/custom_components/aseko_local/translations/fr.json
@@ -101,6 +101,15 @@
             "filtration_2_stop": {
                 "name": "Fin filtration 2"
             },
+            "filtration_mode": {
+                "name": "Mode de filtration",
+                "state": {
+                  "nonstop_24h": "24 h en continu",
+                  "timer_period_1": "Plage horaire 1",
+                  "timer_period_1_and_2": "Plages horaires 1 et 2",
+                  "off_manual": "Arrêt (manuel)"
+                }
+            },
             "pool_volume": {
                 "name": "Volume du bassin"
             },

--- a/custom_components/aseko_local/translations/fr.json
+++ b/custom_components/aseko_local/translations/fr.json
@@ -128,6 +128,9 @@
             "delay_after_dose": {
                 "name": "Délai après dosage"
             },
+            "ph_minus_concentration": {
+                "name": "Concentration pH-"
+            },
             "air_temperature": {
                 "name": "Température de l'air"
             },

--- a/custom_components/aseko_local/translations/fr.json
+++ b/custom_components/aseko_local/translations/fr.json
@@ -48,6 +48,9 @@
             "heating_control_enabled": {
                 "name": "Contrôle du chauffage"
             },
+            "antifreeze_enabled": {
+                "name": "Antigel"
+            },
             "cl_pump_running": {
                 "name": "Pompe à chlore en marche"
             },

--- a/custom_components/aseko_local/translations/fr.json
+++ b/custom_components/aseko_local/translations/fr.json
@@ -51,6 +51,9 @@
             "antifreeze_enabled": {
                 "name": "Antigel"
             },
+            "vsp_pump_running": {
+                "name": "Pompe à vitesse variable"
+            },
             "cl_pump_running": {
                 "name": "Pompe à chlore en marche"
             },

--- a/docs/device analyzes/home_device_analysis.md
+++ b/docs/device analyzes/home_device_analysis.md
@@ -25,7 +25,8 @@ position. The two revisions are referred to throughout this document as
 | Source | This file (Issue #110, #135) | [Issue #133](../temp/Issue-133.md) |
 | Period 2 enable flag | bit 5 (`0x20`) — same as firmware B | bit 5 (`0x20`) |
 | Manual OFF signal | not present in captured frames | bit 2 (`0x04`) — see `byte[37]` table |
-| Heating control flag | bit 3 (`0x08`) — mastered enabled | (n/o) |
+| Heating control flag | bit 3 (`0x08`) — master enable | (n/o) |
+| Antifreeze flag | bit 7 (`0x80`) — master enable (Issue #136) | (n/o) |
 
 \* Serial 110175608 (`byte[4]` = `0x03`, REDOX HOME) is the source of the heating-control findings ([Issue #135](https://github.com/hopkins-tk/home-assistant-aseko-local/issues/135)).
 
@@ -194,6 +195,7 @@ Note on **bytes 94–95**: `max_filling_time` reads bytes[94:96] as a big-endian
 | flowrate_floc             | 10               | Floc+c listed     | ✓     |
 | flowrate_algicide         | 33               | Algicide listed   | ✓ (fixed) |
 | heating_control_enabled   | True / False     | — (app setting)   | ✓ (Issue #135, serial 110175608 REDOX HOME) |
+| antifreeze_enabled        | True / False     | — (app setting)   | ✓ (Issue #136, serial 110175608 REDOX HOME) |
 
 ---
 
@@ -257,12 +259,18 @@ firmware B: serial 110169464, byte 4 = 0x03 — see [Issue #133](../temp/Issue-1
 | Heating ON (nonstop)†         | `0x49`     | (n/o)      | `0100_1001` / —              |
 | Heating OFF (nonstop)†        | `0x41`     | (n/o)      | `0100_0001` / —              |
 | Heating OFF (initial/unconf.)† | `0x45`    | (n/o)      | `0100_0101` / —              |
+| Antifreeze ON (nonstop)†‡     | `0x81`     | (n/o)      | `1000_0001` / —              |
 
 † Bit 1 is clear (`0x02`) in all three heating-health values. When `byte[37]` & `0x40` is set
   but bit-1 is clear, the decoder falls back to schedule-derived filtration mode (see
   `_fill_filtration_mode` in `aseko_decoder.py`). The actual filtration mode is
   determined from the schedule bytes and the `PERIOD2_ENABLED_MASK` (`0x20`).
   `heating_control_enabled` is decoded separately from bit 3 (`0x08`).
+
+‡ When antifreeze is ON, `byte[55]` drops from the normal heating setpoint
+  (25°C in dtpugh's case) to the antifreeze minimum temperature (4°C).
+  `antifreeze_enabled` is decoded from bit 7 (`0x80`), independent of
+  `heating_control_enabled` (bit 3).
 
 \* Firmware A cannot distinguish P1-only from P1&P2 from `byte[37]` alone — both
 share the value `0x53`. The decoder uses the existing `FILTRATION_PERIOD2_ENABLED_MASK = 0x20`
@@ -285,10 +293,11 @@ Mode decoding on firmware B:
 - **Timer mode** ⇔ `(byte[37] & 0x30) != 0`
 - **Manual override** ⇔ `(byte[37] & 0x04) != 0`
 
-**Firmware A bit semantics** (Issue #135, serial 110175608 REDOX HOME):
+**Firmware A bit semantics** (Issue #135, #136, serial 110175608 REDOX HOME):
 
 | Bit | Mask  | Meaning                                                    |
 |-----|-------|------------------------------------------------------------|
+| 7   | `0x80`| Antifreeze master enable (Issue #136)                      |
 | 6   | `0x40`| Firmware A high-nibble indicator (always set)              |
 | 3   | `0x08`| Heating control master enable                              |
 | 2   | `0x04`| Unknown / initial-unconfigured indicator (set on unconfigured `0x45`) |
@@ -301,6 +310,9 @@ Filtration mode decoding on firmware A:
   falls back to schedule-derived filtration mode for these.
 - **Heating control**: bit 3 (`0x08`) is gated on `AsekoDeviceType.HOME` in
   `_fill_heating_demand()` and decoded into `heating_control_enabled`.
+- **Antifreeze**: bit 7 (`0x80`) is decoded as `antifreeze_enabled` (Issue #136).
+  When active, `byte[55]` holds the antifreeze threshold (4°C) instead of the
+  normal heating setpoint.
 
 **Note on `0x43` (firmware A)**: treat this as "consistent with NONSTOP 24H" rather
 than "confirmed NONSTOP 24H active". A frame captured in May 2026 from
@@ -397,4 +409,6 @@ Tests for the HOME decoder live in `tests/test_aseko_decoder.py`:
 - Issue #135: `byte[37]` bit 3 (`0x08`) = heating control master enable on HOME firmware A
   (serial 110175608, REDOX HOME). Confirms `byte[55]` as target water temp setpoint.
   Working notes: [docs/temp/Issue-135.md](../temp/Issue-135.md).
+- Issue #136: `byte[37]` bit 7 (`0x80`) = antifreeze master enable on HOME firmware A
+  (same device). `byte[55]` shows the antifreeze threshold (4°C) when enabled.
 - Working notes: `docs/temp/Issue-133.md`

--- a/docs/device analyzes/home_device_analysis.md
+++ b/docs/device analyzes/home_device_analysis.md
@@ -225,23 +225,65 @@ As a downstream effect, `_fill_consumable_data` short-circuited `algicide_pump_r
 
 ---
 
-### Issue 4 ✅ Resolved — Filtration nonstop mode flag is byte[37]
+### Issue 4 ✅ Resolved — Filtration nonstop mode flag is byte[37] (firmware A)
 
 **Observation**: Aseko Live Config shows **FILTRATION NONSTOP 24H**. The decoder produces start1=08:00, stop1=16:00, start2=18:00, stop2=22:00 (12 h total — inconsistent with nonstop mode).
 
 **Context**: The frame was captured while the pool had an error (likely too little water). The filtration pump was stopped and byte[29] = 0x00, consistent with an active alarm suppressing normal operation.
 
-**Resolution (Issue #110)**: `byte[37]` encodes the filtration mode flag:
+**Resolution (Issue #110)**: `byte[37]` encodes the filtration mode flag on this firmware revision (firmware A, serial 110128063, byte 4 = 0x02):
 
 | byte[37] | Meaning |
 |---|---|
 | `0x43` | FILTRATION NONSTOP 24H active |
-| `0x53` | Timer mode active |
+| `0x53` | Timer mode active (P1 or P1&P2, indistinguishable) |
 | `0x47` / `0x57` | Transitional / edit state — leave as `None` |
 
 **⚠️ Note on the issue #110 evidence**: The diagnostics frame is from **2026-05-23 17:09** (after mannekung changed the filtration schedule to NONSTOP 24H on **2026-05-09**), but `byte[37]` still reads `0x53` (timer). The screenshot from the same user shows the "Suche" indicator (search mode) in the bottom-right corner, which may explain the mismatch — the device might be reporting a transient or special mode rather than the user-configured setting. **Until a frame is captured with a known NONSTOP 24H state and no special UI mode, treat `0x43` as "consistent with NONSTOP 24H" rather than "confirmed NONSTOP 24H active".**
 
 `filtration_nonstop24` is now decoded for **all device types** (HOME, SALT, OXY, NET). Non-HOME real-world values for byte[37] are never `0x43`/`0x53` (SALT uses it for algicide routing, OXY uses `0x03`, NET always `0xFF`), so `filtration_nonstop24` stays `None` for those devices today.
+
+**⚠️ Note on a second HOME v7 encoding (firmware B)**: [Issue #133](https://github.com/hopkins-tk/home-assistant-aseko-local/issues/133) (serial 110169464, byte 4 = 0x03) reports that a *different* HOME v7 firmware uses completely different byte 37 values. See Issue 6 below for the full encoding table and the implications for the `filtration_nonstop24` sensor.
+
+---
+
+### Issue 6 ✅ Resolved — Two HOME v7 firmware revisions use different byte 37 encodings
+
+**Observation**: [@dtpugh's report](https://github.com/hopkins-tk/home-assistant-aseko-local/issues/133) on a HOME REDOX (serial 110169464, byte 4 = 0x03) shows that the existing `_fill_filtration_mode` decoder cannot read byte 37 at all: every observed value falls through to `None`, so neither `filtration_nonstop24` nor any other filtration-mode entity appears. Cross-frame analysis of four captured frames (24h nonstop, P1 only, P1 & P2, OFF manual) shows that the new firmware uses a fundamentally different bit layout.
+
+**Comparison of HOME v7 byte 37 encodings**:
+
+| Mode              | Firmware A (this file) | Firmware B (Issue #133) |
+|-------------------|------------------------|-------------------------|
+| 24h nonstop       | `0x43` (`0b0100_0011`) | `0x01` (`0b0000_0001`) |
+| Timer (P1)        | `0x53` (`0b0101_0011`) | `0x11` (`0b0001_0001`) |
+| Timer (P1 & P2)   | `0x53` (indistinguishable) | `0x31` (`0b0011_0001`) |
+| OFF (manual)      | (not observed)         | `0x35` (`0b0011_0101`) |
+| Transitional      | `0x47` / `0x57`        | (not observed)          |
+
+The two encodings are **disjoint by high nibble** (firmware A: 0x4/0x5; firmware B: 0x0/0x1/0x3) and therefore distinguishable on a single byte, without resorting to the serial number.
+
+**Firmware B bit semantics** (consistent with the existing `FILTRATION_PERIOD2_ENABLED_MASK = 0x20`):
+
+| Bit  | Mask  | Meaning |
+|------|-------|---------|
+| 0    | 0x01  | Filtration present (always set when a filter is configured) |
+| 2    | 0x04  | Manual override active |
+| 4    | 0x10  | Period 1 enabled |
+| 5    | 0x20  | Period 2 enabled |
+
+Mode decoding:
+- **24h nonstop** ⇔ `(byte[37] & 0x30) == 0`
+- **Timer mode** ⇔ `(byte[37] & 0x30) != 0`
+- **Manual override** ⇔ `(byte[37] & 0x04) != 0`
+
+**Cross-validation against other device types**: the firmware B high-nibble range overlaps with values that SALT and OXY use for different purposes (SALT `0x37`/`0x13` for algicide routing, OXY `0x03` for pump presence). The new encoding is therefore **gated on `device_type == HOME`** in the decoder. SALT / OXY / NET / PROFI continue to leave `filtration_mode` as `None`.
+
+**Resolution**: replace the existing `_fill_filtration_mode` with a 6-line `if/elif` chain that handles both encodings on HOME only, and introduce a 4-state `AsekoFiltrationMode` enum (`NONSTOP_24H`, `TIMER_PERIOD_1`, `TIMER_PERIOD_1_AND_2`, `OFF_MANUAL`). A new `filtration_mode` sensor (device_class = `ENUM`, options = the 4 states) surfaces the full state to Home Assistant. The legacy `filtration_nonstop24` binary sensor is kept for backwards compatibility but its default visibility is flipped to `False` on HOME.
+
+**Behavioural fix for `filtration_pump_running`**: byte 29 bit 3 is set in **all four** firmware B frames — including the OFF frame — but the new `OFF_MANUAL` state carries the explicit user intent. In `_fill_consumable_data`, the decoder now short-circuits `filtration_pump_running` to `False` when `filtration_mode == OFF_MANUAL` (gated on HOME, so SALT/OXY/NET behaviour is unchanged). This addresses the user's secondary complaint that the pump state entity stays ON when the user has manually switched the pump off. The remaining open question is whether SALT devices have an analogous manual-override mechanism — no SALT OFF frame has been captured yet, so the short-circuit is intentionally HOME-only.
+
+**Full working notes**: see [docs/temp/Issue-133.md](../temp/Issue-133.md) for the complete frame diff (only 19 of 120 bytes change between the four modes), the cross-validation table, and the test plan.
 
 ---
 
@@ -300,11 +342,13 @@ if unit.device_type == AsekoDeviceType.HOME:
 | # | Status | Description |
 |---|--------|-------------|
 | 3 | Pending | `required_water_temperature` vs app "---" — need normal-operation frame (heating is disabled on this device; only a frame from a pool with heating enabled can confirm byte[55]) |
-| 4 | ✅ Resolved | Filtration NONSTOP 24H flag byte — confirmed as `byte[37] == 0x43` (Issue #110) |
+| 4 | ✅ Resolved | Filtration NONSTOP 24H flag byte — confirmed as `byte[37] == 0x43` (Issue #110, **firmware A**) |
 | 5 | ✅ Resolved | `flowrate_algicide` byte position — confirmed as `byte[103]` on HOME (Issue #115) |
-| 6 | New | `byte[29]` bit masks for HOME pumps remain **unconfirmed** — see §"Actuator byte[29] — HOME masks (uncertain)" above. The masks in `ACTUATOR_MASKS[HOME]` are placeholders matching OXY/NET. Capturing frames with a single HOME pump running (e.g. algicide only) would pin down the per-pump bit. Until then, both `algicide_pump_running` and `floc_pump_running` may report incorrectly on HOME when the corresponding pump is active. |
-| 7 | New | `max_filling_time` overlap with `flowrate_ph_minus` (both use byte[95]) — see note in Segment 3 below. If byte[94] ever becomes non-zero, `max_filling_time` is inflated. Only a frame with a non-zero byte[94] would prove or disprove the assumption. |
-| 8 | New | `heating_active` binary sensor (byte[29] bit 0x04) — added for [Issue #115](https://github.com/hopkins-tk/home-assistant-aseko-local/issues/115) "Entities for heating are not there" request. Mapping is the same as JS-DE-Tech's `relay_byte` bit 2. **Live confirmation pending** — needs a frame captured while the heat pump / electric heater is actually running. Currently it cannot be distinguished from the unconfirmed HOME pump-bit masks. |
+| 6 | ✅ Resolved | **Second HOME v7 byte 37 encoding (firmware B)** — see Issue 6 above. New `AsekoFiltrationMode` enum + `filtration_mode` enum sensor + manual-OFF short-circuit for `filtration_pump_running` (Issue #133). |
+| 7 | New | `byte[29]` bit masks for HOME pumps remain **unconfirmed** — see §"Actuator byte[29] — HOME masks (uncertain)" above. The masks in `ACTUATOR_MASKS[HOME]` are placeholders matching OXY/NET. Capturing frames with a single HOME pump running (e.g. algicide only) would pin down the per-pump bit. Until then, both `algicide_pump_running` and `floc_pump_running` may report incorrectly on HOME when the corresponding pump is active. |
+| 8 | New | `max_filling_time` overlap with `flowrate_ph_minus` (both use byte[95]) — see note in Segment 3 below. If byte[94] ever becomes non-zero, `max_filling_time` is inflated. Only a frame with a non-zero byte[94] would prove or disprove the assumption. |
+| 9 | New | `heating_active` binary sensor (byte[29] bit 0x04) — added for [Issue #115](https://github.com/hopkins-tk/home-assistant-aseko-local/issues/115) "Entities for heating are not there" request. Mapping is the same as JS-DE-Tech's `relay_byte` bit 2. **Live confirmation pending** — needs a frame captured while the heat pump / electric heater is actually running. Currently it cannot be distinguished from the unconfirmed HOME pump-bit masks. |
+| 10 | New | Bytes 31, 38, 65 in the firmware B OFF frame all rise by ~1 (0x00→0x02, 0x02→0x03, 0xa3→0xa4) — possible additional "manual override active" sub-flags, not used by the decoder today. Single observation, no meaning assigned. |
 
 ---
 

--- a/docs/device analyzes/home_device_analysis.md
+++ b/docs/device analyzes/home_device_analysis.md
@@ -242,8 +242,8 @@ routing via `byte[37]` bit 7.
 |---------|-----------|--------------|-------|
 | `start1` | `byte[56:58]` | HH:MM     | Gated on `FILTRATION_TYPES` (HOME in) |
 | `stop1`  | `byte[58:60]` | HH:MM     | Gated on `FILTRATION_TYPES` |
-| `start2` | `byte[60:62]` | HH:MM     | Gated on `FILTRATION_TYPES` AND `filtration2_enabled` |
-| `stop2`  | `byte[62:64]` | HH:MM     | Gated on `FILTRATION_TYPES` AND `filtration2_enabled` |
+| `start2` | `byte[60:62]` | HH:MM     | Gated on `FILTRATION_TYPES` only — see Issue #133 |
+| `stop2`  | `byte[62:64]` | HH:MM     | Gated on `FILTRATION_TYPES` only — see Issue #133 |
 
 ### `byte[37]` — Filtration mode flag + heating control (two encodings observed)
 
@@ -334,6 +334,40 @@ by short-circuiting `filtration_pump_running` to `False` whenever
 `filtration_mode == OFF_MANUAL`. This is a HOME-only behaviour; no SALT/OXY/PROFI
 OFF frame has been captured yet.
 
+**Note on Period 2 schedule bytes (Issue #133)**: All Aseko devices in
+`FILTRATION_TYPES` (SALT, HOME, OXY, PROFI) keep sending the last-configured
+`start2`/`stop2` times in bytes 60-63 even after the user disables Period 2
+in the controller UI. The controller never clears these bytes — they are
+treated as the device's "last-known schedule" and the active/inactive
+state is carried separately in `byte[37]` bit 5 (`0x20`) for HOME firmware
+A/B and SALT/OXY, or in the schedule-byte presence for byte[37] = 0xFF.
+Pre-fix, the decoder used `byte[37]` bit 0x20 to gate `start2`/`stop2` on
+None for any device where the enable flag was clear, which caused
+already-registered entities to flip to "unknown" when the user toggled
+the controller back from "P1 & P2" to "P1 only" (the entity registry
+protects the entity, but the value is read as `None`).  Post-fix, bytes
+60-63 are read unconditionally for any device in `FILTRATION_TYPES` (so
+`start2`/`stop2` stay populated and the entity shows the last-configured
+time); the `filtration_mode` sensor separately reports `TIMER_PERIOD_1`
+to tell the user that Period 2 is inactive.  This behaviour was
+verified against the four diagnostic files from
+[Issue #133](../temp/Issue-133.md) (serial 110169464, ASIN AQUA Home
+firmware B): bytes 60-63 stay populated in all four modes (24h nonstop,
+P1 only, P1 & P2, OFF manual).  The decoder applies the same logic to
+SALT/OXY/PROFI for two reasons:
+
+1.  SALT and OXY share the same protocol layout for bytes 60-63, and
+    `byte[37]` bit 0x20 is the documented enable flag on those devices.
+    There is no protocol-level reason to believe they clear the bytes
+    when Period 2 is disabled.
+2.  PROFI has the same byte layout but no live frame has been captured
+    that toggles Period 2 on/off; the same fix prevents a potential
+    regression if a user reports the same "unknown entity" symptom on
+    PROFI later.
+
+NET is excluded because it has no filtration output at all and is
+not in `FILTRATION_TYPES`.
+
 ### `byte[29]` — Actuator bitmask (HOME)
 
 Bit positions in `byte[29]` for HOME pump states. The masks in
@@ -423,6 +457,10 @@ Tests for the HOME decoder live in `tests/test_aseko_decoder.py`:
 | `test_filtration_pump_running_off_when_manual_override` | Issue #133: `byte[37]=0x35` forces `filtration_pump_running=False` |
 | `test_filtration_pump_running_on_when_not_override` | Regression guard: `byte[29]&0x08` still drives the entity outside OFF_MANUAL |
 | `test_filtration_pump_running_not_overridden_on_salt` | Override short-circuit is HOME-only |
+| `test_decode_filtration_period2_disabled` | Issue #133: bytes 60-63 stay populated; mode flips to `TIMER_PERIOD_1` |
+| `test_decode_filtration_period2_bytes_unspecified` | Issue #133: bytes 60-63 = 0xFF → `start2`/`stop2` = `None` (entity skipped) |
+| `test_decode_filtration_period2_none_for_net` | Issue #133: NET never gets filtration entities (lazy-creation guard) |
+| `test_decode_filtration_period2_real_dtpugh_frames` | Issue #133: end-to-end against @dtpugh's four diagnostic files (P1 only / P1&P2 / 24h / OFF) |
 | `test_decode_home_heating_control_enabled` | Issue #135: `byte[37]=0x49` → `heating_control_enabled=True` with schedule-derived filtration mode |
 | `test_decode_home_heating_control_disabled` | Issue #135: `byte[37]=0x41` → `heating_control_enabled=False` |
 | `test_decode_home_heating_control_unconfigured` | Issue #135: `byte[37]=0x45` → `heating_control_enabled=False` (initial state) |
@@ -439,7 +477,7 @@ Tests for the HOME decoder live in `tests/test_aseko_decoder.py`:
 - NET v8 analysis: `docs/device analyzes/net_v8_device_analysis.md`
 - Issue #110: byte[37] firmware A (`0x43` = nonstop 24h) — original finding, frames in this file
 - Issue #115: HOME `algicide_pump_running` missing — fixed by independent-pump-port branch
-- Issue #133: byte[37] firmware B (4-state mode + manual OFF) — fixed by `_fill_filtration_mode` rewrite
+- Issue #133: byte[37] firmware B (4-state mode + manual OFF) — fixed by `_fill_filtration_mode` rewrite.  Period 2 schedule bytes (60-63) are now read unconditionally for any device in `FILTRATION_TYPES` to avoid "unknown" entities when the user toggles the controller.  See the *Note on Period 2 schedule bytes (Issue #133)* under `byte[29]` vs `filtration_mode` below.
 - Issue #135: `byte[37]` bit 3 (`0x08`) = heating control master enable on HOME firmware A
   (serial 110175608, REDOX HOME). Confirms `byte[55]` as target water temp setpoint.
   Working notes: [docs/temp/Issue-135.md](../temp/Issue-135.md).

--- a/docs/device analyzes/home_device_analysis.md
+++ b/docs/device analyzes/home_device_analysis.md
@@ -18,11 +18,16 @@ position. The two revisions are referred to throughout this document as
 | | Firmware A | Firmware B |
 |---|---|---|
 | Serial (known) | 110128063 (`0x06906bbf`) | 110169464 (`0x06912578`) |
+| | 110175608* (`0x06912578`, REDOX) | |
 | `byte[37]` mode values | high nibble `0x4` / `0x5` | high nibble `0x0` / `0x1` / `0x3` |
-| Known states | nonstop 24h, timer, transitional | nonstop 24h, P1, P1&P2, OFF manual, transitional |
-| Source | This file (Issue #110) | [Issue #133](../temp/Issue-133.md) |
+| Known states | nonstop 24h, timer, transitional, | nonstop 24h, P1, P1&P2, OFF manual, transitional |
+| | heating ON, heating OFF, unconfigured | |
+| Source | This file (Issue #110, #135) | [Issue #133](../temp/Issue-133.md) |
 | Period 2 enable flag | bit 5 (`0x20`) — same as firmware B | bit 5 (`0x20`) |
 | Manual OFF signal | not present in captured frames | bit 2 (`0x04`) — see `byte[37]` table |
+| Heating control flag | bit 3 (`0x08`) — mastered enabled | (n/o) |
+
+\* Serial 110175608 (`byte[4]` = `0x03`, REDOX HOME) is the source of the heating-control findings ([Issue #135](https://github.com/hopkins-tk/home-assistant-aseko-local/issues/135)).
 
 The two revisions are **disjoint by high nibble of byte 37**, so a single
 byte check distinguishes them without resorting to the serial number.
@@ -188,6 +193,7 @@ Note on **bytes 94–95**: `max_filling_time` reads bytes[94:96] as a big-endian
 | flowrate_chlor            | 60               | Chlor Pure listed | ✓     |
 | flowrate_floc             | 10               | Floc+c listed     | ✓     |
 | flowrate_algicide         | 33               | Algicide listed   | ✓ (fixed) |
+| heating_control_enabled   | True / False     | — (app setting)   | ✓ (Issue #135, serial 110175608 REDOX HOME) |
 
 ---
 
@@ -230,7 +236,7 @@ routing via `byte[37]` bit 7.
 | `start2` | `byte[60:62]` | HH:MM     | Gated on `FILTRATION_TYPES` AND `filtration2_enabled` |
 | `stop2`  | `byte[62:64]` | HH:MM     | Gated on `FILTRATION_TYPES` AND `filtration2_enabled` |
 
-### `byte[37]` — Filtration mode flag (two encodings observed)
+### `byte[37]` — Filtration mode flag + heating control (two encodings observed)
 
 > See the **Firmware Revisions** section at the top of this document for
 > background on why two encodings exist. The two are **disjoint by high
@@ -241,13 +247,22 @@ HOME v7 firmware comes in two revisions that use **disjoint** byte 37 layouts.
 Both revisions are confirmed live (firmware A: serial 110128063, byte 4 = 0x02;
 firmware B: serial 110169464, byte 4 = 0x03 — see [Issue #133](../temp/Issue-133.md)).
 
-| Mode              | Firmware A | Firmware B | Binary (A / B)               |
-|-------------------|------------|------------|------------------------------|
-| 24h nonstop       | `0x43`     | `0x01`     | `0100_0011` / `0000_0001`    |
-| Timer (P1)        | `0x53`*    | `0x11`     | `0101_0011` / `0001_0001`    |
-| Timer (P1 & P2)   | `0x53`*    | `0x31`     | `0101_0011` / `0011_0001`    |
-| OFF (manual)      | (n/o)      | `0x35`     | — / `0011_0101`              |
-| Transitional      | `0x47` / `0x57` | (n/o) | `0100_0111` / `0101_0111` / — |
+| Mode                          | Firmware A | Firmware B | Binary (A / B)               |
+|-------------------------------|------------|------------|------------------------------|
+| 24h nonstop                   | `0x43`     | `0x01`     | `0100_0011` / `0000_0001`    |
+| Timer (P1)                    | `0x53`*    | `0x11`     | `0101_0011` / `0001_0001`    |
+| Timer (P1 & P2)               | `0x53`*    | `0x31`     | `0101_0011` / `0011_0001`    |
+| OFF (manual)                  | (n/o)      | `0x35`     | — / `0011_0101`              |
+| Transitional                  | `0x47` / `0x57` | (n/o) | `0100_0111` / `0101_0111` / — |
+| Heating ON (nonstop)†         | `0x49`     | (n/o)      | `0100_1001` / —              |
+| Heating OFF (nonstop)†        | `0x41`     | (n/o)      | `0100_0001` / —              |
+| Heating OFF (initial/unconf.)† | `0x45`    | (n/o)      | `0100_0101` / —              |
+
+† Bit 1 is clear (`0x02`) in all three heating-health values. When `byte[37]` & `0x40` is set
+  but bit-1 is clear, the decoder falls back to schedule-derived filtration mode (see
+  `_fill_filtration_mode` in `aseko_decoder.py`). The actual filtration mode is
+  determined from the schedule bytes and the `PERIOD2_ENABLED_MASK` (`0x20`).
+  `heating_control_enabled` is decoded separately from bit 3 (`0x08`).
 
 \* Firmware A cannot distinguish P1-only from P1&P2 from `byte[37]` alone — both
 share the value `0x53`. The decoder uses the existing `FILTRATION_PERIOD2_ENABLED_MASK = 0x20`
@@ -269,6 +284,23 @@ Mode decoding on firmware B:
 - **24h nonstop** ⇔ `(byte[37] & 0x30) == 0`
 - **Timer mode** ⇔ `(byte[37] & 0x30) != 0`
 - **Manual override** ⇔ `(byte[37] & 0x04) != 0`
+
+**Firmware A bit semantics** (Issue #135, serial 110175608 REDOX HOME):
+
+| Bit | Mask  | Meaning                                                    |
+|-----|-------|------------------------------------------------------------|
+| 6   | `0x40`| Firmware A high-nibble indicator (always set)              |
+| 3   | `0x08`| Heating control master enable                              |
+| 2   | `0x04`| Unknown / initial-unconfigured indicator (set on unconfigured `0x45`) |
+| 1   | `0x02`| Transitional edit in progress (set on `0x47` / `0x57`)     |
+| 0   | `0x01`| Filtration present (always set in known nonstop/timer)     |
+
+Filtration mode decoding on firmware A:
+- **Known modes**: `0x43` (nonstop), `0x53` (timer), `0x47`/`0x57` (transitional → `None`)
+- **Heating overlay values** (`0x41`, `0x45`, `0x49`) have bit 1 clear — the decoder
+  falls back to schedule-derived filtration mode for these.
+- **Heating control**: bit 3 (`0x08`) is gated on `AsekoDeviceType.HOME` in
+  `_fill_heating_demand()` and decoded into `heating_control_enabled`.
 
 **Note on `0x43` (firmware A)**: treat this as "consistent with NONSTOP 24H" rather
 than "confirmed NONSTOP 24H active". A frame captured in May 2026 from
@@ -316,10 +348,10 @@ in `aseko_decoder.py`).
 
 | # | Description |
 |---|-------------|
-| 3 | `required_water_temperature` vs app "---" — need a normal-operation frame from a pool with heating enabled to confirm `byte[55]` mapping. |
+| 3 | `required_water_temperature` vs app "---" — partially resolved by Issue #135: `byte[55]` is confirmed as the heating setpoint on serial 110175608 (REDOX HOME, heating ON frame). A frame from a device where the app actively shows a target temperature (not "---") would further validate this. |
 | 7 | `byte[29]` per-pump bits for HOME (algicide, flocculant, cl, pH−) are unconfirmed. The masks in `ACTUATOR_MASKS[HOME]` are placeholders matching OXY/NET. Capturing frames with a single HOME pump running (e.g. algicide only) would pin down the per-pump bit. Until then, `algicide_pump_running` and `floc_pump_running` may report incorrectly on HOME. |
 | 8 | `max_filling_time` overlap with `flowrate_ph_minus` (both use `byte[95]`). If `byte[94]` ever becomes non-zero, `max_filling_time` is inflated. Only a frame with a non-zero `byte[94]` would prove or disprove the assumption. |
-| 9 | `heating_active` binary sensor (`byte[29]` bit `0x04`) — needs a frame captured while the heat pump / electric heater is actually running. Currently it cannot be distinguished from the unconfirmed HOME pump-bit masks (Open Item 7). |
+| 9 | `heating_active` binary sensor (`byte[29]` bit `0x04`) — needs a frame captured while the heat pump / electric heater is actually running. The `heating_control_enabled` field (byte[37] bit 3) is the **master enable**, separate from the actual heating output state in byte[29] bit 2. A frame with `byte[29]` bit 2 set would confirm this as the running-state indicator. |
 | 10 | Bytes 31, 38, 65 in the firmware B OFF frame all rise by ~1 (0x00→0x02, 0x02→0x03, 0xa3→0xa4) — possible additional "manual override active" sub-flags, not used by the decoder today. Single observation, no meaning assigned. |
 
 ---
@@ -345,16 +377,24 @@ Tests for the HOME decoder live in `tests/test_aseko_decoder.py`:
 | `test_filtration_pump_running_off_when_manual_override` | Issue #133: `byte[37]=0x35` forces `filtration_pump_running=False` |
 | `test_filtration_pump_running_on_when_not_override` | Regression guard: `byte[29]&0x08` still drives the entity outside OFF_MANUAL |
 | `test_filtration_pump_running_not_overridden_on_salt` | Override short-circuit is HOME-only |
+| `test_decode_home_heating_control_enabled` | Issue #135: `byte[37]=0x49` → `heating_control_enabled=True` with schedule-derived filtration mode |
+| `test_decode_home_heating_control_disabled` | Issue #135: `byte[37]=0x41` → `heating_control_enabled=False` |
+| `test_decode_home_heating_control_unconfigured` | Issue #135: `byte[37]=0x45` → `heating_control_enabled=False` (initial state) |
+| `test_decode_home_heating_control_not_present_on_salt` | Heating gating: SALT frames with `byte[37]` set never report `heating_control_enabled` |
 
 ---
 
 ## Cross-References
 
 - Related decoder file: `custom_components/aseko_local/aseko_decoder.py`
-- Actuator masks: `custom_components/aseko_local/aseko_data.py` → `ACTUATOR_MASKS[AsekoDeviceType.HOME]`
+- Actuator masks: `custom_components/aseko_local/aseko_v7_helpers.py` → `ACTUATOR_MASKS[AsekoDeviceType.HOME]`
+- `AsekoByte37Masks`: `custom_components/aseko_local/aseko_v7_helpers.py`
 - OXY analysis (reference for shared byte layout): `docs/device analyzes/oxy_device_analysis.md`
 - NET v8 analysis: `docs/device analyzes/net_v8_device_analysis.md`
 - Issue #110: byte[37] firmware A (`0x43` = nonstop 24h) — original finding, frames in this file
 - Issue #115: HOME `algicide_pump_running` missing — fixed by independent-pump-port branch
 - Issue #133: byte[37] firmware B (4-state mode + manual OFF) — fixed by `_fill_filtration_mode` rewrite
+- Issue #135: `byte[37]` bit 3 (`0x08`) = heating control master enable on HOME firmware A
+  (serial 110175608, REDOX HOME). Confirms `byte[55]` as target water temp setpoint.
+  Working notes: [docs/temp/Issue-135.md](../temp/Issue-135.md).
 - Working notes: `docs/temp/Issue-133.md`

--- a/docs/device analyzes/home_device_analysis.md
+++ b/docs/device analyzes/home_device_analysis.md
@@ -8,6 +8,31 @@
 
 ---
 
+## Firmware Revisions
+
+Two HOME v7 firmware revisions are observed in the wild. They use **different
+byte 37 layouts** for the filtration mode flag but share every other byte
+position. The two revisions are referred to throughout this document as
+**Firmware A** and **Firmware B**:
+
+| | Firmware A | Firmware B |
+|---|---|---|
+| Serial (known) | 110128063 (`0x06906bbf`) | 110169464 (`0x06912578`) |
+| `byte[37]` mode values | high nibble `0x4` / `0x5` | high nibble `0x0` / `0x1` / `0x3` |
+| Known states | nonstop 24h, timer, transitional | nonstop 24h, P1, P1&P2, OFF manual, transitional |
+| Source | This file (Issue #110) | [Issue #133](../temp/Issue-133.md) |
+| Period 2 enable flag | bit 5 (`0x20`) — same as firmware B | bit 5 (`0x20`) |
+| Manual OFF signal | not present in captured frames | bit 2 (`0x04`) — see `byte[37]` table |
+
+The two revisions are **disjoint by high nibble of byte 37**, so a single
+byte check distinguishes them without resorting to the serial number.
+Where a fact in this document differs between the two revisions (only
+`byte[37]` today), both values are listed side by side in the
+*byte[37] — Filtration mode flag* table under "Device Specifications"
+below. All other byte positions are identical across A and B.
+
+---
+
 ## Raw Frame (120 bytes)
 
 The Aseko protocol sends 3×40-byte segments in a single TCP payload.
@@ -50,24 +75,13 @@ Seg3 (bytes 80–119): 06 90 6b bf  02 02  1a 04 1c 08 1b 07
 | 29      | `00`     | 0       | Actuator bits            | all pumps stopped    | STOP          | ✓      |
 | 30–31   | `ffff`   | —       | UNSPECIFIED / padding    | —                    | —             | —      |
 | 32–36   | `00…00`  | 0       | Unknown                  | —                    | —             | ?      |
-| 37      | `43`     | 67      | **Filtration mode flag** | see note §           | NONSTOP 24H    | ✓     |
+| 37      | `43`     | 67      | **Filtration mode flag (firmware A)** | see note §  | NONSTOP 24H    | ✓     |
 | 38      | `0a`     | 10      | Unknown                  | —                    | —             | ?      |
 | 39      | `85`     | 133     | Unknown (checksum?)      | —                    | —             | ?      |
 
 † pH 6.29 vs 6.56 and water temp 37.9 vs 38.2 are explained by different timestamps (frame: 08:27:07, screenshot: later that day). Not a decoding bug.
 
-§ **byte[37] = `0x43`**: This is the **HOME filtration mode flag** (see Issue 4). The value `0x43` here means *FILTRATION NONSTOP 24H* (also reported as such in the Aseko Live app on this device). HOME devices have **independent pump ports** for flocculant and algicide (same layout as OXY Pure), so the SALT-style "shared third-pump port" routing rule (bit 7 = algicide) does **not** apply. The HOME-specific flowrate branch (analogous to OXY) was added in commit 0e78e4d and now reads `byte[101] → flowrate_floc` and `byte[103] → flowrate_algicide` independently — see Bug 3 below.
-
-#### Actuator byte[29] — HOME masks (uncertain)
-
-| Bit   | Mask   | Field                  | Value (0x00) |
-|-------|--------|------------------------|-------------|
-| bit 3 | `0x08` | filtration_pump_running | False ✓     |
-| bit 6 | `0x40` | cl_pump_running        | False ✓     |
-| bit 7 | `0x80` | ph_minus_pump_running  | False ✓     |
-| bit 5 | `0x20` | algicide / floc running | False ✓    |
-
-All masks marked **uncertain** — confirmed only from their absence (byte[29]=0x00 when nothing is running). Need frames captured while individual pumps are active to confirm per-pump bits.
+§ **byte[37] = `0x43`**: HOME filtration mode flag, firmware A. The value `0x43` means *FILTRATION NONSTOP 24H* here. HOME devices have **independent pump ports** for flocculant and algicide (same layout as OXY Pure), so the SALT-style "shared third-pump port" routing rule (bit 7 = algicide) does **not** apply. The full encoding table (firmware A vs B) is in the *Device Specifications → byte[37]* section below.
 
 ---
 
@@ -81,24 +95,30 @@ All masks marked **uncertain** — confirmed only from their absence (byte[29]=0
 | 46–51   | `1a 04 1c 08 1b 07` | — | Timestamp (repeated)       | 2026-04-28 08:27:07 | —            | ✓      |
 | 52      | `46`     | 70      | required_ph (÷10)             | **7.0**        | 7.0               | ✓      |
 | 53      | `03`     | 3       | required_cl_free (÷10)        | **0.3 mg/l**   | 0.3               | ✓      |
-| 54      | `0a`     | 10      | required_floc                 | **10 ml/h** ✓  | 10 ml/h           | ✓ (fixed) |
-| 55      | `19`     | 25      | required_water_temperature    | 25°C ⚠️        | — (disabled)      | ⚠️     |
-| 56–57   | `08 00`  | —       | start1                        | 08:00          | NONSTOP 24H ⚠️    | ⚠️     |
-| 58–59   | `10 00`  | —       | stop1                         | 16:00          | NONSTOP 24H ⚠️    | ⚠️     |
-| 60–61   | `12 00`  | —       | start2                        | 18:00          | NONSTOP 24H ⚠️    | ⚠️     |
-| 62–63   | `16 00`  | —       | stop2                         | 22:00          | NONSTOP 24H ⚠️    | ⚠️     |
+| 54      | `0a`     | 10      | required_floc                 | **10 ml/h**    | 10 ml/h           | ✓      |
+| 55      | `19`     | 25      | required_water_temperature    | 25°C           | — (disabled)      | ⚠ Open Item 3 |
+| 56–57   | `08 00`  | —       | start1                        | 08:00          | last-configured   | ✓     |
+| 58–59   | `10 00`  | —       | stop1                         | 16:00          | last-configured   | ✓     |
+| 60–61   | `12 00`  | —       | start2                        | 18:00          | last-configured   | ✓     |
+| 62–63   | `16 00`  | —       | stop2                         | 22:00          | last-configured   | ✓     |
 | 64–65   | `027c`   | 636     | Unknown                       | —              | —                 | ?      |
 | 66–67   | `017b`   | 379     | Unknown (= water temp raw)    | —              | —                 | ?      |
 | 68      | `03`     | 3       | backwash_every_n_days         | **3 days**     | every 3 days      | ✓      |
 | 69–70   | `15 00`  | —       | backwash_time                 | **21:00**      | starts at 21:00   | ✓      |
 | 71      | `0c`     | 12      | backwash_duration (×10 s)     | **120 s = 2 min** | takes 02:00 min | ✓    |
-| 72      | `00`     | 0       | required_algicide             | **0 ml/m³/day** ✓ | 0 ml/m³/day    | ✓ (fixed) |
+| 72      | `00`     | 0       | required_algicide             | **0 ml/m³/day** | 0 ml/m³/day     | ✓      |
 | 73      | `28`     | 40      | Unknown                       | —              | —                 | ?      |
 | 74–75   | `01e0`   | 480     | delay_after_startup (s)       | **480 s = 8 min** | 8 min          | ✓      |
 | 76      | `2a`     | 42      | Unknown                       | —              | —                 | ?      |
 | 77      | `30`     | 48      | Unknown                       | —              | —                 | ?      |
 | 78      | `a0`     | 160     | Unknown                       | —              | —                 | ?      |
 | 79      | `d8`     | 216     | Unknown                       | —              | —                 | ?      |
+
+> **Schedule vs. mode flag**: bytes 56-63 always carry the last-configured
+> schedule (the unit does not clear them when switching to NONSTOP 24h). The
+> actual mode is reported separately in `byte[37]`. See the *byte[37]
+> — Filtration mode flag* section under "Device Specifications" below for the
+> two encodings.
 
 ---
 
@@ -156,8 +176,8 @@ Note on **bytes 94–95**: `max_filling_time` reads bytes[94:96] as a big-endian
 | required_cl_free          | 0.3 mg/l         | 0.3               | ✓     |
 | required_floc             | 10 ml/h          | 10 ml/h           | ✓ (fixed) |
 | required_algicide         | 0 ml/m³/day      | 0 ml/m³/day       | ✓ (fixed) |
-| required_water_temperature | 25°C            | --- (disabled)    | ⚠️ see Issue 3 |
-| Filtration schedule       | 08:00–16:00 / 18:00–22:00 | NONSTOP 24H | ✓ |
+| required_water_temperature | 25°C            | --- (disabled)    | ⚠ Open Item 3 |
+| Filtration schedule       | 08:00–16:00 / 18:00–22:00 (last-configured) | NONSTOP 24H | ✓ (mode from `byte[37]`, schedule bytes always present) |
 | backwash_every_n_days     | 3                | every 3 days      | ✓     |
 | backwash_time             | 21:00            | starts at 21:00   | ✓     |
 | backwash_duration         | 120 s            | 02:00 min         | ✓     |
@@ -171,184 +191,160 @@ Note on **bytes 94–95**: `max_filling_time` reads bytes[94:96] as a big-endian
 
 ---
 
-## Bugs Found
+## Device Specifications
 
-### Bug 1 (Fixed) — `required_floc` not decoded for HOME devices
+### Pump ports
 
-**Root cause**: `_fill_required_data` decodes byte[54] as either `required_floc` or `required_algicide` only when `masks.byte37_routes_pump_type is True`. For HOME devices `byte37_routes_pump_type = False` (correct — HOME has independent pump ports), so the entire byte[54] block was silently skipped.
+HOME has **4 independent pump ports** (same layout as OXY Pure), unlike SALT
+which has a shared third-pump port. There is no SALT-style algicide/flocculant
+routing via `byte[37]` bit 7.
 
-**Evidence**: byte[54] = `0x0a` = 10 → required_floc = 10 ml/h. Aseko Live Config confirms **Flocc: 10 ml/hour**.
+| Port  | Pump                | `flowrate_*` byte | `flowrate_*` value | `byte[29]` bit (uncertain) | `byte[29]` mask |
+|-------|---------------------|-------------------|--------------------|-----------------------------|-----------------|
+| 1     | pH− (Ph minus)      | `byte[95]`        | `flowrate_ph_minus`  | bit 7                       | `0x80`          |
+| 2     | Chlorine / OXY Pure | `byte[99]`        | `flowrate_chlor`     | bit 6                       | `0x40`          |
+| 3     | Flocculant          | `byte[101]`       | `flowrate_floc`      | bit 5                       | `0x20`          |
+| 4     | Algicide            | `byte[103]`       | `flowrate_algicide`  | bit 4 (PROFI/SALT) / bit 5 (HOME, shared) | `0x20` |
 
-**Fix applied** (`aseko_decoder.py`): Added a HOME-specific branch (parallel to OXY) that unconditionally decodes byte[54] as `required_floc`. Test: `test_decode_home_clf_real_frame`.
+> **Note on cl/oxy routing**: the chlorine pump port can be configured as
+> Chlorine OR OXY Pure (same physical port, same bit in `byte[29]`). The
+> routing byte is not yet confirmed from frames — see Open Item 7.
 
----
+### Setpoints
 
-### Bug 2 (Fixed) — `required_algicide` not decoded for HOME devices
+| Field                   | Byte(s)   | Unit             | Notes |
+|-------------------------|-----------|------------------|-------|
+| `required_ph`           | `byte[52]`| (raw ÷ 10)        |       |
+| `required_cl_free`      | `byte[53]`| mg/L (raw ÷ 10)   | HOME CLF variant only |
+| `required_redox`        | `byte[53]`| mV (raw × 10)     | HOME REDOX variant only |
+| `required_floc`         | `byte[54]`| ml/h              | Same byte position as SALT algicide; gated by `byte[37] != 0xFF` |
+| `required_algicide`     | `byte[72]`| ml/m³/day         | HOME-only, same byte position as OXY Pure |
+| `required_water_temperature` | `byte[55]` | °C            | Disabled on this device — see Open Item 3 |
 
-**Root cause**: Same as Bug 1 — the byte[54]/byte[72] routing block was skipped for HOME. HOME uses the same byte positions as OXY Pure.
+### Schedule (bytes 56-63)
 
-**Evidence**: Aseko Live Config shows **Algicide: 0 ml/m³/day**. Frame byte[72] = `0x00` = 0.
+| Field   | Byte(s)   | Decoded      | Notes |
+|---------|-----------|--------------|-------|
+| `start1` | `byte[56:58]` | HH:MM     | Gated on `FILTRATION_TYPES` (HOME in) |
+| `stop1`  | `byte[58:60]` | HH:MM     | Gated on `FILTRATION_TYPES` |
+| `start2` | `byte[60:62]` | HH:MM     | Gated on `FILTRATION_TYPES` AND `filtration2_enabled` |
+| `stop2`  | `byte[62:64]` | HH:MM     | Gated on `FILTRATION_TYPES` AND `filtration2_enabled` |
 
-**Fix applied** (`aseko_decoder.py`): The same HOME branch also decodes byte[72] as `required_algicide` (identical to OXY layout). Test: `test_decode_home_clf_real_frame`.
+### `byte[37]` — Filtration mode flag (two encodings observed)
 
----
+> See the **Firmware Revisions** section at the top of this document for
+> background on why two encodings exist. The two are **disjoint by high
+> nibble** of `byte[37]` and therefore distinguishable on a single byte.
+> Working notes for firmware B: [docs/temp/Issue-133.md](../temp/Issue-133.md).
 
-### Bug 3 (Fixed) — HOME `flowrate_algicide` and `algicide_pump_running` missing
+HOME v7 firmware comes in two revisions that use **disjoint** byte 37 layouts.
+Both revisions are confirmed live (firmware A: serial 110128063, byte 4 = 0x02;
+firmware B: serial 110169464, byte 4 = 0x03 — see [Issue #133](../temp/Issue-133.md)).
 
-**Root cause**: `_fill_flowrate_data` only had an OXY early-return and a SALT/NET/PROFI fallthrough. For HOME, the SALT fallthrough was used: it routed `byte[101]` exclusively to either `flowrate_algicide` (when `byte[37] & 0x80`) or `flowrate_floc` (otherwise). HOME devices have **independent** pump ports (same as OXY), so this routing is wrong on two counts:
-1. `byte[103]` (the HOME algicide flowrate) was never read.
-2. The `byte[37]` bit 7 has no meaning on HOME (no shared pump port).
+| Mode              | Firmware A | Firmware B | Binary (A / B)               |
+|-------------------|------------|------------|------------------------------|
+| 24h nonstop       | `0x43`     | `0x01`     | `0100_0011` / `0000_0001`    |
+| Timer (P1)        | `0x53`*    | `0x11`     | `0101_0011` / `0001_0001`    |
+| Timer (P1 & P2)   | `0x53`*    | `0x31`     | `0101_0011` / `0011_0001`    |
+| OFF (manual)      | (n/o)      | `0x35`     | — / `0011_0101`              |
+| Transitional      | `0x47` / `0x57` | (n/o) | `0100_0111` / `0101_0111` / — |
 
-As a downstream effect, `_fill_consumable_data` short-circuited `algicide_pump_running` because `flowrate_algicide is None`, so the `algicide_pump_running` binary sensor was never registered. This is the root cause of the [Issue #115](https://github.com/hopkins-tk/home-assistant-aseko-local/issues/115) report: *"no entity for Algacide pump running"*.
+\* Firmware A cannot distinguish P1-only from P1&P2 from `byte[37]` alone — both
+share the value `0x53`. The decoder uses the existing `FILTRATION_PERIOD2_ENABLED_MASK = 0x20`
+(bit 5) to separate them, treating `0x53` as P1&P2 by default. The actual distinction
+on firmware A comes from the per-period enable bit, not the mode flag.
 
-**Evidence**:
-- This frame (serial 110128063): `byte[101] = 0x0a = 10 ml/min` matches Aseko Live "Floc+c 10 ml/min". `byte[103] = 0x21 = 33` is the algicide pump capacity.
-- [Issue #110 frame](https://github.com/hopkins-tk/home-assistant-aseko-local/issues/110) (serial 110071590): `byte[103] = 0x0b = 11 ml/min` → Aseko Live "Algicide listed" (dose is 0, but the installed pump capacity is reported).
+(n/o = not observed in captured frames.)
 
-**Fix applied** (`aseko_decoder.py`): Added a HOME-specific early-return branch in `_fill_flowrate_data` (parallel to OXY), reading `byte[101] → flowrate_floc` and `byte[103] → flowrate_algicide` independently. The `byte[37]` value is ignored on HOME.
+**Firmware B bit semantics**:
 
-**Tests added** (in `tests/test_aseko_decoder.py`):
-- `test_decode_home_independent_flowrates` — verifies HOME reads byte[101]/byte[103] independently of byte[37] (tested with both `0x53` and `0xB3` to prove byte[37] is irrelevant on HOME).
-- `test_decode_home_flowrates_unspecified` — 0xFF on flowrate bytes → `None` (e.g. pump not installed).
-- `test_decode_home_algicide_pump_running` — covers Issue #115: `algicide_pump_running` binary sensor is now correctly registered.
-- `test_decode_home_floc_pump_running_independent` — verifies HOME reports `floc_pump_running` correctly when only floc pump is installed (byte[103] = 0xFF).
+| Bit  | Mask  | Meaning                                       |
+|------|-------|-----------------------------------------------|
+| 0    | `0x01`| Filtration present (always set)               |
+| 2    | `0x04`| Manual override active (user toggled OFF)     |
+| 4    | `0x10`| Period 1 enabled                              |
+| 5    | `0x20`| Period 2 enabled                              |
 
----
-
-### Issue 3 (Pending — low-water condition at capture time)
-
-**Observation**: byte[55] = `0x19` = 25 → decoded as 25°C. Aseko Live shows "---" for Water temp (disabled/not configured).
-
-**Context**: The frame was captured while Aseko Live was showing an error, most likely caused by insufficient water in the pool (evidenced by cl_free = 0 and filtration pump stopped). The device may report a placeholder/default value in certain fields during an error or standby state, which would explain the "---" in the app despite byte[55] being non-zero.
-
-**Action needed**: Request a new frame when the pool is running normally and compare byte[55] — if the water temperature control feature is enabled and active, the decoded value should match the app. Until then this issue remains unresolved.
-
----
-
-### Issue 4 ✅ Resolved — Filtration nonstop mode flag is byte[37] (firmware A)
-
-**Observation**: Aseko Live Config shows **FILTRATION NONSTOP 24H**. The decoder produces start1=08:00, stop1=16:00, start2=18:00, stop2=22:00 (12 h total — inconsistent with nonstop mode).
-
-**Context**: The frame was captured while the pool had an error (likely too little water). The filtration pump was stopped and byte[29] = 0x00, consistent with an active alarm suppressing normal operation.
-
-**Resolution (Issue #110)**: `byte[37]` encodes the filtration mode flag on this firmware revision (firmware A, serial 110128063, byte 4 = 0x02):
-
-| byte[37] | Meaning |
-|---|---|
-| `0x43` | FILTRATION NONSTOP 24H active |
-| `0x53` | Timer mode active (P1 or P1&P2, indistinguishable) |
-| `0x47` / `0x57` | Transitional / edit state — leave as `None` |
-
-**⚠️ Note on the issue #110 evidence**: The diagnostics frame is from **2026-05-23 17:09** (after mannekung changed the filtration schedule to NONSTOP 24H on **2026-05-09**), but `byte[37]` still reads `0x53` (timer). The screenshot from the same user shows the "Suche" indicator (search mode) in the bottom-right corner, which may explain the mismatch — the device might be reporting a transient or special mode rather than the user-configured setting. **Until a frame is captured with a known NONSTOP 24H state and no special UI mode, treat `0x43` as "consistent with NONSTOP 24H" rather than "confirmed NONSTOP 24H active".**
-
-`filtration_nonstop24` is now decoded for **all device types** (HOME, SALT, OXY, NET). Non-HOME real-world values for byte[37] are never `0x43`/`0x53` (SALT uses it for algicide routing, OXY uses `0x03`, NET always `0xFF`), so `filtration_nonstop24` stays `None` for those devices today.
-
-**⚠️ Note on a second HOME v7 encoding (firmware B)**: [Issue #133](https://github.com/hopkins-tk/home-assistant-aseko-local/issues/133) (serial 110169464, byte 4 = 0x03) reports that a *different* HOME v7 firmware uses completely different byte 37 values. See Issue 6 below for the full encoding table and the implications for the `filtration_nonstop24` sensor.
-
----
-
-### Issue 6 ✅ Resolved — Two HOME v7 firmware revisions use different byte 37 encodings
-
-**Observation**: [@dtpugh's report](https://github.com/hopkins-tk/home-assistant-aseko-local/issues/133) on a HOME REDOX (serial 110169464, byte 4 = 0x03) shows that the existing `_fill_filtration_mode` decoder cannot read byte 37 at all: every observed value falls through to `None`, so neither `filtration_nonstop24` nor any other filtration-mode entity appears. Cross-frame analysis of four captured frames (24h nonstop, P1 only, P1 & P2, OFF manual) shows that the new firmware uses a fundamentally different bit layout.
-
-**Comparison of HOME v7 byte 37 encodings**:
-
-| Mode              | Firmware A (this file) | Firmware B (Issue #133) |
-|-------------------|------------------------|-------------------------|
-| 24h nonstop       | `0x43` (`0b0100_0011`) | `0x01` (`0b0000_0001`) |
-| Timer (P1)        | `0x53` (`0b0101_0011`) | `0x11` (`0b0001_0001`) |
-| Timer (P1 & P2)   | `0x53` (indistinguishable) | `0x31` (`0b0011_0001`) |
-| OFF (manual)      | (not observed)         | `0x35` (`0b0011_0101`) |
-| Transitional      | `0x47` / `0x57`        | (not observed)          |
-
-The two encodings are **disjoint by high nibble** (firmware A: 0x4/0x5; firmware B: 0x0/0x1/0x3) and therefore distinguishable on a single byte, without resorting to the serial number.
-
-**Firmware B bit semantics** (consistent with the existing `FILTRATION_PERIOD2_ENABLED_MASK = 0x20`):
-
-| Bit  | Mask  | Meaning |
-|------|-------|---------|
-| 0    | 0x01  | Filtration present (always set when a filter is configured) |
-| 2    | 0x04  | Manual override active |
-| 4    | 0x10  | Period 1 enabled |
-| 5    | 0x20  | Period 2 enabled |
-
-Mode decoding:
+Mode decoding on firmware B:
 - **24h nonstop** ⇔ `(byte[37] & 0x30) == 0`
 - **Timer mode** ⇔ `(byte[37] & 0x30) != 0`
 - **Manual override** ⇔ `(byte[37] & 0x04) != 0`
 
-**Cross-validation against other device types**: the firmware B high-nibble range overlaps with values that SALT and OXY use for different purposes (SALT `0x37`/`0x13` for algicide routing, OXY `0x03` for pump presence). The new encoding is therefore **gated on `device_type == HOME`** in the decoder. SALT / OXY / NET / PROFI continue to leave `filtration_mode` as `None`.
+**Note on `0x43` (firmware A)**: treat this as "consistent with NONSTOP 24H" rather
+than "confirmed NONSTOP 24H active". A frame captured in May 2026 from
+mannekung's device (after switching to NONSTOP 24H) still showed `0x53` (timer)
+with the Aseko app in "Suche" (search) mode — see [Issue #110 frame
+discussion](https://github.com/hopkins-tk/home-assistant-aseko-local/issues/110).
 
-**Resolution**: replace the existing `_fill_filtration_mode` with a 6-line `if/elif` chain that handles both encodings on HOME only, and introduce a 4-state `AsekoFiltrationMode` enum (`NONSTOP_24H`, `TIMER_PERIOD_1`, `TIMER_PERIOD_1_AND_2`, `OFF_MANUAL`). A new `filtration_mode` sensor (device_class = `ENUM`, options = the 4 states) surfaces the full state to Home Assistant. The legacy `filtration_nonstop24` binary sensor is kept for backwards compatibility but its default visibility is flipped to `False` on HOME.
+**Note on `0x35` (firmware B, manual OFF)**: when this value appears, `byte[29]`
+bit 3 (`filtration_pump_running`) is still set in the frame — the firmware does
+not clear the schedule-driven bit on manual override. The decoder compensates
+by short-circuiting `filtration_pump_running` to `False` whenever
+`filtration_mode == OFF_MANUAL`. This is a HOME-only behaviour; no SALT/OXY/PROFI
+OFF frame has been captured yet.
 
-**Behavioural fix for `filtration_pump_running`**: byte 29 bit 3 is set in **all four** firmware B frames — including the OFF frame — but the new `OFF_MANUAL` state carries the explicit user intent. In `_fill_consumable_data`, the decoder now short-circuits `filtration_pump_running` to `False` when `filtration_mode == OFF_MANUAL` (gated on HOME, so SALT/OXY/NET behaviour is unchanged). This addresses the user's secondary complaint that the pump state entity stays ON when the user has manually switched the pump off. The remaining open question is whether SALT devices have an analogous manual-override mechanism — no SALT OFF frame has been captured yet, so the short-circuit is intentionally HOME-only.
+### `byte[29]` — Actuator bitmask (HOME)
 
-**Full working notes**: see [docs/temp/Issue-133.md](../temp/Issue-133.md) for the complete frame diff (only 19 of 120 bytes change between the four modes), the cross-validation table, and the test plan.
+Bit positions in `byte[29]` for HOME pump states. The masks in
+`ACTUATOR_MASKS[HOME]` are placeholders — they match OXY/NET but the per-pump
+bits for HOME-specific pumps (algicide, flocculant) are **not yet confirmed**
+by live capture (see Open Item 7).
+
+| Bit  | Mask  | Field                       | Confidence |
+|------|-------|-----------------------------|------------|
+| 0    | `0x01`| backwash valve relay        | ✓ confirmed (HOME/SALT/OXY all use this bit) |
+| 1    | `0x02`| water-filling active        | ✓ confirmed (NET/NOT-HOME, see Issue #100)    |
+| 2    | `0x04`| heating active              | ⚠ unconfirmed — see Open Item 9                |
+| 3    | `0x08`| filtration pump running     | ✓ confirmed (all FILTRATION_TYPES)            |
+| 4    | `0x10`| algicide pump running       | see Open Item 7        |
+| 5    | `0x20`| flocculant pump running     | see Open Item 7        |
+| 6    | `0x40`| cl pump running             | see Open Item 7        |
+| 7    | `0x80`| pH− pump running            | see Open Item 7        |
+
+### `byte[29]` vs `filtration_mode` (firmware B manual OFF)
+
+Cross-frame analysis of @dtpugh's four firmware B frames (24h nonstop, P1 only,
+P1 & P2, OFF manual) shows that `byte[29]` bit 3 stays set in **all four**
+frames — including the OFF frame. The override state lives in `byte[37]` bit 2
+(firmware B only, value `0x35`), not in `byte[29]`. The decoder compensates for
+this HOME-only behaviour in `_fill_consumable_data` (see `_fill_filtration_mode`
+in `aseko_decoder.py`).
 
 ---
-
-### Issue 5 ✅ Resolved — HOME `flowrate_algicide` is byte[103] (independent port)
-
-**Observation**: Aseko Live Consumption page shows **Algicide** as a tracked chemical. `flowrate_algicide` was `None` in the decoded output before the fix.
-
-**Resolution**: HOME devices use the same independent-pump-port layout as OXY Pure. The HOME-specific flowrate branch was added in `_fill_flowrate_data` (parallel to OXY), reading:
-- `byte[101] → flowrate_floc` (always)
-- `byte[103] → flowrate_algicide` (always)
-
-No `byte[37]` routing is involved on HOME.
-
-**Evidence**:
-- This frame (serial 110128063): `byte[101] = 0x0a = 10 ml/min` → matches Aseko Live "Floc+c 10 ml/min".
-- `byte[103] = 0x21 = 33` — confirmed in the [Issue #110 frame](https://github.com/hopkins-tk/home-assistant-aseko-local/issues/110) (serial 110071590, `byte[103] = 0x0b = 11`) that algicide uses byte[103] with the same ml/min unit. The non-zero value when `required_algicide = 0` suggests the controller still reports the *installed pump capacity* even when the dose is set to zero — similar to how the flocculant pump continues to report 10 ml/min when no flocculant is being dosed.
-
-**Side effect**: The `algicide_pump_running` binary sensor (which was always missing before the fix because `flowrate_algicide is None` short-circuited the assignment in `_fill_consumable_data`) is now correctly registered and reflects `byte[29] & 0x20`. This addresses the [Issue #115](https://github.com/hopkins-tk/home-assistant-aseko-local/issues/115) report "no entity for Algacide pump running".
-
----
-
-## Applied Fixes
-
-1. **`aseko_decoder.py` → `_fill_required_data`** — added HOME device branch (parallel to OXY, no early return so `required_cl_free` / `required_redox` are still decoded via the CLF branch):
-   - byte[54] → `required_floc` (ml/h)
-   - byte[72] → `required_algicide` (ml/m³/day)
-
-```python
-# HOME: has both CLF/REDOX setpoint at byte[53] AND independent floc/algicide setpoints.
-# Same byte layout as OXY Pure for these two fields (confirmed 2026-04-28, frame analysis).
-if unit.device_type == AsekoDeviceType.HOME:
-    unit.required_floc = AsekoDecoder._normalize_value(data[54], int)
-    unit.required_algicide = AsekoDecoder._normalize_value(data[72], int)
-    # Fall through to decode required_cl_free (byte[53]) via the CLF branch below.
-```
-
-2. **`aseko_decoder.py` → `_fill_flowrate_data`** — added HOME-specific branch (parallel to OXY, with early return so SALT routing logic is skipped). Reads `byte[101] → flowrate_floc` and `byte[103] → flowrate_algicide` independently. No `byte[37]` routing applies on HOME.
-
-```python
-if unit.device_type == AsekoDeviceType.HOME:
-    # HOME has independent pump ports for flocculant and algicide.
-    # Same layout as OXY Pure for these two flowrates.
-    unit.flowrate_chlor = AsekoDecoder._normalize_value(data[99], int)
-    unit.flowrate_floc = AsekoDecoder._normalize_value(data[101], int)
-    unit.flowrate_algicide = AsekoDecoder._normalize_value(data[103], int)
-    return
-```
-
-**Tests added** (in `tests/test_aseko_decoder.py`):
-- `test_decode_home_independent_flowrates` — verifies HOME reads byte[101]/byte[103] independently of byte[37].
-- `test_decode_home_flowrates_unspecified` — 0xFF on flowrate bytes → `None`.
-- `test_decode_home_algicide_pump_running` — covers [Issue #115](https://github.com/hopkins-tk/home-assistant-aseko-local/issues/115): the `algicide_pump_running` binary sensor is now correctly registered.
 
 ## Open Items
 
-| # | Status | Description |
-|---|--------|-------------|
-| 3 | Pending | `required_water_temperature` vs app "---" — need normal-operation frame (heating is disabled on this device; only a frame from a pool with heating enabled can confirm byte[55]) |
-| 4 | ✅ Resolved | Filtration NONSTOP 24H flag byte — confirmed as `byte[37] == 0x43` (Issue #110, **firmware A**) |
-| 5 | ✅ Resolved | `flowrate_algicide` byte position — confirmed as `byte[103]` on HOME (Issue #115) |
-| 6 | ✅ Resolved | **Second HOME v7 byte 37 encoding (firmware B)** — see Issue 6 above. New `AsekoFiltrationMode` enum + `filtration_mode` enum sensor + manual-OFF short-circuit for `filtration_pump_running` (Issue #133). |
-| 7 | New | `byte[29]` bit masks for HOME pumps remain **unconfirmed** — see §"Actuator byte[29] — HOME masks (uncertain)" above. The masks in `ACTUATOR_MASKS[HOME]` are placeholders matching OXY/NET. Capturing frames with a single HOME pump running (e.g. algicide only) would pin down the per-pump bit. Until then, both `algicide_pump_running` and `floc_pump_running` may report incorrectly on HOME when the corresponding pump is active. |
-| 8 | New | `max_filling_time` overlap with `flowrate_ph_minus` (both use byte[95]) — see note in Segment 3 below. If byte[94] ever becomes non-zero, `max_filling_time` is inflated. Only a frame with a non-zero byte[94] would prove or disprove the assumption. |
-| 9 | New | `heating_active` binary sensor (byte[29] bit 0x04) — added for [Issue #115](https://github.com/hopkins-tk/home-assistant-aseko-local/issues/115) "Entities for heating are not there" request. Mapping is the same as JS-DE-Tech's `relay_byte` bit 2. **Live confirmation pending** — needs a frame captured while the heat pump / electric heater is actually running. Currently it cannot be distinguished from the unconfirmed HOME pump-bit masks. |
-| 10 | New | Bytes 31, 38, 65 in the firmware B OFF frame all rise by ~1 (0x00→0x02, 0x02→0x03, 0xa3→0xa4) — possible additional "manual override active" sub-flags, not used by the decoder today. Single observation, no meaning assigned. |
+| # | Description |
+|---|-------------|
+| 3 | `required_water_temperature` vs app "---" — need a normal-operation frame from a pool with heating enabled to confirm `byte[55]` mapping. |
+| 7 | `byte[29]` per-pump bits for HOME (algicide, flocculant, cl, pH−) are unconfirmed. The masks in `ACTUATOR_MASKS[HOME]` are placeholders matching OXY/NET. Capturing frames with a single HOME pump running (e.g. algicide only) would pin down the per-pump bit. Until then, `algicide_pump_running` and `floc_pump_running` may report incorrectly on HOME. |
+| 8 | `max_filling_time` overlap with `flowrate_ph_minus` (both use `byte[95]`). If `byte[94]` ever becomes non-zero, `max_filling_time` is inflated. Only a frame with a non-zero `byte[94]` would prove or disprove the assumption. |
+| 9 | `heating_active` binary sensor (`byte[29]` bit `0x04`) — needs a frame captured while the heat pump / electric heater is actually running. Currently it cannot be distinguished from the unconfirmed HOME pump-bit masks (Open Item 7). |
+| 10 | Bytes 31, 38, 65 in the firmware B OFF frame all rise by ~1 (0x00→0x02, 0x02→0x03, 0xa3→0xa4) — possible additional "manual override active" sub-flags, not used by the decoder today. Single observation, no meaning assigned. |
+
+---
+
+## Test Coverage
+
+Tests for the HOME decoder live in `tests/test_aseko_decoder.py`:
+
+| Test | Covers |
+|------|--------|
+| `test_decode_home` | End-to-end HOME REDOX frame decoding, including schedule + max_filling_time |
+| `test_decode_home_clf_real_frame` | Issue #110: real HOME CLF frame with `max_filling_time = 60` |
+| `test_decode_home_independent_flowrates` | Issue #115: HOME reads `byte[101]` and `byte[103]` independently of `byte[37]` |
+| `test_decode_home_flowrates_unspecified` | 0xFF on flowrate bytes → `None` (pump not installed) |
+| `test_decode_home_algicide_pump_running` | Issue #115: `algicide_pump_running` binary sensor is registered |
+| `test_decode_home_floc_pump_running_independent` | HOME reports `floc_pump_running` correctly when only floc pump is installed |
+| `test_filtration_mode_new_encoding_24h` | Issue #133 firmware B: `byte[37]=0x01` → `NONSTOP_24H` |
+| `test_filtration_mode_new_encoding_p1` | Issue #133 firmware B: `byte[37]=0x11` → `TIMER_PERIOD_1` |
+| `test_filtration_mode_new_encoding_p1_and_p2` | Issue #133 firmware B: `byte[37]=0x31` → `TIMER_PERIOD_1_AND_2` |
+| `test_filtration_mode_new_encoding_off_manual` | Issue #133 firmware B: `byte[37]=0x35` → `OFF_MANUAL` |
+| `test_filtration_mode_old_encoding_24h` | Issue #110 firmware A: `byte[37]=0x43` → `NONSTOP_24H` |
+| `test_filtration_mode_old_encoding_timer` | Issue #110 firmware A: `byte[37]=0x53` → `TIMER_PERIOD_1_AND_2` |
+| `test_filtration_pump_running_off_when_manual_override` | Issue #133: `byte[37]=0x35` forces `filtration_pump_running=False` |
+| `test_filtration_pump_running_on_when_not_override` | Regression guard: `byte[29]&0x08` still drives the entity outside OFF_MANUAL |
+| `test_filtration_pump_running_not_overridden_on_salt` | Override short-circuit is HOME-only |
 
 ---
 
@@ -358,3 +354,7 @@ if unit.device_type == AsekoDeviceType.HOME:
 - Actuator masks: `custom_components/aseko_local/aseko_data.py` → `ACTUATOR_MASKS[AsekoDeviceType.HOME]`
 - OXY analysis (reference for shared byte layout): `docs/device analyzes/oxy_device_analysis.md`
 - NET v8 analysis: `docs/device analyzes/net_v8_device_analysis.md`
+- Issue #110: byte[37] firmware A (`0x43` = nonstop 24h) — original finding, frames in this file
+- Issue #115: HOME `algicide_pump_running` missing — fixed by independent-pump-port branch
+- Issue #133: byte[37] firmware B (4-state mode + manual OFF) — fixed by `_fill_filtration_mode` rewrite
+- Working notes: `docs/temp/Issue-133.md`

--- a/docs/device analyzes/home_device_analysis.md
+++ b/docs/device analyzes/home_device_analysis.md
@@ -73,7 +73,7 @@ Seg3 (bytes 80–119): 06 90 6b bf  02 02  1a 04 1c 08 1b 07
 | 16–17   | `0000`   | 0       | Cl free (÷100)           | **0.00 mg/l**        | 0.00 mg/l     | ✓      |
 | 18–19   | `0000`   | 0       | Unused (no REDOX probe)  | —                    | —             | —      |
 | 20–21   | `0002`   | 2       | Cl free mV (big-endian)  | **2 mV**             | —             | ✓      |
-| 22–23   | `90fe`   | 37118   | Unknown (internal probe?) | —                   | —             | ?      |
+| 22–23   | `90fe`   | 37118   | Unknown / VSP pump (see ¶) | —                 | —             | ¶      |
 | 24      | `70`     | 112     | Unknown                  | —                    | —             | ?      |
 | 25–26   | `017b`   | 379     | Water temp (÷10)         | **37.9°C**           | 38.2°C†       | ✓†     |
 | 27      | `08`     | 8       | **Water level (cm)**     | **8 cm**             | (level meter disabled on this device) | ✓     |
@@ -88,6 +88,8 @@ Seg3 (bytes 80–119): 06 90 6b bf  02 02  1a 04 1c 08 1b 07
 † pH 6.29 vs 6.56 and water temp 37.9 vs 38.2 are explained by different timestamps (frame: 08:27:07, screenshot: later that day). Not a decoding bug.
 
 § **byte[37] = `0x43`**: HOME filtration mode flag, firmware A. The value `0x43` means *FILTRATION NONSTOP 24H* here. HOME devices have **independent pump ports** for flocculant and algicide (same layout as OXY Pure), so the SALT-style "shared third-pump port" routing rule (bit 7 = algicide) does **not** apply. The full encoding table (firmware A vs B) is in the *Device Specifications → byte[37]* section below.
+
+¶ **byte[22] bit 3 (0x08)**: On devices with a variable-speed filtration pump (serial 110175608 REDOX HOME, Issue #137), `0x83` → pump OFF, `0x8b` → pump ON (any brand). Decoded as `vsp_pump_running` — see *Variable-speed pump* section below. On this CLF frame (no VSP fitted) the byte carries an unknown value (`0x90fe`).
 
 ---
 
@@ -196,6 +198,7 @@ Note on **bytes 94–95**: `max_filling_time` reads bytes[94:96] as a big-endian
 | flowrate_algicide         | 33               | Algicide listed   | ✓ (fixed) |
 | heating_control_enabled   | True / False     | — (app setting)   | ✓ (Issue #135, serial 110175608 REDOX HOME) |
 | antifreeze_enabled        | True / False     | — (app setting)   | ✓ (Issue #136, serial 110175608 REDOX HOME) |
+| vsp_pump_running          | True / False     | — (app setting)   | ✓ (Issue #137, serial 110175608 REDOX HOME) |
 
 ---
 
@@ -354,6 +357,32 @@ frames — including the OFF frame. The override state lives in `byte[37]` bit 2
 this HOME-only behaviour in `_fill_consumable_data` (see `_fill_filtration_mode`
 in `aseko_decoder.py`).
 
+### `byte[22]` — Variable-speed filtration pump (Issue #137)
+
+Some HOME REDOX devices (serial 110175608) support a variable-speed filtration
+pump. The brand can be configured in the Aseko app (Speck, Pentair, Hayward,
+Dab E.SWIM, Uwe EO PM).
+
+**byte[22] bit 3 (0x08)** reflects the pump ON/OFF state:
+- `0x83` (`1000_0011`) → pump OFF
+- `0x8b` (`1000_1011`) → pump ON (any brand)
+
+The field is decoded as `vsp_pump_running` and gated on `AsekoDeviceType.HOME` in
+`_fill_vsp_pump()` — other device types (SALT, OXY, PROFI, NET) leave it `None`.
+
+**byte[78]** changes with the brand selection but is not a unique brand ID:
+
+| Brand | byte[78] hex | byte[78] dec |
+|-------|--------------|--------------|
+| OFF / Speck / Uwe EO PM | `0x22` | 34 |
+| Pentair / Dab E.SWIM | `0x26` | 38 |
+| Hayward | `0x2a` | 42 |
+
+Speck and Uwe share the same value as OFF, suggesting byte[78] is a
+**pump parameter** (speed/power class) rather than a brand identifier. The
+brand selection itself may be stored only in the Aseko cloud/app, not in the
+120-byte frame — see Open Item 11.
+
 ---
 
 ## Open Items
@@ -365,6 +394,7 @@ in `aseko_decoder.py`).
 | 8 | `max_filling_time` overlap with `flowrate_ph_minus` (both use `byte[95]`). If `byte[94]` ever becomes non-zero, `max_filling_time` is inflated. Only a frame with a non-zero `byte[94]` would prove or disprove the assumption. |
 | 9 | `heating_active` binary sensor (`byte[29]` bit `0x04`) — needs a frame captured while the heat pump / electric heater is actually running. The `heating_control_enabled` field (byte[37] bit 3) is the **master enable**, separate from the actual heating output state in byte[29] bit 2. A frame with `byte[29]` bit 2 set would confirm this as the running-state indicator. |
 | 10 | Bytes 31, 38, 65 in the firmware B OFF frame all rise by ~1 (0x00→0x02, 0x02→0x03, 0xa3→0xa4) — possible additional "manual override active" sub-flags, not used by the decoder today. Single observation, no meaning assigned. |
+| 11 | `byte[78]` pump brand correlation (Issue #137): Speck and Uwe EO PM share `0x22` (same as OFF), Pentair and Dab E.SWIM share `0x26`. Needs a diagnostic captured while switching between two same-value brands (e.g. Speck → Uwe) without turning the pump off to confirm whether byte[78] is a brand ID or a pump parameter. |
 
 ---
 
@@ -411,4 +441,7 @@ Tests for the HOME decoder live in `tests/test_aseko_decoder.py`:
   Working notes: [docs/temp/Issue-135.md](../temp/Issue-135.md).
 - Issue #136: `byte[37]` bit 7 (`0x80`) = antifreeze master enable on HOME firmware A
   (same device). `byte[55]` shows the antifreeze threshold (4°C) when enabled.
+- Issue #137: `byte[22]` bit 3 (`0x08`) = variable-speed pump running state on HOME.
+  `byte[78]` changes with pump brand selection (Speck/Pentair/Hayward/Dab/Uwe) but
+  is not a unique brand ID — see Open Item 11.
 - Working notes: `docs/temp/Issue-133.md`

--- a/docs/device analyzes/home_device_analysis.md
+++ b/docs/device analyzes/home_device_analysis.md
@@ -153,7 +153,9 @@ Seg3 (bytes 80–119): 06 90 6b bf  02 02  1a 04 1c 08 1b 07
 | 106–107 | `00f0`   | 240     | delay_after_dose (s)         | **240 s = 4 min** | 4 min          | ✓      |
 | 108     | `14`     | 20      | Unknown                      | —              | —                 | ?      |
 | 109–110 | `0258`   | 600     | Unknown                      | —              | —                 | ?      |
-| 111–113 | `0f 0f 0f` | 15, 15, 15 | Unknown                | —              | —                 | ?      |
+| 111     | `0f`     | 15      | Unknown                      | —              | —                 | ?      |
+| 112     | `0f`     | 15      | **ph_minus_concentration**   | **5%**         | **5%**           | ✓ (Issue #139) |
+| 113     | `0f`     | 15      | Unknown                      | —              | —                 | ?      |
 | 114     | `1e`     | 30      | Unknown                      | —              | —                 | ?      |
 | 115     | `14`     | 20      | Unknown                      | —              | —                 | ?      |
 | 116     | `ff`     | —       | UNSPECIFIED / padding        | —              | —                 | —      |
@@ -199,6 +201,7 @@ Note on **bytes 94–95**: `max_filling_time` reads bytes[94:96] as a big-endian
 | heating_control_enabled   | True / False     | — (app setting)   | ✓ (Issue #135, serial 110175608 REDOX HOME) |
 | antifreeze_enabled        | True / False     | — (app setting)   | ✓ (Issue #136, serial 110175608 REDOX HOME) |
 | vsp_pump_running          | True / False     | — (app setting)   | ✓ (Issue #137, serial 110175608 REDOX HOME) |
+| ph_minus_concentration    | 5%               | 5%                | ✓ (Issue #139, serial 110175608 REDOX HOME) |
 
 ---
 
@@ -231,6 +234,7 @@ routing via `byte[37]` bit 7.
 | `required_floc`         | `byte[54]`| ml/h              | Same byte position as SALT algicide; gated by `byte[37] != 0xFF` |
 | `required_algicide`     | `byte[72]`| ml/m³/day         | HOME-only, same byte position as OXY Pure |
 | `required_water_temperature` | `byte[55]` | °C            | Disabled on this device — see Open Item 3 |
+| `ph_minus_concentration`     | `byte[112]`| %             | pH⁻ acid concentration (Issue #139). HOME-only — gated on device type. |
 
 ### Schedule (bytes 56-63)
 
@@ -444,4 +448,6 @@ Tests for the HOME decoder live in `tests/test_aseko_decoder.py`:
 - Issue #137: `byte[22]` bit 3 (`0x08`) = variable-speed pump running state on HOME.
   `byte[78]` changes with pump brand selection (Speck/Pentair/Hayward/Dab/Uwe) but
   is not a unique brand ID — see Open Item 11.
+- Issue #139: `byte[112]` = pH⁻ acid concentration (%) on HOME (serial 110175608).
+  Confirmed 5% → 10% → 5% across three diagnostics.
 - Working notes: `docs/temp/Issue-133.md`

--- a/docs/device analyzes/home_device_analysis.md
+++ b/docs/device analyzes/home_device_analysis.md
@@ -275,7 +275,7 @@ firmware B: serial 110169464, byte 4 = 0x03 — see [Issue #133](../temp/Issue-1
   `heating_control_enabled` is decoded separately from bit 3 (`0x08`).
 
 ‡ When antifreeze is ON, `byte[55]` drops from the normal heating setpoint
-  (25°C in dtpugh's case) to the antifreeze minimum temperature (4°C).
+  (eg. 27°C) to the antifreeze setpoint (e.g. 4°C, 5°C or 9°C whatever user sets).
   `antifreeze_enabled` is decoded from bit 7 (`0x80`), independent of
   `heating_control_enabled` (bit 3).
 
@@ -318,8 +318,8 @@ Filtration mode decoding on firmware A:
 - **Heating control**: bit 3 (`0x08`) is gated on `AsekoDeviceType.HOME` in
   `_fill_heating_demand()` and decoded into `heating_control_enabled`.
 - **Antifreeze**: bit 7 (`0x80`) is decoded as `antifreeze_enabled` (Issue #136).
-  When active, `byte[55]` holds the antifreeze threshold (4°C) instead of the
-  normal heating setpoint.
+  When active, `byte[55]` holds the antifreeze setpoint (e.g. 4°C, 5°C, 9°C)
+  instead of the normal heating setpoint.
 
 **Note on `0x43` (firmware A)**: treat this as "consistent with NONSTOP 24H" rather
 than "confirmed NONSTOP 24H active". A frame captured in May 2026 from
@@ -482,7 +482,8 @@ Tests for the HOME decoder live in `tests/test_aseko_decoder.py`:
   (serial 110175608, REDOX HOME). Confirms `byte[55]` as target water temp setpoint.
   Working notes: [docs/temp/Issue-135.md](../temp/Issue-135.md).
 - Issue #136: `byte[37]` bit 7 (`0x80`) = antifreeze master enable on HOME firmware A
-  (same device). `byte[55]` shows the antifreeze threshold (4°C) when enabled.
+  (same device). `byte[55]` shows the antifreeze setpoint (e.g. 4°C, 5°C, 9°C)
+  when enabled.
 - Issue #137: `byte[22]` bit 3 (`0x08`) = variable-speed pump running state on HOME.
   `byte[78]` changes with pump brand selection (Speck/Pentair/Hayward/Dab/Uwe) but
   is not a unique brand ID — see Open Item 11.

--- a/docs/device analyzes/home_device_analysis.md
+++ b/docs/device analyzes/home_device_analysis.md
@@ -67,8 +67,8 @@ Seg3 (bytes 80–119): 06 90 6b bf  02 02  1a 04 1c 08 1b 07
 | 4       | `02`     | 2       | Device type              | HOME (CLF variant)   | —             | ✓      |
 | 5       | `01`     | 1       | Segment marker           | Segment 1            | —             | ✓      |
 | 6–11    | `1a 04 1c 08 1b 07` | — | Timestamp           | 2026-04-28 08:27:07  | —             | ✓      |
-| 12      | `00`     | 0       | Unknown                  | —                    | —             | ?      |
-| 13      | `28`     | 40      | Unknown                  | —                    | —             | ?      |
+| 12      | `00`     | 0       | **Dosing-warning bitmask** (`0x20`=disinfection, `0x40`=pH) | none           | —             | ✓ (Issue #134/#151) |
+| 13      | `28`     | 40      | **Alarm bitmask** (`0x01`=disinfection, `0x02`=pH, `0x04`=no flow, `0x08`=rapid pH) | low nibble `0x08` set → rapid-pH flag (unconfirmed) | — | ✓ (Issue #151) |
 | 14–15   | `0275`   | 629     | pH (÷100)                | **6.29**             | 6.56†         | ✓†     |
 | 16–17   | `0000`   | 0       | Cl free (÷100)           | **0.00 mg/l**        | 0.00 mg/l     | ✓      |
 | 18–19   | `0000`   | 0       | Unused (no REDOX probe)  | —                    | —             | —      |
@@ -163,6 +163,37 @@ Seg3 (bytes 80–119): 06 90 6b bf  02 02  1a 04 1c 08 1b 07
 | 118–119 | `0271`   | 625     | Unknown (checksum?)          | —              | —                 | ?      |
 
 Note on **bytes 94–95**: `max_filling_time` reads bytes[94:96] as a big-endian 16-bit value = `0x003c` = 60. `flowrate_ph_minus` independently reads byte[95] = `0x3c` = 60. They overlap but coincidentally produce the same result because the high byte (94) is 0x00. If byte[94] ever becomes non-zero the max_filling_time would be inflated; however for HOME this is expected to fit in one byte (max ~255 min).
+
+---
+
+## Dosing warnings & alarms (bytes 12 / 13)
+
+HOME devices report dosing safety faults in two adjacent bytes. The decoder reads
+them for **all** device types (`_fill_alarm_data` in `aseko_decoder.py`):
+
+| Binary sensor | byte[12] bit | byte[13] bit |
+|---|---|---|
+| Too many doses of disinfection (`alarm_orp_too_many_doses`) | `0x20` | `0x01` |
+| Too many doses of pH (`alarm_ph_too_many_doses`) | `0x40` | `0x02` |
+| No flow to probes (`alarm_no_flow_to_probes`) | — | `0x04` |
+| Rapid pH change (`alarm_rapid_ph_change`) | — | `0x08` (unconfirmed) |
+
+Confirmed by @dtpugh's diagnostics on HOME serial 110175608 (byte[4] = `0x03`):
+
+* **Issue #134** (2026-07-05), before/after clearing on the controller: both
+  warnings active → byte[12] = `0x60`; pH only → `0x40`; cleared → `0x00`.
+  byte[13] stayed `0x00`.
+* **Issue #151** (2026-08-06/08): chlorine/disinfection "Maximum disinfection
+  dose exceeded" → byte[13] = `0x01` (byte[12] = `0x00`); pH fault → byte[12] =
+  `0x40`; cleared → both `0x00`.
+
+The disinfection fault was observed in byte[12] `0x20` (July) **and** in byte[13]
+`0x01` (August) — likely a firmware change on the Home. The decoder ORs both
+paths so either encoding is detected. The byte[13] `0x02` = pH mapping is
+**inferred** (symmetric to `0x01`; @dtpugh expected `0x02` for a pH fault) and
+still lacks a direct frame capture. The same disinfection fault maps to `ins[12]`
+bit `0x80` on v8 frames (Issue #151, `aseko_decoder_v8.py`), so both protocols
+share the `alarm_orp_too_many_doses` sensor.
 
 ---
 

--- a/docs/device analyzes/home_device_analysis.md
+++ b/docs/device analyzes/home_device_analysis.md
@@ -482,7 +482,7 @@ Tests for the HOME decoder live in `tests/test_aseko_decoder.py`:
 | `test_filtration_mode_new_encoding_24h` | Issue #133 firmware B: `byte[37]=0x01` → `NONSTOP_24H` |
 | `test_filtration_mode_new_encoding_p1` | Issue #133 firmware B: `byte[37]=0x11` → `TIMER_PERIOD_1` |
 | `test_filtration_mode_new_encoding_p1_and_p2` | Issue #133 firmware B: `byte[37]=0x31` → `TIMER_PERIOD_1_AND_2` |
-| `test_filtration_mode_new_encoding_off_manual` | Issue #133 firmware B: `byte[37]=0x35` → `MANUAL` |
+| `test_filtration_mode_new_encoding_manual_p1_and_p2` | Issue #133 firmware B: `byte[37]=0x35` → `MANUAL` |
 | `test_filtration_mode_old_encoding_24h` | Issue #110 firmware A: `byte[37]=0x43` → `NONSTOP_24H` |
 | `test_filtration_mode_old_encoding_timer` | Issue #110 firmware A: `byte[37]=0x53` → `TIMER_PERIOD_1_AND_2` |
 | `test_filtration_pump_running_off_when_manual_override` | Issue #133: `byte[37]=0x35` forces `filtration_pump_running=False` |

--- a/docs/device analyzes/home_device_analysis.md
+++ b/docs/device analyzes/home_device_analysis.md
@@ -362,7 +362,7 @@ discussion](https://github.com/hopkins-tk/home-assistant-aseko-local/issues/110)
 bit 3 (`filtration_pump_running`) is still set in the frame — the firmware does
 not clear the schedule-driven bit on manual override. The decoder compensates
 by short-circuiting `filtration_pump_running` to `False` whenever
-`filtration_mode == OFF_MANUAL`. This is a HOME-only behaviour; no SALT/OXY/PROFI
+`filtration_mode == MANUAL`. This is a HOME-only behaviour; no SALT/OXY/PROFI
 OFF frame has been captured yet.
 
 **Note on Period 2 schedule bytes (Issue #133)**: All Aseko devices in
@@ -482,11 +482,11 @@ Tests for the HOME decoder live in `tests/test_aseko_decoder.py`:
 | `test_filtration_mode_new_encoding_24h` | Issue #133 firmware B: `byte[37]=0x01` → `NONSTOP_24H` |
 | `test_filtration_mode_new_encoding_p1` | Issue #133 firmware B: `byte[37]=0x11` → `TIMER_PERIOD_1` |
 | `test_filtration_mode_new_encoding_p1_and_p2` | Issue #133 firmware B: `byte[37]=0x31` → `TIMER_PERIOD_1_AND_2` |
-| `test_filtration_mode_new_encoding_off_manual` | Issue #133 firmware B: `byte[37]=0x35` → `OFF_MANUAL` |
+| `test_filtration_mode_new_encoding_off_manual` | Issue #133 firmware B: `byte[37]=0x35` → `MANUAL` |
 | `test_filtration_mode_old_encoding_24h` | Issue #110 firmware A: `byte[37]=0x43` → `NONSTOP_24H` |
 | `test_filtration_mode_old_encoding_timer` | Issue #110 firmware A: `byte[37]=0x53` → `TIMER_PERIOD_1_AND_2` |
 | `test_filtration_pump_running_off_when_manual_override` | Issue #133: `byte[37]=0x35` forces `filtration_pump_running=False` |
-| `test_filtration_pump_running_on_when_not_override` | Regression guard: `byte[29]&0x08` still drives the entity outside OFF_MANUAL |
+| `test_filtration_pump_running_on_when_not_override` | Regression guard: `byte[29]&0x08` still drives the entity outside MANUAL |
 | `test_filtration_pump_running_not_overridden_on_salt` | Override short-circuit is HOME-only |
 | `test_decode_filtration_period2_disabled` | Issue #133: bytes 60-63 stay populated; mode flips to `TIMER_PERIOD_1` |
 | `test_decode_filtration_period2_bytes_unspecified` | Issue #133: bytes 60-63 = 0xFF → `start2`/`stop2` = `None` (entity skipped) |

--- a/docs/device analyzes/net_device_analysis.md
+++ b/docs/device analyzes/net_device_analysis.md
@@ -91,6 +91,8 @@ This is different from SALT where `byte[20]` = salinity and `byte[21]` = electro
 | `[4]` | Unit type + probe flags | `0x09` typical |
 | `[5]` | Sub-frame type `0x01` | |
 | `[6:12]` | Timestamp | **Always `0xFF` on NET** — decoder falls back to `now()` |
+| `[12]` | Dosing-warning bitmask | Usually `0x00` on NET — see [`home_device_analysis.md`](home_device_analysis.md) §"Dosing warnings & alarms" |
+| `[13]` | Alarm bitmask | `0x04` = no flow to probes (confirmed on NET); see § above |
 | `[14:16]` | pH = value / 100 | |
 | `[16:18]` | CLF = value / 100 (mg/L) | |
 | `[20:22]` | cl_free_mv (mV, signed) | NET-specific; SALT uses `[20]` for salinity |

--- a/docs/device analyzes/oxy_device_analysis.md
+++ b/docs/device analyzes/oxy_device_analysis.md
@@ -188,6 +188,12 @@ On OXY, `0x03` has neither `0x80` nor `0x10` set — the SALT routing logic does
 **Implementation**: for `AsekoDeviceType.OXY`, do not apply the `ALGICIDE_CONFIGURED` byte[37]
 routing. Both flowrate_algicide and flowrate_floc are read from their own dedicated bytes.
 
+Since Issue #133 the decoder also reads the 4-state filtration mode directly
+from `byte[37]` for every `FILTRATION_TYPES` device (OXY included), using the
+same firmware A/B encodings as HOME — see
+[`home_device_analysis.md`](home_device_analysis.md) §"byte[37] – Filtration
+mode flag".
+
 ---
 
 ## CLF/REDOX Sentinel Analysis
@@ -260,8 +266,9 @@ since it exposes a filtration output).  The lazy-creation guard in
 only if the bytes are `0xFF` (the bytes have never been configured on the
 controller).  Once the entity is registered, it stays populated with the
 last-configured time even when the user disables Period 2 — the
-`filtration_mode` sensor separately reports `TIMER_PERIOD_1` so the user
-knows the schedule is inactive.
+`filtration_mode` sensor (decoded from the `byte[37]` filtration-mode flag)
+separately reports `TIMER_PERIOD_1` so the user knows the schedule is
+inactive.
 
 NET is excluded because it has no filtration output at all and is not in
 `FILTRATION_TYPES`.

--- a/docs/device analyzes/oxy_device_analysis.md
+++ b/docs/device analyzes/oxy_device_analysis.md
@@ -79,8 +79,8 @@ Checksum bytes (39, 79, 119) and timestamp second (byte[11]) change as expected.
 | `[55]` | `0x19` = 25 | Required water temp = 25 °C | |
 | `[56:58]` | `08 00` | Filtration start1 = 08:00 | |
 | `[58:60]` | `10 00` | Filtration stop1 = 16:00 | |
-| `[60:62]` | `12 00` | Filtration start2 = 18:00 | |
-| `[62:64]` | `16 00` | Filtration stop2 = 22:00 | |
+| `[60:62]` | `12 00` | Filtration start2 = 18:00 | Always populated — see Issue #133 |
+| `[62:64]` | `16 00` | Filtration stop2 = 22:00 | Always populated — see Issue #133 |
 | `[68]` | `0x00` | Backwash every N days = 0 (disabled) | |
 | `[69:71]` | `0c 1e` | Backwash time = 12:30 | |
 | `[71]` | `0x0a` | Backwash duration = 100 s | ×10 |
@@ -239,6 +239,30 @@ All flowrate bytes on OXY use the same unit: **ml/min**.
 | `[103]` | 60 | Algicide | 60 ml/min ✓ confirmed 2026-04-11 |
 
 ---
+
+## Period 2 schedule bytes (Issue #133)
+
+Like SALT and HOME, the OXY controller keeps sending the last-configured
+`start2`/`stop2` times in bytes 60-63 even after the user disables Period 2 in
+the controller UI.  This was first verified on SALT (PR #122 frame diff) and
+on HOME (Issue #133 diagnostic files from @dtpugh, serial 110169464, firmware
+B).  The same protocol behaviour is assumed for OXY because OXY shares the
+SALT/HOME byte layout for the filtration schedule — no protocol-level
+reason exists to believe the OXY firmware clears the bytes when Period 2 is
+disabled.
+
+**Decoder behaviour** (post Issue #133 fix): the decoder reads bytes 60-63
+unconditionally for any device in `FILTRATION_TYPES` (which includes OXY
+since it exposes a filtration output).  The lazy-creation guard in
+`sensor.py` skips the `filtration_2_start` / `filtration_2_stop` entities
+only if the bytes are `0xFF` (the bytes have never been configured on the
+controller).  Once the entity is registered, it stays populated with the
+last-configured time even when the user disables Period 2 — the
+`filtration_mode` sensor separately reports `TIMER_PERIOD_1` so the user
+knows the schedule is inactive.
+
+NET is excluded because it has no filtration output at all and is not in
+`FILTRATION_TYPES`.
 
 ## Issue: `raise ValueError` Closes the TCP Connection
 

--- a/docs/device analyzes/oxy_device_analysis.md
+++ b/docs/device analyzes/oxy_device_analysis.md
@@ -60,6 +60,8 @@ Checksum bytes (39, 79, 119) and timestamp second (byte[11]) change as expected.
 | `[4]` | `0x05` | Unit type / probe flags | **OXY-specific, see below** |
 | `[5]` | `0x01` | Sub-frame type | |
 | `[6:12]` | `1a 04 02 17 15 0a` | 2026-04-02 23:21:10 | Device clock desynchronised from server |
+| `[12]` | `00` | 0 | Dosing-warning bitmask — see [`home_device_analysis.md`](home_device_analysis.md) §"Dosing warnings & alarms" |
+| `[13]` | `00` | 0 | Alarm bitmask (`0x01`=disinfection, `0x02`=pH, `0x04`=no flow) — see § above |
 | `[14:16]` | `02 cd` | pH = 7.17 | ÷100 |
 | `[16:18]` | `00 1e` | CLF slot = 30 → 0.30 | **Placeholder, see §CLF/REDOX** |
 | `[18:20]` | `00 1e` | REDOX slot = 30 mV | **Placeholder, see §CLF/REDOX** |

--- a/docs/device analyzes/profi_device_analysis.md
+++ b/docs/device analyzes/profi_device_analysis.md
@@ -78,6 +78,8 @@ All PROFI frames are 120 bytes, split into three 40-byte sub-frames:
 | `[4]` | Unit type = `0x10` | ✅ certain | See note on PROFI identification above |
 | `[5]` | Sub-frame type `0x01` | assumed | Not validated against a real PROFI frame |
 | `[6:12]` | Timestamp | assumed | |
+| `[12]` | Dosing-warning bitmask | assumed | See [`home_device_analysis.md`](home_device_analysis.md) §"Dosing warnings & alarms" |
+| `[13]` | Alarm bitmask (`0x01`=disinfection, `0x02`=pH, `0x04`=no flow) | assumed | See § above |
 | `[14:16]` | pH = value / 100 | assumed | PROFI has a pH probe (per manual) |
 | `[16:18]` | CLF free chlorine (mg/L) if CLF probe present | assumed | PROFI supports CLF |
 | `[18:20]` | REDOX (mV) — same byte on PROFI when both CLF and REDOX are installed | assumed | `_fill_redox_data` already special-cases this (reads 16:18 if 18:19 is `0xFFFF`, else 18:20) |
@@ -248,8 +250,10 @@ same byte positions as HOME/SALT/OXY:
 - `byte[68]` = backwash every N days
 - `byte[69:71]` = backwash time (HH:MM)
 - `byte[71]` = backwash duration (× 10 s)
-- `byte[12]` = backwash active flag (combined with byte[29] bit 0x01 for water-filling
-  state — see [`backwash_tracker.py`](../../custom_components/aseko_local/backwash_tracker.py))
+- `byte[29]` bit `0x01` = backwash relay active (combined with `byte[29]` bit `0x02`
+  for the water-filling state — see [`backwash_tracker.py`](../../custom_components/aseko_local/backwash_tracker.py)).
+  Note: byte[12] is **not** the backwash flag — it is the dosing-warning bitmask
+  (see [`home_device_analysis.md`](home_device_analysis.md) §"Dosing warnings & alarms").
 
 `last_backwash` and `next_backwash` are derived (not from raw bytes) and depend on the
 [`BackwashTracker`](../../custom_components/aseko_local/backwash_tracker.py) state

--- a/docs/device analyzes/profi_device_analysis.md
+++ b/docs/device analyzes/profi_device_analysis.md
@@ -88,7 +88,7 @@ All PROFI frames are 120 bytes, split into three 40-byte sub-frames:
 | `[27]` | **Water level (cm)** | ⚠️ hypothesis | See §"Water level & refill valve" below |
 | `[28]` | Water flow to probes (`0xAA` = flowing) | assumed | |
 | `[29]` | Actuator bitmask | assumed structure | See §"byte[29] – Actuator Bitmask" below |
-| `[37]` | **Not used for routing on PROFI** (`byte37_routes_pump_type = False`) | ✅ certain | PROFI has 5 independent pump ports |
+| `[37]` | **Not used for routing on PROFI** (`byte37_routes_pump_type = False`); also carries the filtration-mode flag since Issue #133 | ✅ certain (routing); ⚠️ assumed (filtration mode) | PROFI has 5 independent pump ports; no live PROFI frame captured yet |
 
 ---
 
@@ -140,8 +140,9 @@ since it exposes a filtration output).  The lazy-creation guard in
 only if the bytes are `0xFF` (the bytes have never been configured on the
 controller).  Once the entity is registered, it stays populated with the
 last-configured time even when the user disables Period 2 — the
-`filtration_mode` sensor separately reports `TIMER_PERIOD_1` so the user
-knows the schedule is inactive.
+`filtration_mode` sensor (decoded from the `byte[37]` filtration-mode flag)
+separately reports `TIMER_PERIOD_1` so the user knows the schedule is
+inactive.
 
 NET is excluded because it has no filtration output at all and is not in
 `FILTRATION_TYPES`.

--- a/docs/device analyzes/profi_device_analysis.md
+++ b/docs/device analyzes/profi_device_analysis.md
@@ -90,6 +90,66 @@ All PROFI frames are 120 bytes, split into three 40-byte sub-frames:
 
 ---
 
+## Byte Map – Sub-frame 2 (config / setpoints, assumed)
+
+> **All byte positions below are assumed to match HOME/SALT/OXY until a real PROFI
+> frame is captured.** The assumption is based on the Aseko Profi manual
+> describing identical filtration + backwash + dosing functions and on the
+> fact that all other ASIN AQUA v7 units share this byte layout. No live
+> PROFI frame has been decoded against this table.
+
+| Byte(s) | Decoded | Confidence | Notes |
+|---|---|---|---|
+| `[52]` | Required pH = value / 10 | assumed | Same as SALT |
+| `[53]` | Required CLF (mg/L ÷10) or REDOX (raw mV) | assumed | Depends on active probe (see PROFI `required_*` table below) |
+| `[54]` | Required algicide / floc setpoint | assumed | PROFI has 5 independent pump ports — the OXY/HOME byte[72] layout may or may not apply; see Open Question #3 |
+| `[55]` | Required water temperature (°C) | assumed | Same as HOME |
+| `[56:58]` | Filtration start1 | assumed | HH:MM; gated on `FILTRATION_TYPES` |
+| `[58:60]` | Filtration stop1 | assumed | HH:MM; gated on `FILTRATION_TYPES` |
+| `[60:62]` | Filtration start2 | assumed | HH:MM; always populated — see Issue #133 below |
+| `[62:64]` | Filtration stop2 | assumed | HH:MM; always populated — see Issue #133 below |
+| `[68]` | Backwash every N days | assumed | `0` = disabled (matches HOME/SALT/OXY) |
+| `[69:71]` | Backwash time | assumed | HH:MM |
+| `[71]` | Backwash duration | assumed | ×10 seconds |
+| `[72]` | Required algicide (ml/m³/day) | ⚠️ hypothesis | May match OXY/HOME layout — see Open Question #3 |
+
+---
+
+## Period 2 schedule bytes (Issue #133)
+
+Like SALT, HOME, and OXY, the PROFI controller is expected to keep sending
+the last-configured `start2`/`stop2` times in bytes 60-63 even after the
+user disables Period 2 in the controller UI.  This was first verified on
+SALT (PR #122 frame diff) and on HOME (Issue #133 diagnostic files from
+@dtpugh, serial 110169464, firmware B).  The same protocol behaviour is
+**assumed** for PROFI because:
+
+1.  PROFI shares the SALT/HOME byte layout for the filtration schedule
+    (bytes 56-63) per the Aseko Profi manual.
+2.  There is no protocol-level reason to believe the PROFI firmware
+    clears the bytes when Period 2 is disabled.
+3.  No live PROFI frame has been captured that toggles Period 2 on/off;
+    the assumption can be re-verified once a real frame is available.
+
+**Decoder behaviour** (post Issue #133 fix): the decoder reads bytes 60-63
+unconditionally for any device in `FILTRATION_TYPES` (which includes PROFI
+since it exposes a filtration output).  The lazy-creation guard in
+`sensor.py` skips the `filtration_2_start` / `filtration_2_stop` entities
+only if the bytes are `0xFF` (the bytes have never been configured on the
+controller).  Once the entity is registered, it stays populated with the
+last-configured time even when the user disables Period 2 — the
+`filtration_mode` sensor separately reports `TIMER_PERIOD_1` so the user
+knows the schedule is inactive.
+
+NET is excluded because it has no filtration output at all and is not in
+`FILTRATION_TYPES`.
+
+See [`home_device_analysis.md`](home_device_analysis.md) §"Note on Period 2
+schedule bytes (Issue #133)" for the full discussion and the diagnostic
+files that proved the behaviour on HOME.
+
+---
+
 ## byte[29] – Actuator Bitmask (assumed)
 
 > **All masks below are placeholders — copied from HOME/OXY because no PROFI frame
@@ -318,3 +378,4 @@ early-return (like OXY and HOME) once the correct byte positions are confirmed.
   after PR #120; was 34 before, then 35 after the water-level blacklist fix)
 - Related water-level analysis: [`water_level_backwash_analysis.md`](../temp/water_level_backwash_analysis.md)
 - Sibling device analyses: [`home_device_analysis.md`](home_device_analysis.md), [`salt_device_analysis.md`](salt_device_analysis.md), [`net_device_analysis.md`](net_device_analysis.md), [`oxy_device_analysis.md`](oxy_device_analysis.md)
+- Issue #133: Period 2 schedule bytes (60-63) are now read unconditionally for any device in `FILTRATION_TYPES` (SALT, HOME, OXY, PROFI) to avoid "unknown" entities when the user toggles the controller.  Same fix applies to PROFI per the assumption above.  See [`home_device_analysis.md`](home_device_analysis.md) §"Note on Period 2 schedule bytes (Issue #133)" for the full discussion.

--- a/docs/device analyzes/salt_device_analysis.md
+++ b/docs/device analyzes/salt_device_analysis.md
@@ -126,8 +126,9 @@ entities to flip to "unknown" when the user toggled Period 2 on/off
 (Home Assistant protects the entity registry, so the entity stays but
 the value is read as `None`).  Post-fix, bytes 60-63 are read
 unconditionally for any device in `FILTRATION_TYPES` (SALT included) and
-`filtration_mode` is derived from `byte[37]` bit 5 (`0x20`) / the schedule
-bytes.  Behaviour was originally verified on SALT by diffing two frames
+`filtration_mode` is decoded directly from the `byte[37]` filtration-mode
+flag (see §byte[37] below).  Behaviour was originally verified on SALT by
+diffing two frames
 captured in PR #122 (algicide mode toggle, `0xb3` ↔ `0x33`); the
 corresponding behaviour for HOME was confirmed in Issue #133 with
 @dtpugh's four diagnostic files (see
@@ -147,6 +148,23 @@ filtration output.
 
 Bit 2 (`0x04`) appears related to dosage encoding. The full semantics of all bits are not
 confirmed.
+
+### byte[37] also carries the filtration-mode flag
+
+Since Issue #133 the decoder reads the 4-state filtration mode directly from
+`byte[37]` for every `FILTRATION_TYPES` device (SALT included), using the same
+two firmware encodings as HOME — see
+[`home_device_analysis.md`](home_device_analysis.md) §"byte[37] – Filtration
+mode flag" for the full table.  In brief:
+
+| `byte[37]` high nibble | Encoding | Filtration mode |
+|---|---|---|
+| `0x4` / `0x5` (firmware A) | exact values | `0x43` → `NONSTOP_24H`, `0x53` → `TIMER_PERIOD_1_AND_2` |
+| `0x0` / `0x1` / `0x3` (firmware B) | bit flags | `0x04` → `MANUAL`; `(b & 0x30)` → `0x00`=`NONSTOP_24H`, `0x10`=`TIMER_PERIOD_1`, `0x30`=`TIMER_PERIOD_1_AND_2` |
+
+Note the overlap with the third-pump routing / dosage encoding above: bit 2
+(`0x04`) is interpreted as the manual-override flag by the filtration-mode
+decode on SALT as well.
 
 ---
 

--- a/docs/device analyzes/salt_device_analysis.md
+++ b/docs/device analyzes/salt_device_analysis.md
@@ -49,6 +49,8 @@ convention, named `PROBE_X_MISSING` in the code).
 | `[4]` | Unit type + probe flags | `0x0E` or `0x0D` |
 | `[5]` | Sub-frame type `0x01` | |
 | `[6:12]` | Timestamp (year−2000, month, day, hour, min, sec) | Device clock |
+| `[12]` | Dosing-warning bitmask | Usually `0x00` on SALT — see [`home_device_analysis.md`](home_device_analysis.md) §"Dosing warnings & alarms" |
+| `[13]` | Alarm bitmask | `0x04` = no flow to probes; see § above |
 | `[14:16]` | pH = value / 100 | |
 | `[16:18]` | CLF or REDOX (probe-dependent) | CLF: `/100` mg/L; REDOX: `×1` mV |
 | `[18:20]` | REDOX (if CLF also present on PROFI-style) | Not applicable on basic SALT |

--- a/docs/device analyzes/salt_device_analysis.md
+++ b/docs/device analyzes/salt_device_analysis.md
@@ -115,6 +115,24 @@ type differently in byte[37].
 firmware versions. See [byte37_algicide_floc_analysis.md](../temp/byte37_algicide_floc_analysis.md) for
 full XOR analysis.
 
+**Note on Period 2 schedule bytes (Issue #133)**: On SALT, the controller keeps
+sending the last-configured `start2`/`stop2` times in bytes 60-63 even after
+the user disables Period 2 in the controller UI.  Pre-fix, the decoder
+gated these fields on `byte[37] & 0x80` and returned `None` for any frame
+where the algicide-routing bit was clear — which caused already-registered
+entities to flip to "unknown" when the user toggled Period 2 on/off
+(Home Assistant protects the entity registry, so the entity stays but
+the value is read as `None`).  Post-fix, bytes 60-63 are read
+unconditionally for any device in `FILTRATION_TYPES` (SALT included) and
+`filtration_mode` is derived from `byte[37]` bit 5 (`0x20`) / the schedule
+bytes.  Behaviour was originally verified on SALT by diffing two frames
+captured in PR #122 (algicide mode toggle, `0xb3` ↔ `0x33`); the
+corresponding behaviour for HOME was confirmed in Issue #133 with
+@dtpugh's four diagnostic files (see
+[`home_device_analysis.md`](home_device_analysis.md) §"Note on Period 2
+schedule bytes (Issue #133)").  NET is excluded because it has no
+filtration output.
+
 ### byte[37] also contains other fields
 
 `byte[37]` is a packed multi-field byte — it is **not** a pure single-bit flag:
@@ -140,8 +158,8 @@ confirmed.
 | `[55]` | Required water temperature (°C) | |
 | `[56:58]` | Filtration start1 | HH:MM |
 | `[58:60]` | Filtration stop1 | HH:MM |
-| `[60:62]` | Filtration start2 | HH:MM |
-| `[62:64]` | Filtration stop2 | HH:MM |
+| `[60:62]` | Filtration start2 | HH:MM | Always populated — see Issue #133 |
+| `[62:64]` | Filtration stop2 | HH:MM | Always populated — see Issue #133 |
 | `[68]` | Backwash every N days | `0` = disabled |
 | `[69:71]` | Backwash time | HH:MM |
 | `[71]` | Backwash duration | ×10 seconds |

--- a/tests/test_aseko_decoder.py
+++ b/tests/test_aseko_decoder.py
@@ -254,8 +254,10 @@ def test_decode_filtration_period2_real_dtpugh_frames() -> None:
                 r = _first_frame(v)
                 if r is not None:
                     return r
-        elif isinstance(payload, str) and len(payload) >= 100 and all(
-            c in "0123456789abcdefABCDEF" for c in payload.strip()
+        elif (
+            isinstance(payload, str)
+            and len(payload) >= 100
+            and all(c in "0123456789abcdefABCDEF" for c in payload.strip())
         ):
             return payload
         return None
@@ -1574,16 +1576,16 @@ def test_filtration_pump_running_off_when_manual_override() -> None:
     for override_value in (0x35, 0x15):
         data = _make_home_bytes()
         data[4] = 0x03  # HOME REDOX (firmware B device)
-        data[29] = 0x08  # schedule-driven output bit SET (would normally mean "running")
+        data[29] = (
+            0x08  # schedule-driven output bit SET (would normally mean "running")
+        )
         data[37] = override_value  # OFF (manual override)
 
         device = AsekoDecoder.decode(bytes(data))
         assert device.filtration_mode == AsekoFiltrationMode.OFF_MANUAL, (
             f"byte[37]={override_value:#x}"
         )
-        assert device.filtration_pump_running is False, (
-            f"byte[37]={override_value:#x}"
-        )
+        assert device.filtration_pump_running is False, f"byte[37]={override_value:#x}"
 
 
 def test_filtration_pump_running_on_when_not_override() -> None:

--- a/tests/test_aseko_decoder.py
+++ b/tests/test_aseko_decoder.py
@@ -1317,10 +1317,28 @@ def test_filtration_mode_new_encoding_p1_and_p2() -> None:
     assert device.filtration_nonstop24 is False
 
 
-def test_filtration_mode_new_encoding_off_manual() -> None:
-    """Firmware B byte[37] = 0x35 → OFF_MANUAL (user toggled OFF on the unit)."""
+def test_filtration_mode_new_encoding_off_manual_p1_and_p2() -> None:
+    """Firmware B byte[37] = 0x35 → OFF_MANUAL (P1 & P2 + manual override).
+
+    The original frame from @dtpugh (serial 110169464) had 0x35: both
+    periods enabled and the user manually toggled filtration OFF.
+    """
     data = _make_home_bytes()
-    data[37] = 0x35  # new encoding: OFF (manual override)
+    data[37] = 0x35  # new encoding: P1 & P2 + manual override (bit 2 set)
+    device = AsekoDecoder.decode(bytes(data))
+    assert device.filtration_mode == AsekoFiltrationMode.OFF_MANUAL
+    assert device.filtration_nonstop24 is False
+
+
+def test_filtration_mode_new_encoding_off_manual_p1_only() -> None:
+    """Firmware B byte[37] = 0x15 → OFF_MANUAL (P1 only + manual override).
+
+    Diagnostic 42 from @dtpugh (serial 110175608): user switched pump OFF
+    while only Period 1 was active. byte[37] = 0x15 (bits 0,2,4 set).
+    Bit 2 (0x04) = manual override → must decode as OFF_MANUAL.
+    """
+    data = _make_home_bytes()
+    data[37] = 0x15  # P1 + manual override
     device = AsekoDecoder.decode(bytes(data))
     assert device.filtration_mode == AsekoFiltrationMode.OFF_MANUAL
     assert device.filtration_nonstop24 is False
@@ -1435,15 +1453,24 @@ def test_filtration_pump_running_off_when_manual_override() -> None:
     The @dtpugh issue: with the user manually switched the pump off, byte[29]
     bit 3 (filtration relay) is still 0x08 in the frame. The decoder trusts
     the explicit OFF_MANUAL flag in byte[37] and forces False.
-    """
-    data = _make_home_bytes()
-    data[4] = 0x03  # HOME REDOX (firmware B device)
-    data[29] = 0x08  # schedule-driven output bit SET (would normally mean "running")
-    data[37] = 0x35  # OFF (manual override)
 
-    device = AsekoDecoder.decode(bytes(data))
-    assert device.filtration_mode == AsekoFiltrationMode.OFF_MANUAL
-    assert device.filtration_pump_running is False
+    Tests both known OFF_MANUAL byte[37] values:
+      - 0x35 = P1 & P2 + manual override (original firmware B frame)
+      - 0x15 = P1 only + manual override (new diagnostic 42, serial 110175608)
+    """
+    for override_value in (0x35, 0x15):
+        data = _make_home_bytes()
+        data[4] = 0x03  # HOME REDOX (firmware B device)
+        data[29] = 0x08  # schedule-driven output bit SET (would normally mean "running")
+        data[37] = override_value  # OFF (manual override)
+
+        device = AsekoDecoder.decode(bytes(data))
+        assert device.filtration_mode == AsekoFiltrationMode.OFF_MANUAL, (
+            f"byte[37]={override_value:#x}"
+        )
+        assert device.filtration_pump_running is False, (
+            f"byte[37]={override_value:#x}"
+        )
 
 
 def test_filtration_pump_running_on_when_not_override() -> None:

--- a/tests/test_aseko_decoder.py
+++ b/tests/test_aseko_decoder.py
@@ -1211,49 +1211,45 @@ def test_water_level_decoded_for_oxy_and_salt() -> None:
         assert device.water_level_high_alarm == 15, f"byte[4]={device_byte:#x}"
 
 
-def test_filtration_nonstop24_none_for_non_home() -> None:
-    """filtration_nonstop24 is None for NET, OXY, SALT when byte[37] has non-mode values.
+def test_filtration_nonstop24_none_for_net() -> None:
+    """filtration_nonstop24 is None for NET only (no filtration output).
 
-    Real-world byte[37] values for these devices:
-      NET = 0xFF (always UNSPECIFIED)
-      OXY = 0x03 (third-pump config, not filtration flag)
-      SALT = 0xb7, 0xb3, 0x37, 0x13 (algicide/floc routing)
-    None of those are 0x43 (nonstop) or 0x53 (timer), so filtration_nonstop24 stays None.
+    Issue #133 follow-up: SALT / OXY / PROFI now also expose a filtration
+    mode. NET is the only AsekoDeviceType that has no filtration output
+    (Issue #66), so the legacy boolean stays None on NET.
     """
-    for device_byte, real_byte37 in (
-        (0x09, 0xFF),  # NET — 0xFF always
-        (0x05, 0x03),  # OXY — third-pump config byte
-        (0x0E, 0xB7),  # SALT — algicide routing
-    ):
-        data = _make_base_bytes()
-        data[4] = device_byte
-        data[37] = real_byte37
+    data = _make_base_bytes()
+    data[4] = 0x09  # NET
+    data[37] = 0xFF  # NET byte 37 is always unspecified
 
-        device = AsekoDecoder.decode(bytes(data))
-        assert device.filtration_nonstop24 is None, (
-            f"byte[4]={device_byte:#x}, byte[37]={real_byte37:#x}"
-        )
+    device = AsekoDecoder.decode(bytes(data))
+    assert device.filtration_nonstop24 is None
 
 
 def test_filtration_nonstop24_decoded_for_all_device_types() -> None:
-    """filtration_nonstop24 is decoded for NET, OXY, SALT when byte[37] = 0x43/0x53.
+    """filtration_nonstop24 mirrors the new 4-state filtration_mode enum.
 
-    Issue #133: the per-device guard was re-introduced. NET, OXY and SALT
-    use byte[37] for entirely different purposes (algicide routing, pump
-    presence, UNSPECIFIED). On those devices the field stays None — only
-    HOME interprets byte[37] as a filtration mode flag.
+    For SALT / OXY / PROFI: the value is derived from the schedule bytes
+    56-63 (no schedule → NONSTOP_24H, otherwise timer with or without P2
+    depending on byte 37 bit 0x20 / start2 presence). With the base test
+    fixture (P1 + P2 schedule, byte 37 bit 0x20 set on SALT 0xb7 via
+    _make_base_bytes default), the legacy boolean reads False.
+
+    For NET: stays None (NET is excluded from FILTRATION_TYPES).
     """
-    for device_byte in (0x09, 0x05, 0x0E):  # NET, OXY, SALT
+    # NET: no filtration output → legacy boolean stays None
+    data = _make_base_bytes()
+    data[4] = 0x09  # NET
+    data[37] = 0xFF
+    assert AsekoDecoder.decode(bytes(data)).filtration_nonstop24 is None
+
+    # SALT / OXY / PROFI: with default schedule (P1 + P2), legacy bool = False
+    for device_byte in (0x0E, 0x05, 0x10):  # SALT, OXY, PROFI
         data = _make_base_bytes()
         data[4] = device_byte
-        data[37] = 0x43
-        assert AsekoDecoder.decode(bytes(data)).filtration_nonstop24 is None, (
-            f"byte[4]={device_byte:#x} (non-HOME: must stay None)"
-        )
-
-        data[37] = 0x53
-        assert AsekoDecoder.decode(bytes(data)).filtration_nonstop24 is None, (
-            f"byte[4]={device_byte:#x} (non-HOME: must stay None)"
+        # keep default schedule + byte[37]
+        assert AsekoDecoder.decode(bytes(data)).filtration_nonstop24 is False, (
+            f"byte[4]={device_byte:#x}"
         )
 
 
@@ -1367,28 +1363,70 @@ def test_filtration_mode_unspecified() -> None:
     assert device.filtration_nonstop24 is None
 
 
-def test_filtration_mode_none_for_non_home() -> None:
-    """filtration_mode stays None for NET, OXY, SALT, PROFI regardless of byte[37].
+def test_filtration_mode_none_for_net() -> None:
+    """filtration_mode stays None for NET — no filtration output (Issue #66).
 
-    These device types use byte[37] for different purposes:
-      SALT: algicide routing (bits 0x10/0x80), observed 0xb7/0xb3/0x37/0x13
-      OXY:  pump-presence bitmap, observed 0x03
-      NET:  always 0xFF
-    Gating on `device_type == HOME` is the only safe interpretation.
+    NET is the only AsekoDeviceType excluded from FILTRATION_TYPES, so the
+    decoder returns without setting filtration_mode. SALT, HOME, OXY and
+    PROFI all populate the field.
     """
-    for device_byte, real_byte37 in (
-        (0x09, 0xFF),  # NET
-        (0x05, 0x03),  # OXY
-        (0x0E, 0xB7),  # SALT
-        (0x10, 0x53),  # PROFI
-    ):
+    data = _make_base_bytes()
+    data[4] = 0x09  # NET CLF
+    data[37] = 0xFF  # NET byte 37 is always unspecified
+    device = AsekoDecoder.decode(bytes(data))
+    assert device.device_type == AsekoDeviceType.NET
+    assert device.filtration_mode is None
+
+
+def test_filtration_mode_derived_for_salt_oxy_profi() -> None:
+    """For SALT / OXY / PROFI the mode is derived from the schedule bytes 56-63.
+
+    The base test fixture has start1 = 08:00 / stop1 = 10:00 / start2 = 14:00 /
+    stop2 = 16:00 (see _make_base_bytes). With both periods set, the derived
+    mode is TIMER_PERIOD_1_AND_2 regardless of the byte[37] value (SALT
+    0xb7, OXY 0x03, PROFI 0x53) — those bits are algicide routing / pump
+    presence / unknown, NOT filtration-mode flags.
+    """
+    for device_byte in (0x0E, 0x05, 0x10):  # SALT, OXY, PROFI
         data = _make_base_bytes()
         data[4] = device_byte
-        data[37] = real_byte37
+        # keep default schedule (08:00, 10:00, 14:00, 16:00) and byte[37]
         device = AsekoDecoder.decode(bytes(data))
-        assert device.filtration_mode is None, (
-            f"byte[4]={device_byte:#x}, byte[37]={real_byte37:#x}"
+        assert device.filtration_mode == AsekoFiltrationMode.TIMER_PERIOD_1_AND_2, (
+            f"byte[4]={device_byte:#x}"
         )
+
+
+def test_filtration_mode_salt_p1_only_when_period2_disabled() -> None:
+    """SALT with byte[37] bit 0x20 clear (period-2 disabled) → TIMER_PERIOD_1.
+
+    Mirrors test_decode_filtration_period2_disabled but checks the new
+    `filtration_mode` enum (not the legacy boolean).
+    """
+    data = _make_base_bytes()
+    data[4] = 0x0E  # SALT
+    data[60:64] = bytes([0xFF, 0xFF, 0xFF, 0xFF])  # no period 2 schedule
+    data[37] = 0x93  # bit 0x20 clear, period 2 disabled
+
+    device = AsekoDecoder.decode(bytes(data))
+    assert device.filtration_mode == AsekoFiltrationMode.TIMER_PERIOD_1
+
+
+def test_filtration_mode_salt_nonstop_when_no_schedule() -> None:
+    """SALT with start1 = 0xFF (no schedule) → NONSTOP_24H.
+
+    Bytes 56-63 are read directly here (this test runs the decoder end-to-end
+    on a SALT fixture, and `_fill_filtration_mode` runs before the schedule
+    is decoded into `unit.start1`).
+    """
+    data = _make_base_bytes()
+    data[4] = 0x0E  # SALT
+    data[56:60] = bytes([0xFF, 0xFF, 0xFF, 0xFF])  # no period 1
+    data[60:64] = bytes([0xFF, 0xFF, 0xFF, 0xFF])  # no period 2
+    data[37] = 0xB7  # SALT algicide routing — irrelevant for mode derivation
+
+    device = AsekoDecoder.decode(bytes(data))
+    assert device.filtration_mode == AsekoFiltrationMode.NONSTOP_24H
 
 
 def test_filtration_pump_running_off_when_manual_override() -> None:
@@ -1421,14 +1459,21 @@ def test_filtration_pump_running_on_when_not_override() -> None:
 
 
 def test_filtration_pump_running_not_overridden_on_salt() -> None:
-    """The OFF_MANUAL short-circuit is gated on HOME — SALT behaviour unchanged."""
+    """The OFF_MANUAL short-circuit is gated on HOME — SALT behaviour unchanged.
+
+    On SALT the override does not apply even if byte[37] is a value that
+    means OFF_MANUAL on HOME (0x35), because SALT uses byte[37] for
+    algicide routing and never reaches the OFF_MANUAL branch.
+    """
     data = _make_base_bytes()
     data[4] = 0x0E  # SALT
     data[29] = 0x08
     data[37] = 0x35  # would be OFF_MANUAL on HOME — irrelevant on SALT
 
     device = AsekoDecoder.decode(bytes(data))
-    assert device.filtration_mode is None  # SALT: never set
+    # SALT byte[37] does not encode OFF_MANUAL → mode is derived from
+    # the schedule (default base fixture: P1 + P2 → TIMER_PERIOD_1_AND_2).
+    assert device.filtration_mode == AsekoFiltrationMode.TIMER_PERIOD_1_AND_2
     assert device.filtration_pump_running is True  # unchanged: byte[29] bit 3 wins
 
 

--- a/tests/test_aseko_decoder.py
+++ b/tests/test_aseko_decoder.py
@@ -157,7 +157,7 @@ def test_decode_filtration_period2_disabled() -> None:
     Post-fix, the bytes 60-63 are read for any device in FILTRATION_TYPES
     because the controller keeps sending the last-configured Period 2 times
     (verified on dtpugh's serial 110169464: bytes 60-63 stay populated in
-    P1 only / P1&P2 / 24h / OFF_MANUAL modes).  The *mode* still flips
+    P1 only / P1&P2 / 24h / MANUAL modes).  The *mode* still flips
     between TIMER_PERIOD_1 and TIMER_PERIOD_1_AND_2 per byte[37] bit 0x20,
     so the user can tell which schedule is active.
     """
@@ -230,7 +230,7 @@ def test_decode_filtration_period2_real_dtpugh_frames() -> None:
     """Issue #133 end-to-end: decode all four real diagnostic frames from
     @dtpugh (serial 110169464, ASIN AQUA Home firmware B) and verify
     Period 2 times are stable across all four modes (P1 only / P1&P2 /
-    24h / OFF_MANUAL).  This is the user-visible regression: pre-fix the
+    24h / MANUAL).  This is the user-visible regression: pre-fix the
     entity would go "unknown" when the user toggled the controller back
     from P1&P2 to P1 only.
     """
@@ -266,7 +266,7 @@ def test_decode_filtration_period2_real_dtpugh_frames() -> None:
         "01_p1only.json": (0x11, AsekoFiltrationMode.TIMER_PERIOD_1),
         "02_p1andp2.json": (0x31, AsekoFiltrationMode.TIMER_PERIOD_1_AND_2),
         "03_24h.json": (0x01, AsekoFiltrationMode.NONSTOP_24H),
-        "04_off.json": (0x35, AsekoFiltrationMode.OFF_MANUAL),
+        "04_off.json": (0x35, AsekoFiltrationMode.MANUAL),
     }
 
     for filename, (expected_b37, expected_mode) in scenarios.items():
@@ -1342,15 +1342,11 @@ def test_filtration_nonstop24_none_for_net() -> None:
 
 
 def test_filtration_nonstop24_decoded_for_all_device_types() -> None:
-    """filtration_nonstop24 mirrors the new 4-state filtration_mode enum.
+    """filtration_nonstop24 mirrors the byte[37] filtration_mode flag for every
+    FILTRATION_TYPES device; NET has no filtration output and stays None.
 
-    For SALT / OXY / PROFI: the value is derived from the schedule bytes
-    56-63 (no schedule → NONSTOP_24H, otherwise timer with or without P2
-    depending on byte 37 bit 0x20 / start2 presence). With the base test
-    fixture (P1 + P2 schedule, byte 37 bit 0x20 set on SALT 0xb7 via
-    _make_base_bytes default), the legacy boolean reads False.
-
-    For NET: stays None (NET is excluded from FILTRATION_TYPES).
+    byte[37] = 0x01 (firmware B "nonstop 24h") → NONSTOP_24H → the legacy
+    boolean reads True on SALT, OXY, PROFI and HOME alike.
     """
     # NET: no filtration output → legacy boolean stays None
     data = _make_base_bytes()
@@ -1358,12 +1354,12 @@ def test_filtration_nonstop24_decoded_for_all_device_types() -> None:
     data[37] = 0xFF
     assert AsekoDecoder.decode(bytes(data)).filtration_nonstop24 is None
 
-    # SALT / OXY / PROFI: with default schedule (P1 + P2), legacy bool = False
-    for device_byte in (0x0E, 0x05, 0x10):  # SALT, OXY, PROFI
+    # SALT / OXY / PROFI / HOME: byte[37] = 0x01 → NONSTOP_24H
+    for device_byte in (0x0E, 0x05, 0x10, 0x03):  # SALT, OXY, PROFI, HOME
         data = _make_base_bytes()
         data[4] = device_byte
-        # keep default schedule + byte[37]
-        assert AsekoDecoder.decode(bytes(data)).filtration_nonstop24 is False, (
+        data[37] = 0x01  # firmware B: nonstop 24h
+        assert AsekoDecoder.decode(bytes(data)).filtration_nonstop24 is True, (
             f"byte[4]={device_byte:#x}"
         )
 
@@ -1433,7 +1429,7 @@ def test_filtration_mode_new_encoding_p1_and_p2() -> None:
 
 
 def test_filtration_mode_new_encoding_off_manual_p1_and_p2() -> None:
-    """Firmware B byte[37] = 0x35 → OFF_MANUAL (P1 & P2 + manual override).
+    """Firmware B byte[37] = 0x35 → MANUAL (P1 & P2 + manual override).
 
     The original frame from @dtpugh (serial 110169464) had 0x35: both
     periods enabled and the user manually toggled filtration OFF.
@@ -1441,21 +1437,21 @@ def test_filtration_mode_new_encoding_off_manual_p1_and_p2() -> None:
     data = _make_home_bytes()
     data[37] = 0x35  # new encoding: P1 & P2 + manual override (bit 2 set)
     device = AsekoDecoder.decode(bytes(data))
-    assert device.filtration_mode == AsekoFiltrationMode.OFF_MANUAL
+    assert device.filtration_mode == AsekoFiltrationMode.MANUAL
     assert device.filtration_nonstop24 is False
 
 
 def test_filtration_mode_new_encoding_off_manual_p1_only() -> None:
-    """Firmware B byte[37] = 0x15 → OFF_MANUAL (P1 only + manual override).
+    """Firmware B byte[37] = 0x15 → MANUAL (P1 only + manual override).
 
     Diagnostic 42 from @dtpugh (serial 110175608): user switched pump OFF
     while only Period 1 was active. byte[37] = 0x15 (bits 0,2,4 set).
-    Bit 2 (0x04) = manual override → must decode as OFF_MANUAL.
+    Bit 2 (0x04) = manual override → must decode as MANUAL.
     """
     data = _make_home_bytes()
     data[37] = 0x15  # P1 + manual override
     device = AsekoDecoder.decode(bytes(data))
-    assert device.filtration_mode == AsekoFiltrationMode.OFF_MANUAL
+    assert device.filtration_mode == AsekoFiltrationMode.MANUAL
     assert device.filtration_nonstop24 is False
 
 
@@ -1511,19 +1507,16 @@ def test_filtration_mode_none_for_net() -> None:
     assert device.filtration_mode is None
 
 
-def test_filtration_mode_derived_for_salt_oxy_profi() -> None:
-    """For SALT / OXY / PROFI the mode is derived from the schedule bytes 56-63.
+def test_filtration_mode_byte37_flags_for_salt_oxy_profi() -> None:
+    """SALT / OXY / PROFI decode the byte[37] mode flag exactly like HOME.
 
-    The base test fixture has start1 = 08:00 / stop1 = 10:00 / start2 = 14:00 /
-    stop2 = 16:00 (see _make_base_bytes). With both periods set, the derived
-    mode is TIMER_PERIOD_1_AND_2 regardless of the byte[37] value (SALT
-    0xb7, OXY 0x03, PROFI 0x53) — those bits are algicide routing / pump
-    presence / unknown, NOT filtration-mode flags.
+    byte[37] = 0x31 (firmware B: P1 & P2) → TIMER_PERIOD_1_AND_2 for every
+    non-NET device type — the flag is not HOME-specific.
     """
     for device_byte in (0x0E, 0x05, 0x10):  # SALT, OXY, PROFI
         data = _make_base_bytes()
         data[4] = device_byte
-        # keep default schedule (08:00, 10:00, 14:00, 16:00) and byte[37]
+        data[37] = 0x31  # firmware B: P1 & P2
         device = AsekoDecoder.decode(bytes(data))
         assert device.filtration_mode == AsekoFiltrationMode.TIMER_PERIOD_1_AND_2, (
             f"byte[4]={device_byte:#x}"
@@ -1545,31 +1538,30 @@ def test_filtration_mode_salt_p1_only_when_period2_disabled() -> None:
     assert device.filtration_mode == AsekoFiltrationMode.TIMER_PERIOD_1
 
 
-def test_filtration_mode_salt_nonstop_when_no_schedule() -> None:
-    """SALT with start1 = 0xFF (no schedule) → NONSTOP_24H.
+def test_filtration_mode_salt_byte37_nonstop() -> None:
+    """SALT decodes NONSTOP_24H from byte[37] = 0x01 even with no schedule.
 
-    Bytes 56-63 are read directly here (this test runs the decoder end-to-end
-    on a SALT fixture, and `_fill_filtration_mode` runs before the schedule
-    is decoded into `unit.start1`).
+    The mode now comes from the byte[37] flag, not from the schedule bytes
+    56-63 (which are 0xFF here and no longer drive the mode).
     """
     data = _make_base_bytes()
     data[4] = 0x0E  # SALT
     data[56:60] = bytes([0xFF, 0xFF, 0xFF, 0xFF])  # no period 1
     data[60:64] = bytes([0xFF, 0xFF, 0xFF, 0xFF])  # no period 2
-    data[37] = 0xB7  # SALT algicide routing — irrelevant for mode derivation
+    data[37] = 0x01  # firmware B: nonstop 24h
 
     device = AsekoDecoder.decode(bytes(data))
     assert device.filtration_mode == AsekoFiltrationMode.NONSTOP_24H
 
 
 def test_filtration_pump_running_off_when_manual_override() -> None:
-    """byte[29] bit 3 stays set in OFF_MANUAL mode, but pump must read as False.
+    """byte[29] bit 3 stays set in MANUAL mode, but pump must read as False.
 
     The @dtpugh issue: with the user manually switched the pump off, byte[29]
     bit 3 (filtration relay) is still 0x08 in the frame. The decoder trusts
-    the explicit OFF_MANUAL flag in byte[37] and forces False.
+    the explicit MANUAL flag in byte[37] and forces False.
 
-    Tests both known OFF_MANUAL byte[37] values:
+    Tests both known MANUAL byte[37] values:
       - 0x35 = P1 & P2 + manual override (original firmware B frame)
       - 0x15 = P1 only + manual override (new diagnostic 42, serial 110175608)
     """
@@ -1582,14 +1574,14 @@ def test_filtration_pump_running_off_when_manual_override() -> None:
         data[37] = override_value  # OFF (manual override)
 
         device = AsekoDecoder.decode(bytes(data))
-        assert device.filtration_mode == AsekoFiltrationMode.OFF_MANUAL, (
+        assert device.filtration_mode == AsekoFiltrationMode.MANUAL, (
             f"byte[37]={override_value:#x}"
         )
         assert device.filtration_pump_running is False, f"byte[37]={override_value:#x}"
 
 
 def test_filtration_pump_running_on_when_not_override() -> None:
-    """Regression guard: outside OFF_MANUAL, byte[29] bit 3 still drives the entity."""
+    """Regression guard: outside MANUAL, byte[29] bit 3 still drives the entity."""
     data = _make_home_bytes()
     data[4] = 0x03
     data[29] = 0x08
@@ -1601,26 +1593,25 @@ def test_filtration_pump_running_on_when_not_override() -> None:
 
 
 def test_filtration_pump_running_not_overridden_on_salt() -> None:
-    """The OFF_MANUAL short-circuit is gated on HOME — SALT behaviour unchanged.
+    """SALT decodes MANUAL from byte[37]=0x35, but the pump override stays
+    HOME-gated.
 
-    On SALT the override does not apply even if byte[37] is a value that
-    means OFF_MANUAL on HOME (0x35), because SALT uses byte[37] for
-    algicide routing and never reaches the OFF_MANUAL branch.
+    The filtration_pump_running short-circuit in _fill_consumable_data only
+    applies to HOME, so on SALT byte[29] bit 3 still drives the entity even
+    though the mode reads MANUAL.
     """
     data = _make_base_bytes()
     data[4] = 0x0E  # SALT
     data[29] = 0x08
-    data[37] = 0x35  # would be OFF_MANUAL on HOME — irrelevant on SALT
+    data[37] = 0x35  # firmware B: P1 & P2 + manual override → MANUAL
 
     device = AsekoDecoder.decode(bytes(data))
-    # SALT byte[37] does not encode OFF_MANUAL → mode is derived from
-    # the schedule (default base fixture: P1 + P2 → TIMER_PERIOD_1_AND_2).
-    assert device.filtration_mode == AsekoFiltrationMode.TIMER_PERIOD_1_AND_2
+    assert device.filtration_mode == AsekoFiltrationMode.MANUAL
     assert device.filtration_pump_running is True  # unchanged: byte[29] bit 3 wins
 
 
 def test_filtration_pump_running_off_when_pump_actually_off() -> None:
-    """byte[29] = 0x00 (no pump running) + OFF_MANUAL → still False (no-op)."""
+    """byte[29] = 0x00 (no pump running) + MANUAL → still False (no-op)."""
     data = _make_home_bytes()
     data[4] = 0x03
     data[29] = 0x00

--- a/tests/test_aseko_decoder.py
+++ b/tests/test_aseko_decoder.py
@@ -7,6 +7,7 @@ import pytest
 from custom_components.aseko_local.aseko_data import (
     AsekoDeviceType,
     AsekoElectrolyzerDirection,
+    AsekoFiltrationMode,
     AsekoProbeType,
 )
 from custom_components.aseko_local.aseko_decoder import AsekoDecoder
@@ -1237,19 +1238,22 @@ def test_filtration_nonstop24_none_for_non_home() -> None:
 def test_filtration_nonstop24_decoded_for_all_device_types() -> None:
     """filtration_nonstop24 is decoded for NET, OXY, SALT when byte[37] = 0x43/0x53.
 
-    The guard was removed — any device reporting 0x43 gets True, 0x53 gets False.
+    Issue #133: the per-device guard was re-introduced. NET, OXY and SALT
+    use byte[37] for entirely different purposes (algicide routing, pump
+    presence, UNSPECIFIED). On those devices the field stays None — only
+    HOME interprets byte[37] as a filtration mode flag.
     """
     for device_byte in (0x09, 0x05, 0x0E):  # NET, OXY, SALT
         data = _make_base_bytes()
         data[4] = device_byte
         data[37] = 0x43
-        assert AsekoDecoder.decode(bytes(data)).filtration_nonstop24 is True, (
-            f"byte[4]={device_byte:#x}"
+        assert AsekoDecoder.decode(bytes(data)).filtration_nonstop24 is None, (
+            f"byte[4]={device_byte:#x} (non-HOME: must stay None)"
         )
 
         data[37] = 0x53
-        assert AsekoDecoder.decode(bytes(data)).filtration_nonstop24 is False, (
-            f"byte[4]={device_byte:#x}"
+        assert AsekoDecoder.decode(bytes(data)).filtration_nonstop24 is None, (
+            f"byte[4]={device_byte:#x} (non-HOME: must stay None)"
         )
 
 
@@ -1285,6 +1289,158 @@ def test_home_filtration_nonstop24() -> None:
 
     data[37] = 0x57  # transitional edit state → None
     assert AsekoDecoder.decode(bytes(data)).filtration_nonstop24 is None
+
+
+# ── Issue #133: HOME v7 firmware B (4-state enum + manual OFF override) ──────
+
+
+def test_filtration_mode_new_encoding_24h() -> None:
+    """Firmware B byte[37] = 0x01 → NONSTOP_24H (serial 110169464)."""
+    data = _make_home_bytes()
+    data[37] = 0x01  # new encoding: nonstop 24h
+    device = AsekoDecoder.decode(bytes(data))
+    assert device.filtration_mode == AsekoFiltrationMode.NONSTOP_24H
+    assert device.filtration_nonstop24 is True  # legacy mirror
+
+
+def test_filtration_mode_new_encoding_p1() -> None:
+    """Firmware B byte[37] = 0x11 → TIMER_PERIOD_1 (P1 only, P2 disabled)."""
+    data = _make_home_bytes()
+    data[37] = 0x11  # new encoding: P1 only
+    device = AsekoDecoder.decode(bytes(data))
+    assert device.filtration_mode == AsekoFiltrationMode.TIMER_PERIOD_1
+    assert device.filtration_nonstop24 is False
+
+
+def test_filtration_mode_new_encoding_p1_and_p2() -> None:
+    """Firmware B byte[37] = 0x31 → TIMER_PERIOD_1_AND_2 (both periods)."""
+    data = _make_home_bytes()
+    data[37] = 0x31  # new encoding: P1 & P2
+    device = AsekoDecoder.decode(bytes(data))
+    assert device.filtration_mode == AsekoFiltrationMode.TIMER_PERIOD_1_AND_2
+    assert device.filtration_nonstop24 is False
+
+
+def test_filtration_mode_new_encoding_off_manual() -> None:
+    """Firmware B byte[37] = 0x35 → OFF_MANUAL (user toggled OFF on the unit)."""
+    data = _make_home_bytes()
+    data[37] = 0x35  # new encoding: OFF (manual override)
+    device = AsekoDecoder.decode(bytes(data))
+    assert device.filtration_mode == AsekoFiltrationMode.OFF_MANUAL
+    assert device.filtration_nonstop24 is False
+
+
+def test_filtration_mode_old_encoding_24h() -> None:
+    """Firmware A byte[37] = 0x43 → NONSTOP_24H (serial 110128063)."""
+    data = _make_home_bytes()
+    data[37] = 0x43
+    device = AsekoDecoder.decode(bytes(data))
+    assert device.filtration_mode == AsekoFiltrationMode.NONSTOP_24H
+    assert device.filtration_nonstop24 is True
+
+
+def test_filtration_mode_old_encoding_timer() -> None:
+    """Firmware A byte[37] = 0x53 → TIMER_PERIOD_1_AND_2 (cannot distinguish P1 vs P1&P2)."""
+    data = _make_home_bytes()
+    data[37] = 0x53
+    device = AsekoDecoder.decode(bytes(data))
+    assert device.filtration_mode == AsekoFiltrationMode.TIMER_PERIOD_1_AND_2
+    assert device.filtration_nonstop24 is False
+
+
+def test_filtration_mode_old_encoding_transitional() -> None:
+    """Firmware A byte[37] = 0x47 / 0x57 → leave as None (transitional edit state)."""
+    for transitional in (0x47, 0x57):
+        data = _make_home_bytes()
+        data[37] = transitional
+        device = AsekoDecoder.decode(bytes(data))
+        assert device.filtration_mode is None
+        assert device.filtration_nonstop24 is None
+
+
+def test_filtration_mode_unspecified() -> None:
+    """byte[37] = 0xFF → None (defensive, also covers NET-like values on HOME)."""
+    data = _make_home_bytes()
+    data[37] = 0xFF
+    device = AsekoDecoder.decode(bytes(data))
+    assert device.filtration_mode is None
+    assert device.filtration_nonstop24 is None
+
+
+def test_filtration_mode_none_for_non_home() -> None:
+    """filtration_mode stays None for NET, OXY, SALT, PROFI regardless of byte[37].
+
+    These device types use byte[37] for different purposes:
+      SALT: algicide routing (bits 0x10/0x80), observed 0xb7/0xb3/0x37/0x13
+      OXY:  pump-presence bitmap, observed 0x03
+      NET:  always 0xFF
+    Gating on `device_type == HOME` is the only safe interpretation.
+    """
+    for device_byte, real_byte37 in (
+        (0x09, 0xFF),  # NET
+        (0x05, 0x03),  # OXY
+        (0x0E, 0xB7),  # SALT
+        (0x10, 0x53),  # PROFI
+    ):
+        data = _make_base_bytes()
+        data[4] = device_byte
+        data[37] = real_byte37
+        device = AsekoDecoder.decode(bytes(data))
+        assert device.filtration_mode is None, (
+            f"byte[4]={device_byte:#x}, byte[37]={real_byte37:#x}"
+        )
+
+
+def test_filtration_pump_running_off_when_manual_override() -> None:
+    """byte[29] bit 3 stays set in OFF_MANUAL mode, but pump must read as False.
+
+    The @dtpugh issue: with the user manually switched the pump off, byte[29]
+    bit 3 (filtration relay) is still 0x08 in the frame. The decoder trusts
+    the explicit OFF_MANUAL flag in byte[37] and forces False.
+    """
+    data = _make_home_bytes()
+    data[4] = 0x03  # HOME REDOX (firmware B device)
+    data[29] = 0x08  # schedule-driven output bit SET (would normally mean "running")
+    data[37] = 0x35  # OFF (manual override)
+
+    device = AsekoDecoder.decode(bytes(data))
+    assert device.filtration_mode == AsekoFiltrationMode.OFF_MANUAL
+    assert device.filtration_pump_running is False
+
+
+def test_filtration_pump_running_on_when_not_override() -> None:
+    """Regression guard: outside OFF_MANUAL, byte[29] bit 3 still drives the entity."""
+    data = _make_home_bytes()
+    data[4] = 0x03
+    data[29] = 0x08
+    data[37] = 0x11  # P1 only — pump should be on per the schedule
+
+    device = AsekoDecoder.decode(bytes(data))
+    assert device.filtration_mode == AsekoFiltrationMode.TIMER_PERIOD_1
+    assert device.filtration_pump_running is True
+
+
+def test_filtration_pump_running_not_overridden_on_salt() -> None:
+    """The OFF_MANUAL short-circuit is gated on HOME — SALT behaviour unchanged."""
+    data = _make_base_bytes()
+    data[4] = 0x0E  # SALT
+    data[29] = 0x08
+    data[37] = 0x35  # would be OFF_MANUAL on HOME — irrelevant on SALT
+
+    device = AsekoDecoder.decode(bytes(data))
+    assert device.filtration_mode is None  # SALT: never set
+    assert device.filtration_pump_running is True  # unchanged: byte[29] bit 3 wins
+
+
+def test_filtration_pump_running_off_when_pump_actually_off() -> None:
+    """byte[29] = 0x00 (no pump running) + OFF_MANUAL → still False (no-op)."""
+    data = _make_home_bytes()
+    data[4] = 0x03
+    data[29] = 0x00
+    data[37] = 0x35
+
+    device = AsekoDecoder.decode(bytes(data))
+    assert device.filtration_pump_running is False
 
 
 def test_home_alarm_bitmask_byte13() -> None:

--- a/tests/test_aseko_decoder.py
+++ b/tests/test_aseko_decoder.py
@@ -1428,11 +1428,11 @@ def test_filtration_mode_new_encoding_p1_and_p2() -> None:
     assert device.filtration_nonstop24 is False
 
 
-def test_filtration_mode_new_encoding_off_manual_p1_and_p2() -> None:
+def test_filtration_mode_new_encoding_manual_p1_and_p2() -> None:
     """Firmware B byte[37] = 0x35 → MANUAL (P1 & P2 + manual override).
 
     The original frame from @dtpugh (serial 110169464) had 0x35: both
-    periods enabled and the user manually toggled filtration OFF.
+    periods enabled and the user switched to manual operation mode.
     """
     data = _make_home_bytes()
     data[37] = 0x35  # new encoding: P1 & P2 + manual override (bit 2 set)
@@ -1441,12 +1441,12 @@ def test_filtration_mode_new_encoding_off_manual_p1_and_p2() -> None:
     assert device.filtration_nonstop24 is False
 
 
-def test_filtration_mode_new_encoding_off_manual_p1_only() -> None:
+def test_filtration_mode_new_encoding_manual_p1_only() -> None:
     """Firmware B byte[37] = 0x15 → MANUAL (P1 only + manual override).
 
-    Diagnostic 42 from @dtpugh (serial 110175608): user switched pump OFF
-    while only Period 1 was active. byte[37] = 0x15 (bits 0,2,4 set).
-    Bit 2 (0x04) = manual override → must decode as MANUAL.
+    Diagnostic 42 from @dtpugh (serial 110175608): user switched to manual
+    operation mode while only Period 1 was active. byte[37] = 0x15
+    (bits 0,2,4 set). Bit 2 (0x04) = manual override → must decode as MANUAL.
     """
     data = _make_home_bytes()
     data[37] = 0x15  # P1 + manual override

--- a/tests/test_aseko_decoder.py
+++ b/tests/test_aseko_decoder.py
@@ -148,24 +148,33 @@ def test_decode_home() -> None:
 
 
 def test_decode_filtration_period2_disabled() -> None:
-    """Second filtration period is hidden when disabled (byte 37 bit 0x20 clear).
+    """Period 2 times are still populated when disabled, but the mode is P1 only.
 
-    The unit keeps reporting the last-configured start2/stop2 times in bytes
-    60-63 even when the period is switched off, so the enable flag must be
-    honoured. Confirmed on an ASIN AQUA Salt by toggling the period-2 checkbox
-    and diffing two frames (PR #122 review).
+    Issue #133: pre-fix, the decoder returned ``None`` for start2/stop2 when
+    byte[37] bit 0x20 was clear, which made already-registered entities go
+    ``unknown`` once the user switched the controller back to "P1 only"
+    (Home Assistant protects the entity registry, so the entity stays).
+    Post-fix, the bytes 60-63 are read for any device in FILTRATION_TYPES
+    because the controller keeps sending the last-configured Period 2 times
+    (verified on dtpugh's serial 110169464: bytes 60-63 stay populated in
+    P1 only / P1&P2 / 24h / OFF_MANUAL modes).  The *mode* still flips
+    between TIMER_PERIOD_1 and TIMER_PERIOD_1_AND_2 per byte[37] bit 0x20,
+    so the user can tell which schedule is active.
     """
     data = _make_base_bytes()
-    data[37] = 0x93  # bit 0x20 clear -> period 2 disabled
+    data[37] = 0x93  # bit 0x20 clear -> period 2 disabled in the controller
 
     device = AsekoDecoder.decode(bytes(data))
 
     # Period 1 is still parsed.
     assert device.start1 == time(8, 0)
     assert device.stop1 == time(10, 0)
-    # Period 2 is hidden despite configured bytes 60-63 (14:00 / 16:00).
-    assert device.start2 is None
-    assert device.stop2 is None
+    # Period 2 times ARE populated (bytes 60-63 are stable) — but the mode
+    # entity correctly reports TIMER_PERIOD_1 so the user knows the schedule
+    # is not active.
+    assert device.start2 == time(14, 0)
+    assert device.stop2 == time(16, 0)
+    assert device.filtration_mode == AsekoFiltrationMode.TIMER_PERIOD_1
 
 
 def test_decode_filtration_period2_enabled() -> None:
@@ -177,6 +186,107 @@ def test_decode_filtration_period2_enabled() -> None:
 
     assert device.start2 == time(14, 0)
     assert device.stop2 == time(16, 0)
+    assert device.filtration_mode == AsekoFiltrationMode.TIMER_PERIOD_1_AND_2
+
+
+def test_decode_filtration_period2_bytes_unspecified() -> None:
+    """When bytes 60-63 themselves are 0xFF (no schedule ever configured),
+    start2 / stop2 stay None — the lazy-creation guard in sensor.py then
+    skips registering the entity.  This is the key branch that keeps
+    devices without a filtration output (NET) from ever surfacing
+    Period 2 entities (Issue #133 contract).
+    """
+    data = _make_base_bytes()
+    data[4] = 0x0E  # SALT (in FILTRATION_TYPES)
+    data[60:64] = bytes([0xFF, 0xFF, 0xFF, 0xFF])  # no period 2 schedule at all
+    data[37] = 0xB7  # SALT algicide routing — bit 0x20 set, but no schedule
+
+    device = AsekoDecoder.decode(bytes(data))
+    assert device.start2 is None
+    assert device.stop2 is None
+
+
+def test_decode_filtration_period2_none_for_net() -> None:
+    """NET has no filtration output — start1/2 / stop1/2 are all None
+    even if the frame happens to carry non-0xFF values in bytes 56-63.
+    Issue #133 contract: lazy creation in sensor.py never registers the
+    entities for NET.
+    """
+    data = _make_base_bytes()
+    data[4] = 0x09  # NET
+    # Garbage values in the schedule bytes (mimic real-world case where a
+    # measurement-only device reports random data in slots it doesn't implement).
+    data[56:64] = bytes([8, 0, 10, 0, 14, 0, 16, 0])
+
+    device = AsekoDecoder.decode(bytes(data))
+    assert device.device_type == AsekoDeviceType.NET
+    assert device.start1 is None
+    assert device.stop1 is None
+    assert device.start2 is None
+    assert device.stop2 is None
+
+
+def test_decode_filtration_period2_real_dtpugh_frames() -> None:
+    """Issue #133 end-to-end: decode all four real diagnostic frames from
+    @dtpugh (serial 110169464, ASIN AQUA Home firmware B) and verify
+    Period 2 times are stable across all four modes (P1 only / P1&P2 /
+    24h / OFF_MANUAL).  This is the user-visible regression: pre-fix the
+    entity would go "unknown" when the user toggled the controller back
+    from P1&P2 to P1 only.
+    """
+    import json
+    from pathlib import Path
+
+    # Diagnostic files live in /tmp/issue133 (downloaded from the issue);
+    # when the test runs in CI without that directory, skip instead of fail.
+    diag_dir = Path("/tmp/issue133")
+    if not diag_dir.exists():
+        pytest.skip("diagnostic files from issue #133 are not available")
+
+    def _first_frame(payload):
+        if isinstance(payload, dict):
+            for v in payload.values():
+                r = _first_frame(v)
+                if r is not None:
+                    return r
+        elif isinstance(payload, list):
+            for v in payload:
+                r = _first_frame(v)
+                if r is not None:
+                    return r
+        elif isinstance(payload, str) and len(payload) >= 100 and all(
+            c in "0123456789abcdefABCDEF" for c in payload.strip()
+        ):
+            return payload
+        return None
+
+    scenarios = {
+        "01_p1only.json": (0x11, AsekoFiltrationMode.TIMER_PERIOD_1),
+        "02_p1andp2.json": (0x31, AsekoFiltrationMode.TIMER_PERIOD_1_AND_2),
+        "03_24h.json": (0x01, AsekoFiltrationMode.NONSTOP_24H),
+        "04_off.json": (0x35, AsekoFiltrationMode.OFF_MANUAL),
+    }
+
+    for filename, (expected_b37, expected_mode) in scenarios.items():
+        with open(diag_dir / filename) as f:
+            frame = bytes.fromhex(_first_frame(json.load(f)))
+        assert frame[37] == expected_b37, f"{filename}: byte 37 mismatch"
+
+        device = AsekoDecoder.decode(frame)
+        # Period 1 is always there.
+        assert device.start1 is not None, f"{filename}: start1 unexpectedly None"
+        assert device.stop1 is not None, f"{filename}: stop1 unexpectedly None"
+        # Period 2 is ALSO always there after the fix (entity stays populated).
+        assert device.start2 is not None, (
+            f"{filename}: start2 is None — entity would go 'unknown' (Issue #133)"
+        )
+        assert device.stop2 is not None, (
+            f"{filename}: stop2 is None — entity would go 'unknown' (Issue #133)"
+        )
+        # Mode entity correctly reports which schedule is active.
+        assert device.filtration_mode == expected_mode, (
+            f"{filename}: expected {expected_mode}, got {device.filtration_mode}"
+        )
 
 
 def test_decode_electrolyzer_data() -> None:
@@ -945,11 +1055,14 @@ def test_decode_home_clf_real_frame() -> None:
     # Schedule
     assert device.start1 == time(8, 0)
     assert device.stop1 == time(16, 0)
-    # Period 2 is disabled on this unit (byte 37 bit 0x20 clear). The 18:00-22:00
-    # bytes are the unit's last-configured/default values and must be hidden.
-    # HOME shares the Salt period-2 enable mechanism (confirmed in PR #122).
-    assert device.start2 is None
-    assert device.stop2 is None
+    # Issue #133: Period 2 times are now always populated for any device in
+    # FILTRATION_TYPES (HOME here).  The mode entity tells the user which
+    # schedule is active — on this frame byte[37] = 0x43 (firmware A) so the
+    # mode is NONSTOP_24H, but bytes 60-63 still report the last-configured
+    # Period 2 times.  Pre-fix, the assertions below were ``is None``.
+    assert device.start2 == time(18, 0)
+    assert device.stop2 == time(22, 0)
+    assert device.filtration_mode == AsekoFiltrationMode.NONSTOP_24H
     # Backwash
     assert device.backwash_every_n_days == 3
     assert device.backwash_time == time(21, 0)

--- a/tests/test_aseko_decoder.py
+++ b/tests/test_aseko_decoder.py
@@ -1631,14 +1631,18 @@ def test_filtration_pump_running_off_when_pump_actually_off() -> None:
 
 
 def test_home_alarm_bitmask_byte13() -> None:
-    """byte[13] alarm bitmask is decoded for all device types; tested here on HOME."""
+    """byte[13] alarm bitmask is decoded for all device types; tested here on HOME.
+
+    Bit mapping (Issue #151, serial 110175608): 0x01 = disinfection/Cl dose fault,
+    0x02 = pH dose fault, 0x04 = no flow, 0x08 = rapid pH change.
+    """
     data = _make_home_bytes()
 
     # All four bits set
     data[13] = 0x0F
     device = AsekoDecoder.decode(bytes(data))
-    assert device.alarm_ph_too_many_doses is True  # bit 0x01
-    assert device.alarm_orp_too_many_doses is True  # bit 0x02
+    assert device.alarm_ph_too_many_doses is True  # bit 0x02
+    assert device.alarm_orp_too_many_doses is True  # bit 0x01
     assert device.alarm_no_flow_to_probes is True  # bit 0x04
     assert device.alarm_rapid_ph_change is True  # bit 0x08
 
@@ -1657,6 +1661,117 @@ def test_home_alarm_bitmask_byte13() -> None:
     assert device.alarm_ph_too_many_doses is False
     assert device.alarm_orp_too_many_doses is False
     assert device.alarm_rapid_ph_change is False
+
+
+def test_home_alarm_byte13_bit01_is_disinfection() -> None:
+    """byte[13] bit 0x01 = disinfection/Cl dose fault → alarm_orp_too_many_doses.
+
+    Issue #151 regression: dtpugh's config48 frame (HOME serial 110175608) shows
+    byte[13]=0x01 while the controller displayed "Maximum disinfection dose
+    exceeded".  Pre-fix this bit was mapped to alarm_ph_too_many_doses, so the
+    chlorine fault falsely lit the "Too many doses of pH" sensor.
+    """
+    data = _make_home_bytes()
+    data[13] = 0x01
+
+    device = AsekoDecoder.decode(bytes(data))
+    assert device.alarm_orp_too_many_doses is True
+    assert device.alarm_ph_too_many_doses is False
+    assert device.alarm_no_flow_to_probes is False
+    assert device.alarm_rapid_ph_change is False
+
+
+def test_home_alarm_byte13_bit02_is_ph() -> None:
+    """byte[13] bit 0x02 = pH dose fault → alarm_ph_too_many_doses.
+
+    Inferred mapping (symmetric to bit 0x01, per dtpugh's expectation in
+    Issue #151 that a pH fault would read 0x02).  Direct frame capture pending.
+    """
+    data = _make_home_bytes()
+    data[13] = 0x02
+
+    device = AsekoDecoder.decode(bytes(data))
+    assert device.alarm_ph_too_many_doses is True
+    assert device.alarm_orp_too_many_doses is False
+    assert device.alarm_no_flow_to_probes is False
+    assert device.alarm_rapid_ph_change is False
+
+
+def test_home_alarm_byte12_dosing_warnings() -> None:
+    """byte[12] dosing-warning bitmask: 0x20 = disinfection, 0x40 = pH (HOME).
+
+    Confirmed by Issue #134 before/after captures (serial 110175608):
+    both → 0x60, pH only → 0x40, cleared → 0x00.
+    """
+    data = _make_home_bytes()
+
+    # Disinfection only
+    data[12] = 0x20
+    device = AsekoDecoder.decode(bytes(data))
+    assert device.alarm_orp_too_many_doses is True
+    assert device.alarm_ph_too_many_doses is False
+
+    # pH only
+    data[12] = 0x40
+    device = AsekoDecoder.decode(bytes(data))
+    assert device.alarm_ph_too_many_doses is True
+    assert device.alarm_orp_too_many_doses is False
+
+    # Both
+    data[12] = 0x60
+    device = AsekoDecoder.decode(bytes(data))
+    assert device.alarm_ph_too_many_doses is True
+    assert device.alarm_orp_too_many_doses is True
+
+    # None
+    data[12] = 0x00
+    data[13] = 0x00
+    device = AsekoDecoder.decode(bytes(data))
+    assert device.alarm_ph_too_many_doses is False
+    assert device.alarm_orp_too_many_doses is False
+
+
+def test_decode_alarm_real_dtpugh_frames() -> None:
+    """Issue #151 end-to-end: decode the three real diagnostic frames from
+    @dtpugh (HOME serial 110175608) and verify the correct alarm sensors fire.
+
+      config48 (chlorine/disinfection overdose): byte[13]=0x01 → disinfection ON,
+        pH OFF.  config49 (pH fault only): byte[12]=0x40 → pH ON, disinfection OFF.
+      config50 (cleared): both OFF.
+    """
+    frames = {
+        # chlorine / disinfection dose exceeded (2026-08-06 17:29:15)
+        "48": (
+            "0691257803011a0806111d0f000102d202d802d802d8a3fe70012ffeaa48001d000000000005027b"
+            "0691257803031a0806111d0f4a5000200800100a100f16000298012f00080515025a01e00e10a2ff"
+            "0691257803021a0806111d0f008c003c003c003c000a1e3c6e9600f00502580f050f1e1effc20283",
+            (False, True),
+        ),
+        # pH fault only (2026-08-08 09:08:40)
+        "49": (
+            "0691257803011a0808090828400002e3031003100310a3fe70012dfeaa08000000000000000102bd"
+            "0691257803031a08080908284a4a00200800100a100f16000297012d00080515025a01e00e10a2cc"
+            "0691257803021a0808090828008c003c003c003c000a1e3c6e9600f00a02580f050f1e1effc202a8",
+            (True, False),
+        ),
+        # cleared (2026-08-08 09:22:20)
+        "50": (
+            "0691257803011a0808091614000002e1031003100310a3fe70012dfeaa08000000000000000102dd"
+            "0691257803031a08080916144a4a00200800100a100f16000295012d00080515025a01e00e10a2ec"
+            "0691257803021a0808091614008c003c003c003c000a1e3c6e9600f00a02580f050f1e1effc2028a",
+            (False, False),
+        ),
+    }
+
+    for name, (hex_dump, (exp_ph, exp_orp)) in frames.items():
+        device = AsekoDecoder.decode(bytes.fromhex(hex_dump))
+        assert device.device_type == AsekoDeviceType.HOME, f"config{name}"
+        assert device.alarm_ph_too_many_doses is exp_ph, (
+            f"config{name}: alarm_ph_too_many_doses expected {exp_ph}"
+        )
+        assert device.alarm_orp_too_many_doses is exp_orp, (
+            f"config{name}: alarm_orp_too_many_doses expected {exp_orp}"
+        )
 
 
 def test_home_byte12_not_an_alarm_byte() -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from custom_components.aseko_local import (
     async_setup_entry,
+    async_unload_entry,
 )
 from custom_components.aseko_local.aseko_data import AsekoDevice
 from custom_components.aseko_local.const import (
@@ -128,6 +129,12 @@ async def test_setup_unload_entry(hass, bypass_get_data, api_server_running) -> 
         frame = b"\x03" * 120
         # Should not raise or call anything
         await server._call_forward_cb(frame)  # noqa: SLF001
+
+    # Unload the entry so the coordinator's periodic stale-check timer is
+    # stopped. pytest_homeassistant_custom_component fails any test that
+    # leaves a lingering timer behind (async_track_time_interval started in
+    # async_start_stale_check).
+    assert await async_unload_entry(hass, config_entry)
 
 
 # Hilfsfunktion: Hex-String zu Bytes

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -273,7 +273,8 @@ async def test_async_setup_salt_redox(hass) -> None:
     # + 2 new backwash schedule sensors (last_backwash, next_backwash)
     # + 1 new backwash_active binary sensor
     # + 1 new heating_active binary sensor
-    assert len(added_entities) == 38
+    # + 1 new filtration_mode sensor (Issue #133) — SALT has filtration
+    assert len(added_entities) == 40
     assert any(
         getattr(e.entity_description, "key", None) != "water_flow_to_probes"
         for e in added_entities
@@ -377,7 +378,8 @@ async def test_async_setup_salt_clf(hass) -> None:
     # + 2 new backwash schedule sensors (last_backwash, next_backwash)
     # + 1 new backwash_active binary sensor
     # + 1 new heating_active binary sensor
-    assert len(added_entities) == 39
+    # + 1 new filtration_mode sensor (Issue #133) — SALT has filtration
+    assert len(added_entities) == 41
     assert any(
         getattr(e.entity_description, "key", None) != "water_flow_to_probes"
         for e in added_entities
@@ -620,7 +622,10 @@ async def test_async_setup_profi_clf_redox(hass) -> None:
     # but no documented filling input), so max_filling_time is suppressed even
     # though bytes 94-95 carry a real value. -1 entity compared to the PR #120
     # baseline.
-    assert len(added_entities) == 41
+    #
+    # Issue #133: PROFI is in FILTRATION_TYPES, so the new filtration_mode
+    # sensor is now created. +1 entity compared to the PR #120 baseline.
+    assert len(added_entities) == 43
     assert any(
         getattr(e.entity_description, "key", None) == "free_chlorine"
         for e in added_entities


### PR DESCRIPTION
User dtpugh has an Aseko Home for wich we hadn't enough data before.

He delivered some details which we have corrected. No all of his issues are solved. For some the data isn't in the record (eg. issue #137 Variable speed pumps). And issue #148 (Backwash) I don't understand this issue.

But fixed is the following:
- #133 Filtration Schedule: use correct bits and if filtration 2 isn't set use "n/a" instead of unavailable
- #136 Antifreeze: new binary on/off and docu, that required water temperature changes to the set antifreeze temperature
- #138 Flowmeter: new binary if flowmeter is on/off
- #139 PH- liquid concentration: The HOME has an option to define which concentration the acid has. The has been added.
- #140 Water level measurement on/off: a new binary added which shows if water level measurement is on or off
- #151 Wrong bits for PH and ORP dose exeeded