### PR TITLE
Fix/backwash

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,16 +227,114 @@ If your sensor is mounted at a different height than the Aseko factory default (
 
 This mirrors the same pattern used for canister volume in the previous section and works for any device that exposes `sensor.<device>_water_level` (HOME, SALT, OXY). Devices without a water-level sensor (e.g. NET) will simply not have these entities.
 
-## Backwash schedule (ASIN Aqua Home, Salt)
+## Backwash (ASIN Aqua Home, Salt, Oxygen, Profi)
 
-Devices with a configured backwash schedule expose:
+The device transmits its backwash **configuration** and the live state of the backwash valve, but never its history — it does not report when the last cycle ran. The integration therefore watches the valve itself and builds the history from what it observes.
+
+Configuration read straight from the frame:
 
 | Entity | Description |
 |---|---|
-| `sensor.backwash_every_n_days` | Interval in days (`0` = disabled) |
+| `sensor.backwash_every_n_days` | Interval in days (`0` = automatic backwash disabled) |
 | `sensor.backwash_time` | Scheduled start time (HH:MM) |
 | `sensor.backwash_duration` | Duration in seconds |
-| `sensor.last_backwash` | Last backwash — schedule-derived until a real backwash cycle is observed, then the live/persistent value is used |
-| `sensor.next_backwash` | Next scheduled slot |
+| `binary_sensor.backwash_active` | Valve is open right now |
 
-> **Note:** `last_backwash` is initially derived from the configured schedule and frame timestamp. Once the integration observes a real backwash cycle (the backwash relay stays on for at least 60 seconds), it records and persists that timestamp and uses it instead. This survives Home Assistant restarts.
+History, recorded live and persisted across restarts. **These are not all equally reliable** — see below:
+
+| Entity | Description | Timestamp | Which bucket it lands in |
+|---|---|---|---|
+| `sensor.last_backwash` | Last cycle, whatever started it. **Unknown** until one is seen | Observed | n/a — it holds every cycle |
+| `datetime.last_scheduled_backwash` | Last cycle that looked like the unit's own scheduled run — **and settable**, see below | Observed *or* entered by hand — see its `source` attribute | Estimated |
+| `sensor.last_manual_backwash` | Last cycle that did not | Observed | Estimated |
+| `sensor.next_scheduled_backwash` | Projected next automatic cycle. **Unknown** until a scheduled cycle is known | **Calculated** | Inherited |
+
+The two columns matter separately. A cycle the integration watched has an exact
+timestamp — what is estimated is only *which* of the two buckets it belongs in.
+Only `next_scheduled_backwash` holds a timestamp that was computed rather than
+measured, which is why it is the one carrying "(estimated)" in its name.
+
+### Observed vs. estimated
+
+A cycle is **recorded** when the backwash valve stays open for at least 60 seconds — short activations (menu navigation, output test mode) are ignored. That part is a direct observation: `sensor.last_backwash` means the valve really did run a full cycle.
+
+The device does **not** report *why* the valve opened. So the split into scheduled and manual is a guess based on the only signal available — the time the valve opened:
+
+* within **±15 minutes** of `backwash_time`, on a unit whose schedule is enabled → **scheduled**;
+* anything else, including any cycle on a unit with `backwash_every_n_days = 0` → **manual**.
+
+The tolerance absorbs drift between the unit's clock and Home Assistant's, plus up to one transmit interval (~30 s) of lag before the frame reports the valve as open.
+
+`next_scheduled_backwash` is projected from the last **scheduled** cycle: that timestamp plus the configured interval, snapped to `backwash_time`, and stepped forward if cycles were missed while Home Assistant was down. A manual backwash deliberately does not move it — starting one by hand does not tell us (nor, on the unit, change) the schedule phase. Since it builds on the classification, it inherits any error in it.
+
+> **Upgrading:** `sensor.next_backwash` was renamed to `sensor.next_scheduled_backwash`. The integration rewrites the entity registry on startup, so the entity keeps its `entity_id`, its recorded history and any automation or dashboard pointing at it — only the displayed name changes.
+
+### Seeding the schedule by hand
+
+Because the device never transmits its history, `next_scheduled_backwash` stays unknown until the integration has watched a whole scheduled cycle — up to a full interval of waiting.
+
+To skip that wait, **click `datetime.last_scheduled_backwash` and pick the date** in the dialog. That is why it is a `datetime` entity rather than a read-only sensor: no helper, no script, no confirm button.
+
+The same thing from an automation:
+
+```yaml
+action: aseko_local.set_last_scheduled_backwash
+data:
+  timestamp: "2026-08-01 12:30:00"
+  # serial_number: 110071590   # optional; omit to set every backwash-capable device
+```
+
+The timestamp must be in the past. `datetime.last_scheduled_backwash` carries a
+`source` attribute saying where its value came from:
+
+| `source` | Meaning |
+|---|---|
+| `observed` | The integration watched this cycle run |
+| `manual` | You entered it |
+
+`next_scheduled_backwash` has no `source` of its own — it is always projected
+from `last_scheduled_backwash`, so that sensor's `source` covers both.
+
+**The last write wins, and the stored timestamps are never compared.**
+
+* Entering a date always applies, whatever it is and whatever was there
+  before — if you are typing it in, you have a reason to.
+* A scheduled cycle detected *after* that entry replaces it, and the source
+  flips back to `observed`. The value you entered stood in for a real cycle
+  until one turned up; one has.
+
+So a seed is only ever overtaken by an actual observation, never by an older
+record, and you can always take control back by entering a date again.
+
+Seeding deliberately does **not** touch `sensor.last_backwash`: that one means
+"the integration watched this happen", and a typed-in date has not been
+watched. It also does not touch `last_manual_backwash`, which tracks *observed*
+cycles that were started by hand — a different thing from a manually entered
+date.
+
+To undo a mistyped date there is `aseko_local.clear_last_scheduled_backwash`,
+which returns the value to unknown (optionally for one `serial_number`). If an
+older cycle is on record, clearing also re-derives the split from it — see
+below.
+
+### Upgrading from a store that predates the split
+
+`last_scheduled_backwash` and `last_manual_backwash` are newer than
+`last_backwash`, so an existing install has a stored cycle but no record of
+which kind it was. Rather than leave both empty until the next cycle — up to a
+whole interval away — the integration classifies that stored timestamp against
+the schedule on the first frame after the upgrade, and fills in whichever of
+the two it belongs to. It only ever does this while both are empty, so a real
+cycle is never second-guessed.
+
+### Known ways the estimate gets it wrong
+
+* A cycle you start **by hand near the scheduled time** is reported as scheduled.
+* Only the **time of day** is checked, not the day itself. A manual cycle at exactly `backwash_time` on a day the interval does not fall on still counts as scheduled. (Checking the day would require knowing the schedule phase — which is exactly what this is trying to establish — and would break whenever you change the interval.)
+* If the unit's **clock drifts** more than 15 minutes from Home Assistant's, its own scheduled cycles are reported as manual.
+* A cycle the unit runs on its own **for some other reason** (e.g. after a fault) is reported as manual.
+* Classification uses the schedule **as it was at the time of the cycle** and is never revisited — changing `backwash_time` later does not reclassify history.
+
+If a cycle looks misclassified, the integration's diagnostics download carries `last_backwash_trigger` alongside the raw frame, so you can see what it decided and open an issue.
+
+> **Note:** all four history sensors read "unknown" on a fresh install and stay that way until the integration actually sees a cycle. This is intentional. Earlier versions derived `last_backwash` from the schedule, which showed a confident timestamp for a backwash that may never have happened.

--- a/README.md
+++ b/README.md
@@ -246,24 +246,29 @@ History, recorded live and persisted across restarts. **These are not all equall
 |---|---|---|---|
 | `sensor.last_backwash` | Last cycle, whatever started it. **Unknown** until one is seen | Observed | n/a — it holds every cycle |
 | `datetime.last_scheduled_backwash` | Last cycle that looked like the unit's own scheduled run — **and settable**, see below | Observed *or* entered by hand — see its `source` attribute | Estimated |
-| `sensor.last_manual_backwash` | Last cycle that did not | Observed | Estimated |
+| `sensor.last_manual_backwash` | Last cycle the unit's settings menu was open for (ASIN AQUA Salt only) | Observed | Observed |
 | `sensor.next_scheduled_backwash` | Projected next automatic cycle. **Unknown** until a scheduled cycle is known | **Calculated** | Inherited |
 
 The two columns matter separately. A cycle the integration watched has an exact
-timestamp — what is estimated is only *which* of the two buckets it belongs in.
-Only `next_scheduled_backwash` holds a timestamp that was computed rather than
+timestamp — what is estimated is only *which* bucket it belongs in. Only
+`next_scheduled_backwash` holds a timestamp that was computed rather than
 measured, which is why it is the one carrying "(estimated)" in its name.
 
 ### Observed vs. estimated
 
 A cycle is **recorded** when the backwash valve stays open for at least 60 seconds — short activations (menu navigation, output test mode) are ignored. That part is a direct observation: `sensor.last_backwash` means the valve really did run a full cycle.
 
-The device does **not** report *why* the valve opened. So the split into scheduled and manual is a guess based on the only signal available — the time the valve opened:
+The device does **not** report *why* the valve opened. Two things are checked, in this order:
 
-* within **±15 minutes** of `backwash_time`, on a unit whose schedule is enabled → **scheduled**;
-* anything else, including any cycle on a unit with `backwash_every_n_days = 0` → **manual**.
+* the unit's **settings menu was open** while the valve was → **manual**;
+* menu shut, and the valve opened within **±15 minutes** of `backwash_time` on a unit whose schedule is enabled → **scheduled**;
+* anything else → **unattributed**: `sensor.last_backwash` moves and neither of the other two does.
 
-The tolerance absorbs drift between the unit's clock and Home Assistant's, plus up to one transmit interval (~30 s) of lag before the frame reports the valve as open.
+The first is an observation, not a guess. On the ASIN AQUA Salt the frame reports the settings menu being open — the menu a backwash is started by hand from — so a cycle running while it is open was started by a person. (`binary_sensor.service_menu` shows the same bit live.) Other device types do not report it in a form that can be trusted here, so on those `sensor.last_manual_backwash` stays unknown and by-hand cycles come out unattributed.
+
+The second is a comparison against a clock. The tolerance absorbs drift between the unit's clock and Home Assistant's, plus up to one transmit interval (~30 s) of lag before the frame reports the valve as open.
+
+Nothing falls through to "manual" by elimination. A cycle that does not match the schedule tells you the unit's own timer does not explain it — not that somebody started it. A fault-triggered cycle, or one on a unit whose clock has drifted, would look exactly the same. So those are recorded as having happened and left at that.
 
 `next_scheduled_backwash` is projected from the last **scheduled** cycle: that timestamp plus the configured interval, snapped to `backwash_time`, and stepped forward if cycles were missed while Home Assistant was down. A manual backwash deliberately does not move it — starting one by hand does not tell us (nor, on the unit, change) the schedule phase. Since it builds on the classification, it inherits any error in it.
 
@@ -323,18 +328,20 @@ below.
 `last_backwash`, so an existing install has a stored cycle but no record of
 which kind it was. Rather than leave both empty until the next cycle — up to a
 whole interval away — the integration classifies that stored timestamp against
-the schedule on the first frame after the upgrade, and fills in whichever of
-the two it belongs to. It only ever does this while both are empty, so a real
-cycle is never second-guessed.
+the schedule on the first frame after the upgrade, and fills in
+`last_scheduled_backwash` if it matches. It cannot reach the other half — the
+settings-menu bit is not recoverable after the fact — so a stored cycle that
+does not match the schedule stays unattributed. It only ever does this while
+both are empty, so a real cycle is never second-guessed.
 
 ### Known ways the estimate gets it wrong
 
-* A cycle you start **by hand near the scheduled time** is reported as scheduled.
-* Only the **time of day** is checked, not the day itself. A manual cycle at exactly `backwash_time` on a day the interval does not fall on still counts as scheduled. (Checking the day would require knowing the schedule phase — which is exactly what this is trying to establish — and would break whenever you change the interval.)
-* If the unit's **clock drifts** more than 15 minutes from Home Assistant's, its own scheduled cycles are reported as manual.
-* A cycle the unit runs on its own **for some other reason** (e.g. after a fault) is reported as manual.
+* A cycle you start **by hand near the scheduled time** is reported as scheduled — unless the unit reported its settings menu open for it, which on the ASIN AQUA Salt settles it as manual.
+* Only the **time of day** is checked, not the day itself. A cycle at exactly `backwash_time` on a day the interval does not fall on still counts as scheduled. (Checking the day would require knowing the schedule phase — which is exactly what this is trying to establish — and would break whenever you change the interval.)
+* If the unit's **clock drifts** more than 15 minutes from Home Assistant's, its own scheduled cycles come out unattributed.
+* A cycle the unit runs on its own **for some other reason** (e.g. after a fault) comes out unattributed.
 * Classification uses the schedule **as it was at the time of the cycle** and is never revisited — changing `backwash_time` later does not reclassify history.
 
-If a cycle looks misclassified, the integration's diagnostics download carries `last_backwash_trigger` alongside the raw frame, so you can see what it decided and open an issue.
+If a cycle looks misclassified, the integration's diagnostics download carries `last_backwash_trigger` alongside the raw frame, so you can see what it decided — `scheduled`, `manual` or `unknown` — and open an issue.
 
 > **Note:** all four history sensors read "unknown" on a fresh install and stay that way until the integration actually sees a cycle. This is intentional. Earlier versions derived `last_backwash` from the schedule, which showed a confident timestamp for a backwash that may never have happened.

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ History, recorded live and persisted across restarts. **These are not all equall
 |---|---|---|---|
 | `sensor.last_backwash` | Last cycle, whatever started it. **Unknown** until one is seen | Observed | n/a — it holds every cycle |
 | `datetime.last_scheduled_backwash` | Last cycle that looked like the unit's own scheduled run — **and settable**, see below | Observed *or* entered by hand — see its `source` attribute | Estimated |
-| `sensor.last_manual_backwash` | Last cycle the unit's settings menu was open for (ASIN AQUA Salt only) | Observed | Observed |
+| `sensor.last_manual_backwash` | Last cycle started by hand | Observed | Observed on ASIN AQUA Salt, estimated elsewhere |
 | `sensor.next_scheduled_backwash` | Projected next automatic cycle. **Unknown** until a scheduled cycle is known | **Calculated** | Inherited |
 
 The two columns matter separately. A cycle the integration watched has an exact
@@ -262,13 +262,16 @@ The device does **not** report *why* the valve opened. Two things are checked, i
 
 * the unit's **settings menu was open** while the valve was → **manual**;
 * menu shut, and the valve opened within **±15 minutes** of `backwash_time` on a unit whose schedule is enabled → **scheduled**;
-* anything else → **unattributed**: `sensor.last_backwash` moves and neither of the other two does.
+* anything else → depends on the device, see below.
 
-The first is an observation, not a guess. On the ASIN AQUA Salt the frame reports the settings menu being open — the menu a backwash is started by hand from — so a cycle running while it is open was started by a person. (`binary_sensor.service_menu` shows the same bit live.) Other device types do not report it in a form that can be trusted here, so on those `sensor.last_manual_backwash` stays unknown and by-hand cycles come out unattributed.
+The first is an observation, not a guess. On the ASIN AQUA Salt the frame reports the settings menu being open — the menu a backwash is started by hand from — so a cycle running while it is open was started by a person. (`binary_sensor.service_menu` shows the same bit live.)
 
 The second is a comparison against a clock. The tolerance absorbs drift between the unit's clock and Home Assistant's, plus up to one transmit interval (~30 s) of lag before the frame reports the valve as open.
 
-Nothing falls through to "manual" by elimination. A cycle that does not match the schedule tells you the unit's own timer does not explain it — not that somebody started it. A fault-triggered cycle, or one on a unit whose clock has drifted, would look exactly the same. So those are recorded as having happened and left at that.
+What happens to a cycle that matches neither depends on whether your unit reports that menu:
+
+* **ASIN AQUA Salt** — the cycle is left **unattributed**: `sensor.last_backwash` moves and neither of the other two does. The unit would have said if somebody had been at it, and it did not, so "the timer does not explain this" is the whole answer. A fault-triggered cycle, or one on a unit whose clock has drifted past the tolerance, looks exactly like this.
+* **Every other model** — the cycle is called **manual** by elimination, as it was before this signal existed. The guess is no better there, but it is all there is: without the menu bit, holding out for an observation would leave `sensor.last_manual_backwash` permanently empty.
 
 `next_scheduled_backwash` is projected from the last **scheduled** cycle: that timestamp plus the configured interval, snapped to `backwash_time`, and stepped forward if cycles were missed while Home Assistant was down. A manual backwash deliberately does not move it — starting one by hand does not tell us (nor, on the unit, change) the schedule phase. Since it builds on the classification, it inherits any error in it.
 
@@ -328,18 +331,19 @@ below.
 `last_backwash`, so an existing install has a stored cycle but no record of
 which kind it was. Rather than leave both empty until the next cycle — up to a
 whole interval away — the integration classifies that stored timestamp against
-the schedule on the first frame after the upgrade, and fills in
-`last_scheduled_backwash` if it matches. It cannot reach the other half — the
+the schedule on the first frame after the upgrade, and fills in whichever of
+the two it belongs to. On the Salt it cannot reach the manual half — the
 settings-menu bit is not recoverable after the fact — so a stored cycle that
-does not match the schedule stays unattributed. It only ever does this while
-both are empty, so a real cycle is never second-guessed.
+does not match the schedule stays unattributed there until the next real
+cycle. It only ever does this while both are empty, so a real cycle is never
+second-guessed.
 
 ### Known ways the estimate gets it wrong
 
 * A cycle you start **by hand near the scheduled time** is reported as scheduled — unless the unit reported its settings menu open for it, which on the ASIN AQUA Salt settles it as manual.
 * Only the **time of day** is checked, not the day itself. A cycle at exactly `backwash_time` on a day the interval does not fall on still counts as scheduled. (Checking the day would require knowing the schedule phase — which is exactly what this is trying to establish — and would break whenever you change the interval.)
-* If the unit's **clock drifts** more than 15 minutes from Home Assistant's, its own scheduled cycles come out unattributed.
-* A cycle the unit runs on its own **for some other reason** (e.g. after a fault) comes out unattributed.
+* If the unit's **clock drifts** more than 15 minutes from Home Assistant's, its own scheduled cycles come out unattributed on the Salt, and manual on every other model.
+* A cycle the unit runs on its own **for some other reason** (e.g. after a fault) does the same.
 * Classification uses the schedule **as it was at the time of the cycle** and is never revisited — changing `backwash_time` later does not reclassify history.
 
 If a cycle looks misclassified, the integration's diagnostics download carries `last_backwash_trigger` alongside the raw frame, so you can see what it decided — `scheduled`, `manual` or `unknown` — and open an issue.

--- a/custom_components/aseko_local/__init__.py
+++ b/custom_components/aseko_local/__init__.py
@@ -9,7 +9,9 @@ import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PORT, Platform
 from homeassistant.core import HomeAssistant, ServiceCall
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryNotReady, ServiceValidationError
+from homeassistant.helpers import config_validation as cv
+from homeassistant.util import dt as dt_util
 
 from .aseko_data import AsekoDevice
 from .aseko_server import AsekoDeviceServer
@@ -30,12 +32,19 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.BUTTON, Platform.SENSOR]
+PLATFORMS: list[Platform] = [
+    Platform.BINARY_SENSOR,
+    Platform.BUTTON,
+    Platform.DATETIME,
+    Platform.SENSOR,
+]
 
 _MIRRORS: dict[str, AsekoCloudMirror] = {}
 _SERVERS: dict[str, AsekoDeviceServer] = {}
 
 SERVICE_RESET_CONSUMPTION = "reset_consumption"
+SERVICE_SET_LAST_SCHEDULED_BACKWASH = "set_last_scheduled_backwash"
+SERVICE_CLEAR_LAST_SCHEDULED_BACKWASH = "clear_last_scheduled_backwash"
 
 RESET_CONSUMPTION_SCHEMA = vol.Schema(
     {
@@ -43,6 +52,19 @@ RESET_CONSUMPTION_SCHEMA = vol.Schema(
         vol.Optional("counter", default="canister"): vol.In(
             ["canister", "total", "all"]
         ),
+    }
+)
+
+SET_LAST_SCHEDULED_BACKWASH_SCHEMA = vol.Schema(
+    {
+        vol.Required("timestamp"): cv.datetime,
+        vol.Optional("serial_number"): cv.positive_int,
+    }
+)
+
+CLEAR_LAST_SCHEDULED_BACKWASH_SCHEMA = vol.Schema(
+    {
+        vol.Optional("serial_number"): cv.positive_int,
     }
 )
 
@@ -177,6 +199,87 @@ async def async_setup_entry(
         )
         _LOGGER.debug("Registered service %s.%s", DOMAIN, SERVICE_RESET_CONSUMPTION)
 
+    if not hass.services.has_service(DOMAIN, SERVICE_SET_LAST_SCHEDULED_BACKWASH):
+
+        async def handle_set_last_scheduled_backwash(call: ServiceCall) -> None:
+            """Seed the last scheduled backwash so the projection can start.
+
+            The device never transmits when it last ran a backwash, so without
+            this the "next" projection has to wait out a whole interval for the
+            first observed cycle.  The seeded value is marked as manual and is
+            replaced as soon as a real scheduled cycle is detected.
+            """
+            timestamp = call.data["timestamp"]
+            serial = call.data.get("serial_number")
+
+            # A naive datetime from the service call is in the user's local
+            # time; the tracker compares against timezone-aware timestamps.
+            if timestamp.tzinfo is None:
+                timestamp = timestamp.replace(tzinfo=dt_util.DEFAULT_TIME_ZONE)
+
+            if timestamp > dt_util.now():
+                raise ServiceValidationError(
+                    f"{timestamp.isoformat()} is in the future; "
+                    "the last scheduled backwash must already have happened"
+                )
+
+            matched = False
+            for entry in hass.config_entries.async_entries(DOMAIN):
+                rd = getattr(entry, "runtime_data", None)
+                if rd and rd.coordinator.set_last_scheduled_backwash(timestamp, serial):
+                    matched = True
+
+            if not matched:
+                raise ServiceValidationError(
+                    f"No Aseko device found for serial_number {serial}"
+                    if serial is not None
+                    else "No Aseko device with a backwash valve has been seen yet"
+                )
+
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_SET_LAST_SCHEDULED_BACKWASH,
+            handle_set_last_scheduled_backwash,
+            schema=SET_LAST_SCHEDULED_BACKWASH_SCHEMA,
+        )
+        _LOGGER.debug(
+            "Registered service %s.%s", DOMAIN, SERVICE_SET_LAST_SCHEDULED_BACKWASH
+        )
+
+    if not hass.services.has_service(DOMAIN, SERVICE_CLEAR_LAST_SCHEDULED_BACKWASH):
+
+        async def handle_clear_last_scheduled_backwash(call: ServiceCall) -> None:
+            """Return the last scheduled backwash to unknown.
+
+            The undo for a mistyped date.  Also re-arms the classification of
+            an older stored cycle, so if one is on record it is re-derived on
+            the next frame.
+            """
+            serial = call.data.get("serial_number")
+
+            matched = False
+            for entry in hass.config_entries.async_entries(DOMAIN):
+                rd = getattr(entry, "runtime_data", None)
+                if rd and rd.coordinator.clear_last_scheduled_backwash(serial):
+                    matched = True
+
+            if not matched:
+                raise ServiceValidationError(
+                    f"No Aseko device found for serial_number {serial}"
+                    if serial is not None
+                    else "No Aseko device with a backwash valve has been seen yet"
+                )
+
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_CLEAR_LAST_SCHEDULED_BACKWASH,
+            handle_clear_last_scheduled_backwash,
+            schema=CLEAR_LAST_SCHEDULED_BACKWASH_SCHEMA,
+        )
+        _LOGGER.debug(
+            "Registered service %s.%s", DOMAIN, SERVICE_CLEAR_LAST_SCHEDULED_BACKWASH
+        )
+
     return True
 
 
@@ -207,13 +310,15 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             for e in hass.config_entries.async_entries(DOMAIN)
             if e.entry_id != entry.entry_id
         ]
-        if not remaining and hass.services.has_service(
-            DOMAIN, SERVICE_RESET_CONSUMPTION
-        ):
-            hass.services.async_remove(DOMAIN, SERVICE_RESET_CONSUMPTION)
-            _LOGGER.debug(
-                "Unregistered service %s.%s", DOMAIN, SERVICE_RESET_CONSUMPTION
-            )
+        if not remaining:
+            for service in (
+                SERVICE_RESET_CONSUMPTION,
+                SERVICE_SET_LAST_SCHEDULED_BACKWASH,
+                SERVICE_CLEAR_LAST_SCHEDULED_BACKWASH,
+            ):
+                if hass.services.has_service(DOMAIN, service):
+                    hass.services.async_remove(DOMAIN, service)
+                    _LOGGER.debug("Unregistered service %s.%s", DOMAIN, service)
 
         # Remove runtime_data to avoid stale references
         domain_data = hass.data.get(DOMAIN)

--- a/custom_components/aseko_local/aseko_data.py
+++ b/custom_components/aseko_local/aseko_data.py
@@ -52,18 +52,25 @@ class AsekoElectrolyzerDirection(Enum):
 class AsekoBackwashTrigger(Enum):
     """What started the most recently observed backwash cycle.
 
-    SCHEDULED — the cycle started within the tolerance window around the
-        configured ``backwash_time`` on a device whose backwash schedule is
-        enabled, so the unit ran it on its own.
-    MANUAL — anything else: the cycle started outside that window, or the
-        schedule is disabled/unconfigured, so a human started it.
+    MANUAL — the unit's settings menu was open while the valve was, so a
+        person was standing at the menu the backwash button lives on.
+        Observed, not inferred.
+    SCHEDULED — the menu was shut and the cycle started within the tolerance
+        window around the configured ``backwash_time`` on a device whose
+        backwash schedule is enabled, so the unit ran it on its own.
+    UNKNOWN — neither.  The valve was seen to open, which is a fact, but
+        nothing in the frame says who opened it.
 
-    The device does not transmit *why* the valve opened, so this is derived
-    from the observed start time.  See ``backwash_tracker.py``.
+    The device does not transmit *why* the valve opened.  Only the menu bit
+    is direct evidence; the schedule match is a comparison against the clock.
+    Everything outside those two is left as UNKNOWN rather than guessed, so a
+    cycle is never filed under a cause that was never observed.
+    See ``backwash_tracker.py``.
     """
 
     SCHEDULED = "scheduled"
     MANUAL = "manual"
+    UNKNOWN = "unknown"
 
 
 class AsekoBackwashSource(Enum):
@@ -271,23 +278,32 @@ class AsekoDevice:
     # OBSERVED — the integration watched the backwash valve stay open for a
     # full cycle, so this happened:
     #   last_backwash           = most recent cycle, whatever started it.
+    #   last_manual_backwash    = most recent cycle the unit's settings menu
+    #                             was open for.  Somebody was standing at the
+    #                             menu the backwash button lives on, so this
+    #                             is observed too — SALT only, since that is
+    #                             the only device the bit is trusted on.
     #
-    # DERIVED — split out of the above by a heuristic on the start time, which
-    # can misclassify (see BackwashTracker._classify for how and when):
-    #   last_scheduled_backwash = most recent cycle that looked like the unit's
-    #                             own scheduled run.
-    #   last_manual_backwash    = most recent cycle that did not.
-    #   last_backwash_trigger   = which of the two the latest cycle was.  No
-    #                             entity — it is redundant with comparing the
-    #                             two timestamps above — but it is surfaced in
-    #                             diagnostics so a misclassification is visible
-    #                             in a dump.
+    # DERIVED — matched against the configured schedule, which is a comparison
+    # against a clock (see BackwashTracker._classify for how it can be wrong):
+    #   last_scheduled_backwash = most recent cycle that ran at the configured
+    #                             time with the menu shut.
     #   next_scheduled_backwash = last_scheduled_backwash projected forward by
     #                             backwash_every_n_days, so it inherits any
-    #                             error in that classification.  None while no
-    #                             scheduled cycle is known: a manual backwash
-    #                             does not reveal the schedule phase, and an
-    #                             unscheduled one cannot be predicted.
+    #                             error in that match.  None while no scheduled
+    #                             cycle is known: a manual backwash does not
+    #                             reveal the schedule phase, and an unscheduled
+    #                             one cannot be predicted.
+    #
+    # A cycle that is neither is left as UNKNOWN and updates only
+    # last_backwash.  It is not filed as manual: not matching the schedule
+    # says the unit's own timer does not explain the cycle, which is not the
+    # same as knowing a person started it.
+    #   last_backwash_trigger   = which of the three the latest cycle was.  No
+    #                             entity — it is nearly redundant with
+    #                             comparing the timestamps above — but it is
+    #                             surfaced in diagnostics so a misclassified
+    #                             or unattributed cycle is visible in a dump.
     #
     # last_scheduled_backwash_source says whether that timestamp was observed
     # or entered by hand, and is exposed as a "source" state attribute so a

--- a/custom_components/aseko_local/aseko_data.py
+++ b/custom_components/aseko_local/aseko_data.py
@@ -49,6 +49,44 @@ class AsekoElectrolyzerDirection(Enum):
     WAITING = "waiting"
 
 
+class AsekoBackwashTrigger(Enum):
+    """What started the most recently observed backwash cycle.
+
+    SCHEDULED — the cycle started within the tolerance window around the
+        configured ``backwash_time`` on a device whose backwash schedule is
+        enabled, so the unit ran it on its own.
+    MANUAL — anything else: the cycle started outside that window, or the
+        schedule is disabled/unconfigured, so a human started it.
+
+    The device does not transmit *why* the valve opened, so this is derived
+    from the observed start time.  See ``backwash_tracker.py``.
+    """
+
+    SCHEDULED = "scheduled"
+    MANUAL = "manual"
+
+
+class AsekoBackwashSource(Enum):
+    """Where ``last_scheduled_backwash`` came from.
+
+    OBSERVED — the integration watched the backwash valve run a full cycle.
+    MANUAL — the user entered it via ``aseko_local.set_last_scheduled_backwash``,
+        to seed the schedule phase instead of waiting for the next real cycle.
+
+    Last write wins, and the timestamps themselves are never compared.  A
+    manual entry replaces whatever is stored, because whoever types a date in
+    has a reason to.  A scheduled cycle detected afterwards replaces that in
+    turn, because the guess it stood in for has now actually been seen.
+
+    ``next_scheduled_backwash`` carries no source of its own — it is always
+    projected from ``last_scheduled_backwash``, so its provenance is that
+    sensor's and repeating it would only be one more thing to keep in sync.
+    """
+
+    OBSERVED = "observed"
+    MANUAL = "manual"
+
+
 class AsekoFiltrationSchedule(Enum):
     """The filtration schedule the unit is configured for (Issue #133).
 
@@ -220,15 +258,47 @@ class AsekoDevice:
     delay_after_dose: int | None = None  # byte 107 & 108 ? (seconds)
     delay_after_startup: int | None = None  # byte 74 & 75 (seconds)
 
-    # Computed backwash schedule (derived from backwash_time + backwash_every_n_days + timestamp).
-    # last_backwash = most recent daily occurrence of backwash_time at or before
-    #                  the frame timestamp.  After the first detected backwash
-    #                  cycle, the BackwashTracker in coordinator.py overrides
-    #                  this with a real observed timestamp (persistent across
-    #                  restarts).  See custom_components/aseko_local/backwash_tracker.py.
-    # next_backwash = last_backwash + backwash_every_n_days days.
+    # Backwash history — filled by the coordinator from BackwashTracker
+    # (persistent across restarts) and None until a real cycle has been seen.
+    # The device never transmits its backwash history, so there is nothing to
+    # derive these from before that: the schedule alone cannot tell us whether
+    # a cycle actually ran, so guessing from it would show a confident
+    # timestamp for something that may never have happened.
+    # See custom_components/aseko_local/backwash_tracker.py.
+    #
+    # These differ in how much they can be trusted:
+    #
+    # OBSERVED — the integration watched the backwash valve stay open for a
+    # full cycle, so this happened:
+    #   last_backwash           = most recent cycle, whatever started it.
+    #
+    # DERIVED — split out of the above by a heuristic on the start time, which
+    # can misclassify (see BackwashTracker._classify for how and when):
+    #   last_scheduled_backwash = most recent cycle that looked like the unit's
+    #                             own scheduled run.
+    #   last_manual_backwash    = most recent cycle that did not.
+    #   last_backwash_trigger   = which of the two the latest cycle was.  No
+    #                             entity — it is redundant with comparing the
+    #                             two timestamps above — but it is surfaced in
+    #                             diagnostics so a misclassification is visible
+    #                             in a dump.
+    #   next_scheduled_backwash = last_scheduled_backwash projected forward by
+    #                             backwash_every_n_days, so it inherits any
+    #                             error in that classification.  None while no
+    #                             scheduled cycle is known: a manual backwash
+    #                             does not reveal the schedule phase, and an
+    #                             unscheduled one cannot be predicted.
+    #
+    # last_scheduled_backwash_source says whether that timestamp was observed
+    # or entered by hand, and is exposed as a "source" state attribute so a
+    # seeded value is never mistaken for a measured one.  next_scheduled_backwash
+    # needs no equivalent: it is always projected from that same timestamp.
     last_backwash: datetime | None = None
-    next_backwash: datetime | None = None
+    last_scheduled_backwash: datetime | None = None
+    last_scheduled_backwash_source: AsekoBackwashSource | None = None
+    last_manual_backwash: datetime | None = None
+    last_backwash_trigger: AsekoBackwashTrigger | None = None
+    next_scheduled_backwash: datetime | None = None
 
     # Server-side receive timestamp – set by the coordinator on every incoming frame.
     # Independent of the device clock (which can be wrong or missing on some models).

--- a/custom_components/aseko_local/aseko_data.py
+++ b/custom_components/aseko_local/aseko_data.py
@@ -58,14 +58,16 @@ class AsekoBackwashTrigger(Enum):
     SCHEDULED — the menu was shut and the cycle started within the tolerance
         window around the configured ``backwash_time`` on a device whose
         backwash schedule is enabled, so the unit ran it on its own.
-    UNKNOWN — neither.  The valve was seen to open, which is a fact, but
-        nothing in the frame says who opened it.
+    UNKNOWN — neither, on a device that reports the menu.  The valve was seen
+        to open, which is a fact, but the unit would have said if somebody had
+        been at it and it did not, so nothing explains the cycle.
 
-    The device does not transmit *why* the valve opened.  Only the menu bit
-    is direct evidence; the schedule match is a comparison against the clock.
-    Everything outside those two is left as UNKNOWN rather than guessed, so a
-    cycle is never filed under a cause that was never observed.
-    See ``backwash_tracker.py``.
+    The device does not transmit *why* the valve opened.  Only the menu bit is
+    direct evidence; the schedule match is a comparison against the clock.  On
+    a device that does not report the menu there is no third option worth
+    having — leftovers there are MANUAL by elimination, as they always were,
+    because the alternative is a ``last_manual_backwash`` that is never filled.
+    See ``BackwashTracker._classify``.
     """
 
     SCHEDULED = "scheduled"
@@ -280,9 +282,11 @@ class AsekoDevice:
     #   last_backwash           = most recent cycle, whatever started it.
     #   last_manual_backwash    = most recent cycle the unit's settings menu
     #                             was open for.  Somebody was standing at the
-    #                             menu the backwash button lives on, so this
-    #                             is observed too — SALT only, since that is
-    #                             the only device the bit is trusted on.
+    #                             menu the backwash button lives on, so on
+    #                             SALT this is observed.  Elsewhere the bit is
+    #                             not trusted and the field falls back to
+    #                             "did not match the schedule", which is a
+    #                             guess — see BackwashTracker._classify.
     #
     # DERIVED — matched against the configured schedule, which is a comparison
     # against a clock (see BackwashTracker._classify for how it can be wrong):
@@ -295,10 +299,11 @@ class AsekoDevice:
     #                             reveal the schedule phase, and an unscheduled
     #                             one cannot be predicted.
     #
-    # A cycle that is neither is left as UNKNOWN and updates only
-    # last_backwash.  It is not filed as manual: not matching the schedule
-    # says the unit's own timer does not explain the cycle, which is not the
-    # same as knowing a person started it.
+    # On SALT a cycle that is neither is left as UNKNOWN and updates only
+    # last_backwash: not matching the schedule says the unit's own timer does
+    # not explain the cycle, which is not the same as knowing a person started
+    # it, and the unit would have reported the menu if one had.  Other device
+    # types cannot report that, so there UNKNOWN never appears.
     #   last_backwash_trigger   = which of the three the latest cycle was.  No
     #                             entity — it is nearly redundant with
     #                             comparing the timestamps above — but it is

--- a/custom_components/aseko_local/aseko_decoder.py
+++ b/custom_components/aseko_local/aseko_decoder.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime, time, timedelta
+from datetime import datetime, time
 import homeassistant.util
 from typing import Type, TypeVar
 
@@ -559,12 +559,14 @@ class AsekoDecoder:
         None for NET — it is the user's responsibility to interpret "no entity
         at all" as "device does not have a backwash output".
 
-        Live confirmation: not yet captured in a frame while a backwash cycle
-        is actually running.  A "no flow to probes" condition (byte[13] bit
-        0x04) was independently confirmed to be associated with byte[28] == 0
-        (and not byte[29] bit 0x01) — see Issue #100, DomSchCoding capture.
-        The bit-0x01 mapping is the same one JS-DE-Tech uses and DomSchCoding
-        identified as a candidate in Issue #100 §"Open: Dynamic State Bytes".
+        Live confirmation (SALT, 2026-08-11): a diagnostics capture spanning a
+        manually started backwash shows byte[29] going 0x48 → 0x49 → 0x48, with
+        the bit set from 13:26:43 to 13:28:09 and clear again at 13:28:29.  The
+        observed 86–106 s relay window matches the unit's configured
+        backwash_duration of 100 s (byte[71] = 0x0a), and no other actuator bit
+        moved during it.  A "no flow to probes" condition (byte[13] bit 0x04)
+        was independently confirmed to be associated with byte[28] == 0 (and
+        not byte[29] bit 0x01) — see Issue #100, DomSchCoding capture.
         """
         if unit.device_type == AsekoDeviceType.NET:
             # NET has no backwash valve — leave the field as None so the
@@ -572,63 +574,6 @@ class AsekoDecoder:
             return
 
         unit.backwash_active = bool(data[29] & 0x01)
-
-    @staticmethod
-    def _fill_backwash_schedule(unit: AsekoDevice) -> None:
-        """Compute estimated last/next backwash datetimes from the schedule config.
-
-        Algorithm:
-          last_backwash = most recent occurrence of backwash_time at or before
-                          the frame timestamp (i.e. today's or yesterday's slot).
-          next_backwash = last_backwash + backwash_every_n_days days.
-
-        Caveat (last_backwash): This is a schedule-based *estimate*.  The actual
-        backwash phase is unknown from the device because it does not transmit
-        when the last backwash physically ran.
-
-        The coordinator (``coordinator.py``) overrides ``last_backwash`` with
-        the value from ``BackwashTracker`` (a persistent store of the last
-        observed ≥60 s relay-on window) once a real backwash has been seen.
-        So:
-            * Before the first observed backwash: the value here is shown
-              (i.e. the latest scheduled slot in the past).
-            * After the first observed backwash: the tracker's value wins
-              (and persists across HA restarts).
-
-        See ``backwash_tracker.py`` for the live-tracking implementation.
-        """
-        # Defensive: the schedule fields are already gated on BACKWASH_TYPES in
-        # decode(), but we re-check the device type here so this method stays
-        # safe even if it is ever called from a code path that didn't pre-filter.
-        if unit.device_type is None or unit.device_type not in BACKWASH_TYPES:
-            return
-        if (
-            unit.backwash_every_n_days is None
-            or unit.backwash_time is None
-            or unit.timestamp is None
-        ):
-            return
-
-        # `0` means "schedule disabled" per the device config / README.
-        # In that case the schedule-derived sensors stay None so the user
-        # does not see bogus last/next datetimes that all collapse to
-        # the same value.
-        if unit.backwash_every_n_days <= 0:
-            return
-
-        tz = unit.timestamp.tzinfo
-        today_at_backwash = datetime.combine(
-            unit.timestamp.date(), unit.backwash_time
-        ).replace(tzinfo=tz)
-
-        # If the scheduled time is still in the future today, use yesterday's slot.
-        if today_at_backwash > unit.timestamp:
-            last = today_at_backwash - timedelta(days=1)
-        else:
-            last = today_at_backwash
-
-        unit.last_backwash = last
-        unit.next_backwash = last + timedelta(days=unit.backwash_every_n_days)
 
     @staticmethod
     def _fill_alarm_data(unit: AsekoDevice, data: bytes) -> None:
@@ -984,6 +929,11 @@ class AsekoDecoder:
         AsekoDecoder._fill_vsp_pump(device, data)
         AsekoDecoder._fill_ph_minus_concentration(device, data)
         AsekoDecoder._fill_backwash_active(device, data)
-        AsekoDecoder._fill_backwash_schedule(device)
+        # The backwash history fields are deliberately NOT derived from the
+        # schedule here: the frame carries the *configuration* (bytes 68-71),
+        # never the history, so the schedule alone cannot say whether a cycle
+        # actually ran.  The coordinator fills those fields from
+        # BackwashTracker once a real relay window has been observed; until
+        # then they stay None and the sensors read "unknown".
 
         return device

--- a/custom_components/aseko_local/backwash_tracker.py
+++ b/custom_components/aseko_local/backwash_tracker.py
@@ -1,11 +1,33 @@
-"""Persistent tracker for the last successful filter backwash cycle.
+"""Persistent tracker for observed filter backwash cycles.
 
 A "successful" backwash is defined as the backwash relay (byte[29] bit 0x01)
 remaining continuously active for at least 60 seconds.  Short relay
 activations (e.g. menu navigation, output-test mode) are ignored.
 
-The last detected backwash timestamp is stored persistently via the
-Home Assistant ``Store`` API and survives:
+That much is observed fact.  Everything else here is derived from it.
+
+Each recorded cycle is *classified* as scheduled or manual by comparing the
+moment the relay opened against the unit's configured ``backwash_time``:
+
+    * within ±``SCHEDULED_MATCH_TOLERANCE`` of the configured time, on a unit
+      whose schedule is enabled  →  SCHEDULED (the unit ran it itself)
+    * anything else                                    →  MANUAL
+
+The device does not transmit *why* the valve opened, nor when it last ran, so
+the start time is the only signal available and the classification is a guess
+that can be wrong — ``_classify`` lists the specific ways.  Consumers should
+treat ``last_backwash`` as reliable and the scheduled/manual split (and the
+``next_scheduled_backwash`` projection built on it) as an estimate.
+
+Nothing is guessed before the first observation, though: every value starts out
+as ``None``: until a cycle has actually been seen, the honest answer is
+"unknown" rather than a timestamp derived from the schedule.
+
+The last scheduled cycle is what drives the "next backwash" projection — a
+manual backwash does not reveal (nor, on the unit, reset) the schedule phase.
+
+The recorded timestamps are stored persistently via the Home Assistant
+``Store`` API and survive:
     * Home Assistant restarts
     * Integration reloads
     * Integration updates
@@ -19,17 +41,22 @@ Public API:
     * ``await tracker.async_load()`` — call once at startup
     * ``tracker.update(device, now)`` — call after every received frame
     * ``await tracker.async_save()`` — fire-and-forget after a recordable event
-    * ``tracker.last_backwash`` — read-only property; the value shown to HA
+    * ``tracker.last_backwash`` / ``last_scheduled_backwash`` /
+      ``last_manual_backwash`` / ``last_trigger`` — read-only properties
+    * ``tracker.next_scheduled_backwash(device, now)`` — projected next
+      automatic cycle
 """
 
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, time, timedelta
 from typing import TYPE_CHECKING
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.storage import Store
+
+from .aseko_data import AsekoBackwashSource, AsekoBackwashTrigger
 
 if TYPE_CHECKING:
     from .aseko_data import AsekoDevice
@@ -49,17 +76,28 @@ MIN_BACKWASH_DURATION = timedelta(seconds=60)
 # being so long that a genuine connection loss is mistaken for a cycle.
 MAX_FRAME_GAP = timedelta(minutes=5)
 
+# How far the observed relay-on start may drift from the configured
+# ``backwash_time`` and still count as the unit's own scheduled cycle.
+# The unit fires on its own clock, which can be a few minutes off from HA's,
+# and the frame that first reports the relay as on can lag the actual start
+# by one transmit interval (~30 s).  15 minutes absorbs both while staying
+# far below any plausible "user pressed the button around that time" overlap.
+SCHEDULED_MATCH_TOLERANCE = timedelta(minutes=15)
+
 # Home Assistant Store schema versioning — bump if the persisted shape changes.
+# Version 1 held only ``last_backwash``; the classification keys added later are
+# optional on load, so old stores keep working and simply report the trigger of
+# the pre-upgrade cycle as unknown.
 STORAGE_VERSION = 1
 STORAGE_KEY_PREFIX = "aseko_local_backwash_"
 
 
 class BackwashTracker:
-    """Detects and persistently records filter backwash events.
+    """Detects, classifies and persistently records filter backwash events.
 
     One instance per device (keyed by ``serial_number``).  Holds the relay
     state machine between frames and is responsible for saving the
-    confirmed backwash timestamp to disk so it survives restarts.
+    confirmed backwash timestamps to disk so they survive restarts.
     """
 
     def __init__(self, hass: HomeAssistant, serial_number: int) -> None:
@@ -78,8 +116,16 @@ class BackwashTracker:
         # Last frame timestamp we processed — used to detect dropped connections.
         self._last_frame_at: datetime | None = None
 
-        # The recorded timestamp (loaded from / saved to storage).
+        # Recorded timestamps (loaded from / saved to storage).
         self._last_backwash: datetime | None = None
+        self._last_scheduled_backwash: datetime | None = None
+        self._last_manual_backwash: datetime | None = None
+        self._last_trigger: AsekoBackwashTrigger | None = None
+
+        # Where _last_scheduled_backwash came from: OBSERVED (we watched the
+        # valve run) or MANUAL (the user seeded it).  Drives the "source"
+        # attribute on both the last- and next-scheduled sensors.
+        self._last_scheduled_source: AsekoBackwashSource | None = None
 
     @property
     def serial_number(self) -> int:
@@ -88,28 +134,145 @@ class BackwashTracker:
 
     @property
     def last_backwash(self) -> datetime | None:
-        """Return the most recent confirmed backwash timestamp, or None."""
+        """Return the most recent observed backwash of any kind, or None."""
         return self._last_backwash
+
+    @property
+    def last_scheduled_backwash(self) -> datetime | None:
+        """Return the most recent backwash that ran on the unit's schedule."""
+        return self._last_scheduled_backwash
+
+    @property
+    def last_scheduled_source(self) -> AsekoBackwashSource | None:
+        """Return where ``last_scheduled_backwash`` came from, or None if unset."""
+        return self._last_scheduled_source
+
+    def set_last_scheduled_backwash(self, moment: datetime) -> None:
+        """Record a user-supplied timestamp for the last scheduled backwash.
+
+        Lets the schedule projection start working immediately instead of
+        waiting out a whole interval for the next real cycle.  The value is
+        marked MANUAL and persisted, and ``next_scheduled_backwash`` is
+        projected from it.
+
+        Last write wins, and the stored timestamps are never compared: an entry
+        always applies, even when it moves the record backwards, because
+        somebody typing a date in is correcting it on purpose.  Symmetrically,
+        a scheduled cycle detected *after* this entry replaces it (see
+        ``_record_window``) — by then the guess has been overtaken by the real
+        thing.
+
+        ``last_backwash`` is deliberately left alone: it means "we watched this
+        happen", and a typed-in date has not been watched.
+        """
+        self._last_scheduled_backwash = moment
+        self._last_scheduled_source = AsekoBackwashSource.MANUAL
+        _LOGGER.info(
+            "Last scheduled backwash for serial=%s set manually to %s",
+            self._serial,
+            moment.isoformat(),
+        )
+        self._hass.async_create_task(self.async_save())
+
+    @property
+    def last_manual_backwash(self) -> datetime | None:
+        """Return the most recent backwash that was started by hand."""
+        return self._last_manual_backwash
+
+    @property
+    def last_trigger(self) -> AsekoBackwashTrigger | None:
+        """Return how the most recent observed backwash was started."""
+        return self._last_trigger
 
     async def async_load(self) -> None:
         """Load the persistent state from storage.  Call once at startup."""
         data = await self._store.async_load()
-        if not data or "last_backwash" not in data:
+        if not data:
             return
+
+        self._last_backwash = self._parse_stored_datetime(data, "last_backwash")
+        self._last_scheduled_backwash = self._parse_stored_datetime(
+            data, "last_scheduled_backwash"
+        )
+        self._last_manual_backwash = self._parse_stored_datetime(
+            data, "last_manual_backwash"
+        )
+
+        trigger = data.get("last_trigger")
+        if trigger is not None:
+            try:
+                self._last_trigger = AsekoBackwashTrigger(trigger)
+            except ValueError:
+                _LOGGER.warning(
+                    "Could not parse stored last_trigger for serial=%s: %r",
+                    self._serial,
+                    trigger,
+                )
+
+        source = data.get("last_scheduled_source")
+        if source is not None:
+            try:
+                self._last_scheduled_source = AsekoBackwashSource(source)
+            except ValueError:
+                _LOGGER.warning(
+                    "Could not parse stored last_scheduled_source for serial=%s: %r",
+                    self._serial,
+                    source,
+                )
+        elif self._last_scheduled_backwash is not None:
+            # Written before provenance was tracked.  Anything already in the
+            # store got there by observation — manual entry did not exist yet.
+            self._last_scheduled_source = AsekoBackwashSource.OBSERVED
+
+    def _parse_stored_datetime(self, data: dict, key: str) -> datetime | None:
+        """Return a stored ISO timestamp as a datetime, or None if absent/invalid."""
+        raw = data.get(key)
+        if raw is None:
+            return None
         try:
-            self._last_backwash = datetime.fromisoformat(data["last_backwash"])
+            return datetime.fromisoformat(raw)
         except (TypeError, ValueError):
             _LOGGER.warning(
-                "Could not parse stored last_backwash for serial=%s: %r",
-                self._serial,
-                data.get("last_backwash"),
+                "Could not parse stored %s for serial=%s: %r", key, self._serial, raw
             )
+            return None
 
     async def async_save(self) -> None:
-        """Persist the current state to storage.  No-op if no event recorded yet."""
-        if self._last_backwash is None:
-            return
-        await self._store.async_save({"last_backwash": self._last_backwash.isoformat()})
+        """Persist the current state to storage.
+
+        Writes unconditionally, nulls included.  An earlier version skipped the
+        write while nothing was recorded, which silently broke
+        ``clear_last_scheduled_backwash``: clearing the only stored value left
+        the old one on disk, and it came back on the next restart.  Every
+        caller reaches this after a change, so there is nothing to save on.
+        """
+        await self._store.async_save(
+            {
+                "last_backwash": (
+                    self._last_backwash.isoformat()
+                    if self._last_backwash is not None
+                    else None
+                ),
+                "last_scheduled_backwash": (
+                    self._last_scheduled_backwash.isoformat()
+                    if self._last_scheduled_backwash is not None
+                    else None
+                ),
+                "last_scheduled_source": (
+                    self._last_scheduled_source.value
+                    if self._last_scheduled_source is not None
+                    else None
+                ),
+                "last_manual_backwash": (
+                    self._last_manual_backwash.isoformat()
+                    if self._last_manual_backwash is not None
+                    else None
+                ),
+                "last_trigger": (
+                    self._last_trigger.value if self._last_trigger is not None else None
+                ),
+            }
+        )
 
     def update(self, device: "AsekoDevice", now: datetime) -> None:
         """Feed a fresh decoded device state into the tracker.
@@ -121,6 +284,8 @@ class BackwashTracker:
         if device.backwash_active is None:
             # NET or unknown — nothing to track.
             return
+
+        self._backfill_split(device)
 
         # Step 1: detect a connection-loss gap and clear the in-progress
         # window.  We do this *before* the "relay on" branch below so the
@@ -149,29 +314,209 @@ class BackwashTracker:
 
         # Step 3: relay just went off.  Evaluate the previous "on" window.
         if self._relay_on_since is not None:
-            duration = now - self._relay_on_since
-            if duration >= MIN_BACKWASH_DURATION:
-                # Record the midpoint of the window as the backwash timestamp.
-                # Better than the start (user might still see "now") or the end
-                # (user has to wait until relay goes off to see anything).
-                recorded_at = self._relay_on_since + duration / 2
-                if self._last_backwash is None or recorded_at > self._last_backwash:
-                    self._last_backwash = recorded_at
-                    _LOGGER.info(
-                        "Backwash detected for serial=%s: %s (duration %s)",
-                        self._serial,
-                        recorded_at.isoformat(),
-                        duration,
-                    )
-                    # Fire-and-forget save; the coordinator will trigger the
-                    # next async_save explicitly when convenient.
-                    self._hass.async_create_task(self.async_save())
-                else:
-                    _LOGGER.debug(
-                        "Backwash event for serial=%s older than last record; "
-                        "skipping (%s <= %s)",
-                        self._serial,
-                        recorded_at,
-                        self._last_backwash,
-                    )
+            self._record_window(device, self._relay_on_since, now)
             self._relay_on_since = None
+
+    def clear_last_scheduled_backwash(self) -> None:
+        """Forget the last scheduled backwash, returning it to unknown.
+
+        The undo for ``set_last_scheduled_backwash``: without it a mistyped
+        date is permanent, because every other path only ever overwrites the
+        value with another one.
+
+        Clearing it also re-arms ``_backfill_split``, so if a
+        ``last_backwash`` is on record and no manual cycle has been observed,
+        the next frame re-derives the split from it.
+        """
+        if self._last_scheduled_backwash is None:
+            return
+        self._last_scheduled_backwash = None
+        self._last_scheduled_source = None
+        _LOGGER.info("Last scheduled backwash cleared for serial=%s", self._serial)
+        self._hass.async_create_task(self.async_save())
+
+    def _backfill_split(self, device: "AsekoDevice") -> None:
+        """Classify a stored ``last_backwash`` that predates the split, once.
+
+        Stores written before the scheduled/manual split existed hold only
+        ``last_backwash``.  That cycle *was* one or the other, and the schedule
+        needed to tell which is in every frame — so rather than leave both new
+        sensors empty until the next cycle (up to a full interval away), work
+        it out from the timestamp we already have.
+
+        Runs from ``update`` rather than ``async_load`` because the schedule
+        comes from the frame, not from storage.  It is a no-op once either
+        bucket is filled, so a later real cycle is never second-guessed.
+        """
+        if self._last_backwash is None:
+            return
+        if (
+            self._last_scheduled_backwash is not None
+            or self._last_manual_backwash is not None
+        ):
+            return
+        if device.backwash_time is None:
+            # No schedule in this frame — try again on the next one.
+            return
+
+        # The stored value is the midpoint of the relay window, while
+        # classification wants its start.  The offset is half a cycle (~50 s on
+        # a 100 s backwash), an order of magnitude inside the tolerance, so the
+        # midpoint stands in for the start without changing any verdict.
+        trigger = self._classify(device, self._last_backwash)
+        if trigger is AsekoBackwashTrigger.SCHEDULED:
+            self._last_scheduled_backwash = self._last_backwash
+            self._last_scheduled_source = AsekoBackwashSource.OBSERVED
+        else:
+            self._last_manual_backwash = self._last_backwash
+        if self._last_trigger is None:
+            self._last_trigger = trigger
+
+        _LOGGER.info(
+            "Classified pre-existing backwash record for serial=%s as %s (%s)",
+            self._serial,
+            trigger.value,
+            self._last_backwash.isoformat(),
+        )
+        self._hass.async_create_task(self.async_save())
+
+    def _record_window(
+        self, device: "AsekoDevice", started_at: datetime, ended_at: datetime
+    ) -> None:
+        """Record a completed relay-on window if it is long enough to be real."""
+        duration = ended_at - started_at
+        if duration < MIN_BACKWASH_DURATION:
+            return
+
+        # Record the midpoint of the window as the backwash timestamp.
+        # Better than the start (user might still see "now") or the end
+        # (user has to wait until relay goes off to see anything).
+        recorded_at = started_at + duration / 2
+        if self._last_backwash is not None and recorded_at <= self._last_backwash:
+            _LOGGER.debug(
+                "Backwash event for serial=%s older than last record; "
+                "skipping (%s <= %s)",
+                self._serial,
+                recorded_at,
+                self._last_backwash,
+            )
+            return
+
+        # Classify on the *start* of the window: that is the moment the unit
+        # opened the valve, and therefore the moment to compare against the
+        # configured schedule.  The midpoint is shifted by half the cycle
+        # duration and would bias every comparison.
+        trigger = self._classify(device, started_at)
+
+        self._last_backwash = recorded_at
+        self._last_trigger = trigger
+        if trigger is AsekoBackwashTrigger.SCHEDULED:
+            # Last write wins: this cycle was detected after whatever is
+            # stored, so it is the more current answer — including when it
+            # replaces a manual seed with an earlier timestamp.  The seed
+            # covered the gap until a real cycle showed up; it has.
+            self._last_scheduled_backwash = recorded_at
+            self._last_scheduled_source = AsekoBackwashSource.OBSERVED
+        else:
+            self._last_manual_backwash = recorded_at
+
+        _LOGGER.info(
+            "Backwash detected for serial=%s: %s (duration %s, trigger %s)",
+            self._serial,
+            recorded_at.isoformat(),
+            duration,
+            trigger.value,
+        )
+        # Fire-and-forget save; the coordinator will trigger the
+        # next async_save explicitly when convenient.
+        self._hass.async_create_task(self.async_save())
+
+    @staticmethod
+    def _classify(device: "AsekoDevice", started_at: datetime) -> AsekoBackwashTrigger:
+        """Return whether a cycle starting at ``started_at`` was scheduled.
+
+        A cycle counts as scheduled only if the unit could have started it
+        itself: the schedule must be configured and enabled, and the relay
+        must have opened within ``SCHEDULED_MATCH_TOLERANCE`` of the
+        configured time of day.  Everything else is a manual start.
+
+        This is a guess, not a fact.  The device reports that the valve opened,
+        never why, so the start time is all there is to go on.  Known ways it
+        gets the answer wrong:
+
+        * A cycle started by hand within the tolerance window of the scheduled
+          time is reported as scheduled.
+        * Only the time of day is checked, not the day itself — a manual cycle
+          at exactly ``backwash_time`` on a day the interval does not fall on
+          still counts as scheduled.  Checking the day would need the schedule
+          phase, which is precisely what we are trying to establish, and would
+          break whenever the user changes the interval.
+        * If the unit's clock drifts more than the tolerance from Home
+          Assistant's, its own scheduled cycles are reported as manual.
+        * A cycle the unit runs on its own for some other reason (e.g. after a
+          fault) is reported as manual.
+
+        Classification uses the schedule as it was in the frame at the time of
+        the cycle, and is never revisited: changing ``backwash_time`` later
+        does not reclassify history.
+        """
+        scheduled_time = device.backwash_time
+        interval = device.backwash_every_n_days
+        if scheduled_time is None or interval is None or interval <= 0:
+            # No usable schedule (0xFF in the config bytes, or interval 0 =
+            # "automatic backwash disabled") — the unit cannot have started
+            # this on its own, so somebody did.
+            return AsekoBackwashTrigger.MANUAL
+
+        if _within_tolerance(started_at, scheduled_time, SCHEDULED_MATCH_TOLERANCE):
+            return AsekoBackwashTrigger.SCHEDULED
+        return AsekoBackwashTrigger.MANUAL
+
+    def next_scheduled_backwash(
+        self, device: "AsekoDevice", now: datetime
+    ) -> datetime | None:
+        """Return the projected next automatic backwash, or None if unknown.
+
+        The projection starts from the last *scheduled* cycle and steps forward
+        in ``backwash_every_n_days`` increments until it lands in the future,
+        so a run of missed cycles (HA offline, unit powered down) does not
+        leave the sensor stuck on a past date.  The result is snapped to the
+        configured ``backwash_time`` rather than to the observed midpoint,
+        because that is when the unit will actually fire.
+
+        Returns None while no scheduled cycle has been observed: a manual
+        backwash says nothing about the unit's schedule phase, and the device
+        does not transmit it.
+        """
+        last_scheduled = self._last_scheduled_backwash
+        interval = device.backwash_every_n_days
+        scheduled_time = device.backwash_time
+        if last_scheduled is None or scheduled_time is None:
+            return None
+        if interval is None or interval <= 0:
+            # Automatic backwash disabled — there is no next one.
+            return None
+
+        step = timedelta(days=interval)
+        next_at = _at_time_of_day(last_scheduled, scheduled_time) + step
+        while next_at <= now:
+            next_at += step
+        return next_at
+
+
+def _at_time_of_day(moment: datetime, at: time) -> datetime:
+    """Return ``moment``'s date at the given wall-clock time, same tz."""
+    return moment.replace(hour=at.hour, minute=at.minute, second=0, microsecond=0)
+
+
+def _within_tolerance(moment: datetime, at: time, tolerance: timedelta) -> bool:
+    """Return True if ``moment`` is within ``tolerance`` of the daily ``at`` time.
+
+    Checks the previous and next day as well so a cycle scheduled near
+    midnight still matches when the two land on different dates.
+    """
+    same_day = _at_time_of_day(moment, at)
+    return any(
+        abs(moment - (same_day + timedelta(days=offset))) <= tolerance
+        for offset in (-1, 0, 1)
+    )

--- a/custom_components/aseko_local/backwash_tracker.py
+++ b/custom_components/aseko_local/backwash_tracker.py
@@ -382,6 +382,21 @@ class BackwashTracker:
         self._last_frame_at = now
 
         # Step 2: if the relay is on, start (or continue) a new window.
+        #
+        # The menu flag is latched (|=) rather than read when the window ends:
+        # the unit drops it around the moment the valve shuts, so the frame
+        # that closes the window has usually lost it already.
+        #
+        # The latch deliberately starts at the window and does not look at
+        # frames before it.  The flag cannot be cleared while the valve is
+        # open — in both captures of a by-hand cycle it is set in every frame
+        # the valve is open in, and in the 2026-08-11 one it stays up ~20 s
+        # after the valve shuts.  So a frame showing the valve open with the
+        # flag down is evidence the cycle was not started from the menu, not
+        # evidence that we looked too late.  Widening the window backwards
+        # would only let a stale flag — the unit emits one frame on entering
+        # the menu and then goes quiet — reach a cycle it has nothing to do
+        # with.
         if device.backwash_active:
             if self._relay_on_since is None:
                 self._relay_on_since = now

--- a/custom_components/aseko_local/backwash_tracker.py
+++ b/custom_components/aseko_local/backwash_tracker.py
@@ -12,7 +12,8 @@ Each recorded cycle is then *classified*, in this order:
     * menu shut, and the relay opened within ±``SCHEDULED_MATCH_TOLERANCE``
       of the configured ``backwash_time`` on a unit whose schedule is
       enabled                                        →  SCHEDULED
-    * anything else                                  →  UNKNOWN
+    * anything else, on a device that reports the menu →  UNKNOWN
+    * anything else, on a device that does not        →  MANUAL
 
 The device does not transmit *why* the valve opened, nor when it last ran.
 Only the first rule is an observation: on SALT, byte[37] bit 0x04 marks the
@@ -21,11 +22,15 @@ from, so a cycle running while the bit is set was started by a person.  See
 ``_service_menu_open``.
 
 The second rule is a comparison against a clock and can be wrong — the ways
-are listed in ``_classify``.  Everything left over is UNKNOWN rather than
-manual: the valve opening is a fact, but a cycle that does not fit the
-schedule is not thereby evidence that somebody started it, and calling it
+are listed in ``_classify``.
+
+What is left over depends on the device.  Where the menu bit is available the
+answer is UNKNOWN: the valve opening is a fact, but a cycle that does not fit
+the schedule is not thereby evidence that somebody started it, and calling it
 manual would put a guess in the same field the menu bit fills with an
-observation.
+observation.  Where it is not available the older elimination rule stands and
+the cycle is called MANUAL — no better, but the alternative there is an
+answer that is always empty.
 
 Consumers should treat ``last_backwash`` as reliable, ``last_manual_backwash``
 as observed, and ``last_scheduled_backwash`` — with the
@@ -100,9 +105,26 @@ def _service_menu_open(device: "AsekoDevice") -> bool:
     cycle scheduled: nobody being at the unit is no proof that the unit
     started the cycle itself.
     """
+    return _service_menu_reported(device) and device.service_menu_open is True
+
+
+def _service_menu_reported(device: "AsekoDevice") -> bool:
+    """Return True if this device reports the settings menu usefully at all.
+
+    Only SALT does.  NET has no filtration output and leaves the field None;
+    on HOME firmware B the same bit is documented as a standing pump override
+    (Issue #133) that can sit set indefinitely, so it says nothing about
+    whether somebody was at the unit for any one cycle.
+
+    This gates more than the MANUAL verdict — it decides whether a cycle that
+    matches nothing can be left UNKNOWN.  Where the signal exists, "not
+    observed and not on schedule" is a real answer.  Where it does not, there
+    is nothing better to say than the pre-existing guess, so the elimination
+    rule stands.  See ``_classify``.
+    """
     return (
         device.device_type is AsekoDeviceType.SALT
-        and device.service_menu_open is True
+        and device.service_menu_open is not None
     )
 
 
@@ -533,11 +555,18 @@ class BackwashTracker:
         the relay must have opened within ``SCHEDULED_MATCH_TOLERANCE`` of the
         configured time of day.
 
-        Anything that is neither is ``UNKNOWN``.  The valve opening is a fact;
-        who opened it is not, and a cycle outside the schedule window is only
-        evidence that the unit's own timer does not explain it — not evidence
-        that a person does.  Calling those manual would put a guess in the
-        same field the menu signal fills with an observation.
+        What happens to a cycle that is neither depends on whether the device
+        reports the menu at all (``_service_menu_reported``):
+
+        * It does (SALT) — ``UNKNOWN``.  The valve opening is a fact; who
+          opened it is not, and a cycle outside the schedule window is only
+          evidence that the unit's own timer does not explain it, not evidence
+          that a person does.  Calling it manual would put a guess in the same
+          field the menu signal fills with an observation.
+        * It does not (everything else) — ``MANUAL``, by elimination, as
+          before this signal existed.  The guess is no better there, but it is
+          all there is, and leaving those devices with a permanently empty
+          ``last_manual_backwash`` would trade a rough answer for none at all.
 
         The schedule match itself is still a comparison against a clock, so it
         can be wrong in ways worth knowing:
@@ -571,7 +600,14 @@ class BackwashTracker:
         ):
             return AsekoBackwashTrigger.SCHEDULED
 
-        return AsekoBackwashTrigger.UNKNOWN
+        if _service_menu_reported(device):
+            # The device would have told us if somebody had been at it, and it
+            # did not — so this matched nothing, and that is the answer.
+            return AsekoBackwashTrigger.UNKNOWN
+
+        # No menu signal on this device type: fall back to the elimination
+        # rule this integration has always used.
+        return AsekoBackwashTrigger.MANUAL
 
     def next_scheduled_backwash(
         self, device: "AsekoDevice", now: datetime

--- a/custom_components/aseko_local/backwash_tracker.py
+++ b/custom_components/aseko_local/backwash_tracker.py
@@ -6,24 +6,30 @@ activations (e.g. menu navigation, output-test mode) are ignored.
 
 That much is observed fact.  Everything else here is derived from it.
 
-Each recorded cycle is *classified* as scheduled or manual by comparing the
-moment the relay opened against the unit's configured ``backwash_time``:
+Each recorded cycle is then *classified*, in this order:
 
-    * within ±``SCHEDULED_MATCH_TOLERANCE`` of the configured time, on a unit
-      whose schedule is enabled  →  SCHEDULED (the unit ran it itself)
-    * anything else                                    →  MANUAL
+    * the settings menu was open while the valve was  →  MANUAL
+    * menu shut, and the relay opened within ±``SCHEDULED_MATCH_TOLERANCE``
+      of the configured ``backwash_time`` on a unit whose schedule is
+      enabled                                        →  SCHEDULED
+    * anything else                                  →  UNKNOWN
 
-The device does not transmit *why* the valve opened, nor when it last ran, so
-on most units the start time is the only signal available and the
-classification is a guess that can be wrong — ``_classify`` lists the specific
-ways.  Consumers should treat ``last_backwash`` as reliable and the
-scheduled/manual split (and the ``next_scheduled_backwash`` projection built
-on it) as an estimate.
+The device does not transmit *why* the valve opened, nor when it last ran.
+Only the first rule is an observation: on SALT, byte[37] bit 0x04 marks the
+settings menu being open, and that is the menu a backwash is started by hand
+from, so a cycle running while the bit is set was started by a person.  See
+``_service_menu_open``.
 
-SALT is the exception: byte[37] bit 0x04 marks its settings menu being open,
-and that is the menu a backwash is started by hand from — so a cycle that
-runs while the bit is set is manual as a matter of observation rather than
-inference.  See ``_service_menu_open``.
+The second rule is a comparison against a clock and can be wrong — the ways
+are listed in ``_classify``.  Everything left over is UNKNOWN rather than
+manual: the valve opening is a fact, but a cycle that does not fit the
+schedule is not thereby evidence that somebody started it, and calling it
+manual would put a guess in the same field the menu bit fills with an
+observation.
+
+Consumers should treat ``last_backwash`` as reliable, ``last_manual_backwash``
+as observed, and ``last_scheduled_backwash`` — with the
+``next_scheduled_backwash`` projection built on it — as an estimate.
 
 Nothing is guessed before the first observation, though: every value starts out
 as ``None``: until a cycle has actually been seen, the honest answer is
@@ -164,6 +170,9 @@ class BackwashTracker:
         self._last_scheduled_backwash: datetime | None = None
         self._last_manual_backwash: datetime | None = None
         self._last_trigger: AsekoBackwashTrigger | None = None
+
+        # _backfill_split runs at most once per session — see its docstring.
+        self._backfill_attempted = False
 
         # Where _last_scheduled_backwash came from: OBSERVED (we watched the
         # valve run) or MANUAL (the user seeded it).  Drives the "source"
@@ -393,11 +402,19 @@ class BackwashTracker:
         sensors empty until the next cycle (up to a full interval away), work
         it out from the timestamp we already have.
 
+        The menu bit is not available retroactively, so this can only ever
+        reach the schedule half of the answer: a stored cycle that does not
+        match the schedule comes out ``UNKNOWN`` and fills neither bucket.
+
         Runs from ``update`` rather than ``async_load`` because the schedule
         comes from the frame, not from storage.  It is a no-op once either
-        bucket is filled, so a later real cycle is never second-guessed.
+        bucket is filled, so a later real cycle is never second-guessed, and
+        runs at most once per session either way — an UNKNOWN verdict fills
+        nothing, and re-deciding it on every frame would only re-log it.
         """
         if self._last_backwash is None:
+            return
+        if self._backfill_attempted:
             return
         if (
             self._last_scheduled_backwash is not None
@@ -412,14 +429,25 @@ class BackwashTracker:
         # classification wants its start.  The offset is half a cycle (~50 s on
         # a 100 s backwash), an order of magnitude inside the tolerance, so the
         # midpoint stands in for the start without changing any verdict.
+        self._backfill_attempted = True
         trigger = self._classify(device, self._last_backwash)
+        if self._last_trigger is None:
+            self._last_trigger = trigger
+
         if trigger is AsekoBackwashTrigger.SCHEDULED:
             self._last_scheduled_backwash = self._last_backwash
             self._last_scheduled_source = AsekoBackwashSource.OBSERVED
         else:
-            self._last_manual_backwash = self._last_backwash
-        if self._last_trigger is None:
-            self._last_trigger = trigger
+            # UNKNOWN — the stored timestamp does not match the schedule, and
+            # whether somebody was at the unit for it is not recoverable now.
+            # It stays in last_backwash alone.
+            _LOGGER.debug(
+                "Pre-existing backwash record for serial=%s (%s) matches no "
+                "schedule; leaving the split empty",
+                self._serial,
+                self._last_backwash.isoformat(),
+            )
+            return
 
         _LOGGER.info(
             "Classified pre-existing backwash record for serial=%s as %s (%s)",
@@ -470,8 +498,11 @@ class BackwashTracker:
             # covered the gap until a real cycle showed up; it has.
             self._last_scheduled_backwash = recorded_at
             self._last_scheduled_source = AsekoBackwashSource.OBSERVED
-        else:
+        elif trigger is AsekoBackwashTrigger.MANUAL:
             self._last_manual_backwash = recorded_at
+        # UNKNOWN updates neither split: last_backwash records that a cycle
+        # happened, and that is all this frame supports.  Filing it under one
+        # of the two would also drag next_scheduled_backwash with it.
 
         _LOGGER.info(
             "Backwash detected for serial=%s: %s (duration %s, trigger %s)",
@@ -500,23 +531,27 @@ class BackwashTracker:
         Without it, a cycle counts as scheduled only if the unit could have
         started it itself: the schedule must be configured and enabled, and
         the relay must have opened within ``SCHEDULED_MATCH_TOLERANCE`` of the
-        configured time of day.  Everything else is a manual start.
+        configured time of day.
 
-        That part is a guess, not a fact.  The device reports that the valve
-        opened, never why, so the start time is all there is to go on.  Known
-        ways it gets the answer wrong:
+        Anything that is neither is ``UNKNOWN``.  The valve opening is a fact;
+        who opened it is not, and a cycle outside the schedule window is only
+        evidence that the unit's own timer does not explain it — not evidence
+        that a person does.  Calling those manual would put a guess in the
+        same field the menu signal fills with an observation.
 
-        * A cycle started by hand within the tolerance window of the scheduled
-          time is reported as scheduled (unless ``service_menu_observed``).
-        * Only the time of day is checked, not the day itself — a manual cycle
-          at exactly ``backwash_time`` on a day the interval does not fall on
+        The schedule match itself is still a comparison against a clock, so it
+        can be wrong in ways worth knowing:
+
+        * A cycle started by hand within the tolerance window, on a unit whose
+          menu bit is not available (anything but SALT), is reported as
+          scheduled.
+        * Only the time of day is checked, not the day itself — a cycle at
+          exactly ``backwash_time`` on a day the interval does not fall on
           still counts as scheduled.  Checking the day would need the schedule
           phase, which is precisely what we are trying to establish, and would
           break whenever the user changes the interval.
         * If the unit's clock drifts more than the tolerance from Home
-          Assistant's, its own scheduled cycles are reported as manual.
-        * A cycle the unit runs on its own for some other reason (e.g. after a
-          fault) is reported as manual.
+          Assistant's, its own scheduled cycles come out UNKNOWN.
 
         Classification uses the schedule as it was in the frame at the time of
         the cycle, and is never revisited: changing ``backwash_time`` later
@@ -528,15 +563,15 @@ class BackwashTracker:
 
         scheduled_time = device.backwash_time
         interval = device.backwash_every_n_days
-        if scheduled_time is None or interval is None or interval <= 0:
-            # No usable schedule (0xFF in the config bytes, or interval 0 =
-            # "automatic backwash disabled") — the unit cannot have started
-            # this on its own, so somebody did.
-            return AsekoBackwashTrigger.MANUAL
-
-        if _within_tolerance(started_at, scheduled_time, SCHEDULED_MATCH_TOLERANCE):
+        if (
+            scheduled_time is not None
+            and interval is not None
+            and interval > 0
+            and _within_tolerance(started_at, scheduled_time, SCHEDULED_MATCH_TOLERANCE)
+        ):
             return AsekoBackwashTrigger.SCHEDULED
-        return AsekoBackwashTrigger.MANUAL
+
+        return AsekoBackwashTrigger.UNKNOWN
 
     def next_scheduled_backwash(
         self, device: "AsekoDevice", now: datetime

--- a/custom_components/aseko_local/backwash_tracker.py
+++ b/custom_components/aseko_local/backwash_tracker.py
@@ -14,10 +14,16 @@ moment the relay opened against the unit's configured ``backwash_time``:
     * anything else                                    →  MANUAL
 
 The device does not transmit *why* the valve opened, nor when it last ran, so
-the start time is the only signal available and the classification is a guess
-that can be wrong — ``_classify`` lists the specific ways.  Consumers should
-treat ``last_backwash`` as reliable and the scheduled/manual split (and the
-``next_scheduled_backwash`` projection built on it) as an estimate.
+on most units the start time is the only signal available and the
+classification is a guess that can be wrong — ``_classify`` lists the specific
+ways.  Consumers should treat ``last_backwash`` as reliable and the
+scheduled/manual split (and the ``next_scheduled_backwash`` projection built
+on it) as an estimate.
+
+SALT is the exception: byte[37] bit 0x04 marks its settings menu being open,
+and that is the menu a backwash is started by hand from — so a cycle that
+runs while the bit is set is manual as a matter of observation rather than
+inference.  See ``_service_menu_open``.
 
 Nothing is guessed before the first observation, though: every value starts out
 as ``None``: until a cycle has actually been seen, the honest answer is
@@ -56,12 +62,43 @@ from typing import TYPE_CHECKING
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.storage import Store
 
-from .aseko_data import AsekoBackwashSource, AsekoBackwashTrigger
+from .aseko_data import (
+    AsekoBackwashSource,
+    AsekoBackwashTrigger,
+    AsekoDeviceType,
+)
 
 if TYPE_CHECKING:
     from .aseko_data import AsekoDevice
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _service_menu_open(device: "AsekoDevice") -> bool:
+    """Return True if somebody has the unit's settings menu open.
+
+    On SALT, byte[37] bit 0x04 marks that menu — the one filtration and
+    backwash can be started by hand from.  It appears on entering, before
+    anything is touched, so on its own it says only that a person is at the
+    unit.  Paired with a running backwash it says more: a capture of a
+    by-hand cycle has the bit set on every frame from ~30 s before the valve
+    opened until ~20 s after it closed.  Somebody was standing at the menu
+    the button lives on — observed, not inferred from the clock.
+
+    Restricted to SALT because the same bit is documented differently on
+    HOME firmware B (Issue #133): a standing manual override that forces the
+    pump off and can stay set indefinitely.  Honouring it there would
+    misclassify every scheduled cycle that ran while the override was on.
+
+    The bit is only ever *additional* evidence.  It is never used to call a
+    cycle scheduled: nobody being at the unit is no proof that the unit
+    started the cycle itself.
+    """
+    return (
+        device.device_type is AsekoDeviceType.SALT
+        and device.service_menu_open is True
+    )
+
 
 # Minimum continuous relay-on duration to count as a real backwash cycle.
 # The device has reported backwash durations of 1:40 to 2:00 minutes; 60 s
@@ -112,6 +149,12 @@ class BackwashTracker:
         # State machine: when did the current "relay on" window start?
         # None = relay is currently off, or we have not seen it on yet.
         self._relay_on_since: datetime | None = None
+
+        # Was the settings menu open during the current window?  Latched
+        # across the whole window rather than read at the end: the unit
+        # drops the flag a frame or two after the valve closes, so by the
+        # time the window is recorded it has usually gone again.
+        self._service_menu_in_window = False
 
         # Last frame timestamp we processed — used to detect dropped connections.
         self._last_frame_at: datetime | None = None
@@ -304,18 +347,24 @@ class BackwashTracker:
                 self._serial,
             )
             self._relay_on_since = None
+            self._service_menu_in_window = False
         self._last_frame_at = now
 
         # Step 2: if the relay is on, start (or continue) a new window.
         if device.backwash_active:
             if self._relay_on_since is None:
                 self._relay_on_since = now
+                self._service_menu_in_window = False
+            self._service_menu_in_window |= _service_menu_open(device)
             return
 
         # Step 3: relay just went off.  Evaluate the previous "on" window.
         if self._relay_on_since is not None:
-            self._record_window(device, self._relay_on_since, now)
+            self._record_window(
+                device, self._relay_on_since, now, self._service_menu_in_window
+            )
             self._relay_on_since = None
+            self._service_menu_in_window = False
 
     def clear_last_scheduled_backwash(self) -> None:
         """Forget the last scheduled backwash, returning it to unknown.
@@ -381,7 +430,11 @@ class BackwashTracker:
         self._hass.async_create_task(self.async_save())
 
     def _record_window(
-        self, device: "AsekoDevice", started_at: datetime, ended_at: datetime
+        self,
+        device: "AsekoDevice",
+        started_at: datetime,
+        ended_at: datetime,
+        service_menu_observed: bool = False,
     ) -> None:
         """Record a completed relay-on window if it is long enough to be real."""
         duration = ended_at - started_at
@@ -406,7 +459,7 @@ class BackwashTracker:
         # opened the valve, and therefore the moment to compare against the
         # configured schedule.  The midpoint is shifted by half the cycle
         # duration and would bias every comparison.
-        trigger = self._classify(device, started_at)
+        trigger = self._classify(device, started_at, service_menu_observed)
 
         self._last_backwash = recorded_at
         self._last_trigger = trigger
@@ -432,20 +485,29 @@ class BackwashTracker:
         self._hass.async_create_task(self.async_save())
 
     @staticmethod
-    def _classify(device: "AsekoDevice", started_at: datetime) -> AsekoBackwashTrigger:
+    def _classify(
+        device: "AsekoDevice",
+        started_at: datetime,
+        service_menu_observed: bool = False,
+    ) -> AsekoBackwashTrigger:
         """Return whether a cycle starting at ``started_at`` was scheduled.
 
-        A cycle counts as scheduled only if the unit could have started it
-        itself: the schedule must be configured and enabled, and the relay
-        must have opened within ``SCHEDULED_MATCH_TOLERANCE`` of the
+        ``service_menu_observed`` is the one hard signal available: on SALT the
+        unit reports that somebody was operating it by hand while the valve
+        was open (see ``_service_menu_open``), which settles the question.
+        It is only ever raised, never lowered — its absence proves nothing.
+
+        Without it, a cycle counts as scheduled only if the unit could have
+        started it itself: the schedule must be configured and enabled, and
+        the relay must have opened within ``SCHEDULED_MATCH_TOLERANCE`` of the
         configured time of day.  Everything else is a manual start.
 
-        This is a guess, not a fact.  The device reports that the valve opened,
-        never why, so the start time is all there is to go on.  Known ways it
-        gets the answer wrong:
+        That part is a guess, not a fact.  The device reports that the valve
+        opened, never why, so the start time is all there is to go on.  Known
+        ways it gets the answer wrong:
 
         * A cycle started by hand within the tolerance window of the scheduled
-          time is reported as scheduled.
+          time is reported as scheduled (unless ``service_menu_observed``).
         * Only the time of day is checked, not the day itself — a manual cycle
           at exactly ``backwash_time`` on a day the interval does not fall on
           still counts as scheduled.  Checking the day would need the schedule
@@ -460,6 +522,10 @@ class BackwashTracker:
         the cycle, and is never revisited: changing ``backwash_time`` later
         does not reclassify history.
         """
+        if service_menu_observed:
+            # Observed fact rather than inference: a person was at the unit.
+            return AsekoBackwashTrigger.MANUAL
+
         scheduled_time = device.backwash_time
         interval = device.backwash_every_n_days
         if scheduled_time is None or interval is None or interval <= 0:

--- a/custom_components/aseko_local/backwash_tracker.py
+++ b/custom_components/aseko_local/backwash_tracker.py
@@ -459,6 +459,11 @@ class BackwashTracker:
         if trigger is AsekoBackwashTrigger.SCHEDULED:
             self._last_scheduled_backwash = self._last_backwash
             self._last_scheduled_source = AsekoBackwashSource.OBSERVED
+        elif trigger is AsekoBackwashTrigger.MANUAL:
+            # Only reachable on a device with no menu signal, where MANUAL is
+            # the elimination verdict — the bit itself is not recoverable
+            # after the fact, so a live MANUAL can never be backfilled.
+            self._last_manual_backwash = self._last_backwash
         else:
             # UNKNOWN — the stored timestamp does not match the schedule, and
             # whether somebody was at the unit for it is not recoverable now.

--- a/custom_components/aseko_local/coordinator.py
+++ b/custom_components/aseko_local/coordinator.py
@@ -2,7 +2,7 @@
 
 import logging
 from collections.abc import Callable
-from datetime import timedelta
+from datetime import datetime, timedelta
 from types import CoroutineType
 from typing import Any
 
@@ -87,6 +87,12 @@ class AsekoLocalDataUpdateCoordinator(DataUpdateCoordinator[AsekoData]):
                 "➡️ Device %s is_new_device=%s", device.serial_number, is_new_device
             )
 
+            # Fill the observed-backwash fields *before* handing the device to
+            # AsekoData.set(): for an already-known device, set() copies the
+            # attributes off this object onto the stored one, and anything
+            # written afterwards would never reach the entities.
+            self._update_backwash(device)
+
             new_data.set(device.serial_number, device)
 
             # Stamp server-side receive time (independent of device clock)
@@ -98,28 +104,6 @@ class AsekoLocalDataUpdateCoordinator(DataUpdateCoordinator[AsekoData]):
             if device.serial_number not in self._trackers:
                 self._trackers[device.serial_number] = AsekoConsumptionTracker()
             self._trackers[device.serial_number].update(device, dt_util.now())
-
-            # Update backwash tracker for this device (live detection,
-            # overrides the schedule-based schedule estimate with a real
-            # observed timestamp that survives restarts).
-            #
-            # Lazy-load persisted state on first frame after a restart so
-            # the saved last_backwash survives reloads.  Doing it here
-            # (rather than in ``async_setup_backwash_trackers``) avoids a
-            # race where the tracker is created on the first frame *before*
-            # the setup hook has a chance to load its persisted state.
-            if device.serial_number not in self._backwash_trackers:
-                tracker = BackwashTracker(self.hass, device.serial_number)
-                self._backwash_trackers[device.serial_number] = tracker
-                self.hass.async_create_task(tracker.async_load())
-            tracker = self._backwash_trackers[device.serial_number]
-            tracker.update(device, dt_util.now())
-            # Override schedule-based estimate with the real observed value.
-            # The sensor reads device.last_backwash, so this transparently
-            # switches from "schedule" to "live" once the tracker has data.
-            observed = tracker.last_backwash
-            if observed is not None:
-                device.last_backwash = observed
 
             _LOGGER.debug(
                 "✅ Stored device %s → known serials now: %s",
@@ -151,6 +135,99 @@ class AsekoLocalDataUpdateCoordinator(DataUpdateCoordinator[AsekoData]):
                         listener,
                         device.serial_number,
                     )
+
+    def _update_backwash(self, device: AsekoDevice) -> None:
+        """Feed the frame to the device's BackwashTracker and publish its state.
+
+        The device transmits only the backwash *configuration* and the live
+        relay bit, never its history, so every observed-backwash field on
+        ``AsekoDevice`` comes from the tracker.  They stay None until a real
+        cycle has been seen, which is what makes the sensors read "unknown"
+        rather than showing a schedule-derived guess.
+
+        Lazy-load persisted state on the first frame after a restart so the
+        saved timestamps survive reloads.  Doing it here (rather than in
+        ``async_setup_backwash_trackers``) avoids a race where the tracker is
+        created on the first frame *before* the setup hook has had a chance to
+        load its persisted state.
+        """
+        serial = device.serial_number
+        if serial is None:
+            return
+
+        if serial not in self._backwash_trackers:
+            new_tracker = BackwashTracker(self.hass, serial)
+            self._backwash_trackers[serial] = new_tracker
+            self.hass.async_create_task(new_tracker.async_load())
+
+        tracker = self._backwash_trackers[serial]
+        now = dt_util.now()
+        tracker.update(device, now)
+        self._publish_backwash(device, tracker, now)
+
+    @staticmethod
+    def _publish_backwash(
+        device: AsekoDevice, tracker: BackwashTracker, now: datetime
+    ) -> None:
+        """Copy the tracker's state onto the device object the entities read."""
+        device.last_backwash = tracker.last_backwash
+        device.last_scheduled_backwash = tracker.last_scheduled_backwash
+        device.last_scheduled_backwash_source = tracker.last_scheduled_source
+        device.last_manual_backwash = tracker.last_manual_backwash
+        device.last_backwash_trigger = tracker.last_trigger
+        device.next_scheduled_backwash = tracker.next_scheduled_backwash(device, now)
+
+    def set_last_scheduled_backwash(
+        self, moment: datetime, serial_number: int | None = None
+    ) -> bool:
+        """Seed the last scheduled backwash for one device, or for all of them."""
+        return self._apply_to_backwash_trackers(
+            lambda tracker: tracker.set_last_scheduled_backwash(moment),
+            serial_number,
+        )
+
+    def clear_last_scheduled_backwash(self, serial_number: int | None = None) -> bool:
+        """Forget the last scheduled backwash for one device, or for all of them."""
+        return self._apply_to_backwash_trackers(
+            lambda tracker: tracker.clear_last_scheduled_backwash(),
+            serial_number,
+        )
+
+    def _apply_to_backwash_trackers(
+        self,
+        action: Callable[[BackwashTracker], None],
+        serial_number: int | None,
+    ) -> bool:
+        """Run ``action`` on the matching trackers and republish their state.
+
+        Backs the ``aseko_local.*_last_scheduled_backwash`` services.  Returns
+        True if at least one tracker matched, so the service can tell the user
+        when a serial number matched nothing.
+
+        The stored device objects are updated in place and listeners notified,
+        so the entities reflect the change straight away instead of waiting for
+        the next frame.
+        """
+        if serial_number is not None:
+            trackers = {
+                serial: tracker
+                for serial, tracker in self._backwash_trackers.items()
+                if serial == serial_number
+            }
+        else:
+            trackers = dict(self._backwash_trackers)
+
+        if not trackers:
+            return False
+
+        for serial, tracker in trackers.items():
+            action(tracker)
+            device = self.get_device(serial)
+            if device is not None:
+                self._publish_backwash(device, tracker, dt_util.now())
+
+        self.async_update_listeners()
+        return True
 
     def async_add_new_device_listener(
         self, listener: Callable[[AsekoDevice], None]

--- a/custom_components/aseko_local/datetime.py
+++ b/custom_components/aseko_local/datetime.py
@@ -1,0 +1,105 @@
+"""Aseko Local writable datetime entities.
+
+Holds the one backwash value the device cannot tell us: when its last
+*scheduled* cycle ran.  Until that is known the "next scheduled backwash"
+projection has nothing to count from, and waiting for the integration to
+observe a cycle can take a whole interval.
+
+Making it a ``datetime`` entity rather than a read-only sensor means the value
+is set the obvious way — click it, pick a date in the dialog, done — with no
+helper or script in between.  ``aseko_local.set_last_scheduled_backwash``
+remains available for automations.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+
+from homeassistant.components.datetime import DateTimeEntity, DateTimeEntityDescription
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.util import dt as dt_util
+
+from . import AsekoLocalConfigEntry
+from .aseko_data import AsekoDevice
+from .coordinator import AsekoLocalDataUpdateCoordinator
+from .entity import AsekoLocalEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+LAST_SCHEDULED_BACKWASH = DateTimeEntityDescription(
+    key="last_scheduled_backwash",
+    translation_key="last_scheduled_backwash",
+    icon="mdi:calendar-check",
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: AsekoLocalConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the writable backwash datetime entities."""
+
+    coordinator = config_entry.runtime_data.coordinator
+    async_add_entities(_build_entities(coordinator.get_devices(), coordinator))
+
+    @callback
+    def _async_add_new_device(device: AsekoDevice) -> None:
+        new_entities = _build_entities([device], coordinator)
+        if new_entities:
+            async_add_entities(new_entities)
+
+    config_entry.async_on_unload(
+        coordinator.async_add_new_device_listener(_async_add_new_device)
+    )
+
+
+def _build_entities(
+    devices: list[AsekoDevice],
+    coordinator: AsekoLocalDataUpdateCoordinator,
+) -> list[DateTimeEntity]:
+    """Create one entity per device that has a backwash valve.
+
+    ``backwash_active`` is the decoder's presence marker for that output: it is
+    left as None on device types without one (NET).  See Issue #129.
+    """
+    return [
+        AsekoLastScheduledBackwashEntity(device, coordinator, LAST_SCHEDULED_BACKWASH)
+        for device in devices
+        if device.backwash_active is not None
+    ]
+
+
+class AsekoLastScheduledBackwashEntity(AsekoLocalEntity, DateTimeEntity):
+    """When the unit last ran its scheduled backwash — observed or entered."""
+
+    entity_description: DateTimeEntityDescription
+
+    @property
+    def native_value(self) -> datetime | None:
+        """Return the stored timestamp, or None while nothing is known."""
+        return self.device.last_scheduled_backwash
+
+    @property
+    def extra_state_attributes(self) -> dict[str, str] | None:
+        """Publish whether this was observed or entered by hand.
+
+        Omitted while the value is unknown — an attribute describing where a
+        non-existent value came from is just noise.
+        """
+        source = self.device.last_scheduled_backwash_source
+        if source is None:
+            return None
+        return {"source": source.value}
+
+    async def async_set_value(self, value: datetime) -> None:
+        """Record a user-supplied timestamp and re-project the next cycle."""
+        if value > dt_util.now():
+            raise ServiceValidationError(
+                f"{value.isoformat()} is in the future; "
+                "the last scheduled backwash must already have happened"
+            )
+        self.coordinator.set_last_scheduled_backwash(value, self.device.serial_number)

--- a/custom_components/aseko_local/diagnostics.py
+++ b/custom_components/aseko_local/diagnostics.py
@@ -236,6 +236,15 @@ def _parse_v8_frame(raw: bytes) -> dict[str, Any] | None:
     }
 
 
+def _str_or_none(value: Any) -> str | None:
+    """Render an optional value as a string, keeping None as None.
+
+    ``str(None)`` would produce the literal "None", which reads in a dump like
+    a value rather than like "never observed".
+    """
+    return None if value is None else str(value)
+
+
 async def async_get_config_entry_diagnostics(
     hass: HomeAssistant,
     config_entry: AsekoLocalConfigEntry,
@@ -283,6 +292,21 @@ async def async_get_config_entry_diagnostics(
             "flowrate_ph_plus_ml_min": device.flowrate_ph_plus,
             "flowrate_algicide_ml_min": device.flowrate_algicide,
             "flowrate_floc_ml_min": device.flowrate_floc,
+            # Backwash: the live relay bit plus the observed history the
+            # BackwashTracker has built from it.  Without these a dump only
+            # carries the schedule config (bytes 68-71) and the raw byte[29],
+            # so answering "did a backwash run?" meant decoding bit 0x01 by
+            # hand across a series of dumps.  None = not yet observed.
+            "backwash_active": device.backwash_active,
+            "last_backwash": _str_or_none(device.last_backwash),
+            "last_scheduled_backwash": _str_or_none(device.last_scheduled_backwash),
+            "last_manual_backwash": _str_or_none(device.last_manual_backwash),
+            "last_backwash_trigger": (
+                device.last_backwash_trigger.value
+                if device.last_backwash_trigger
+                else None
+            ),
+            "next_scheduled_backwash": _str_or_none(device.next_scheduled_backwash),
         }
 
         # --- Consumption counters ---

--- a/custom_components/aseko_local/sensor.py
+++ b/custom_components/aseko_local/sensor.py
@@ -26,7 +26,11 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
 from . import AsekoLocalConfigEntry
-from .aseko_data import AsekoDevice, AsekoElectrolyzerDirection, ACTUATOR_MASKS
+from .aseko_data import (
+    ACTUATOR_MASKS,
+    AsekoDevice,
+    AsekoElectrolyzerDirection,
+)
 from .coordinator import AsekoLocalDataUpdateCoordinator
 from .entity import AsekoLocalEntity
 
@@ -41,6 +45,17 @@ class AsekoSensorEntityDescription(SensorEntityDescription):
 
     value_fn: Callable[[AsekoDevice], StateType]
     enabled: bool = True
+    # Decides whether the device has this sensor at all.  By default a sensor
+    # is created only when its value is already known, which is right for
+    # values read straight out of the frame: a None there means the device
+    # does not report that quantity.
+    #
+    # It is wrong for values that are legitimately unknown until an event is
+    # observed — the observed-backwash timestamps start out None on a device
+    # that does have a backwash valve, and without an explicit check their
+    # entities would never be created.  Set this to decide presence from
+    # something other than the current value.
+    supported_fn: Callable[[AsekoDevice], bool] | None = None
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -200,6 +215,18 @@ RETIRED_UNIQUE_ID_SUFFIXES: frozenset[str] = frozenset(
         "filtration_mode",
     }
 )
+
+
+def _has_backwash(device: AsekoDevice) -> bool:
+    """Return True if the device has a backwash valve.
+
+    ``backwash_active`` is the decoder's presence marker for the backwash
+    output: it is left as None on device types without one (NET), and is a
+    real bool on every type that has one, whether or not the valve is
+    currently open.  See ``AsekoDecoder._fill_backwash_active`` and Issue #129.
+    """
+    return device.backwash_active is not None
+
 
 SENSORS: list[AsekoSensorEntityDescription] = [
     AsekoSensorEntityDescription(
@@ -600,21 +627,62 @@ SENSORS: list[AsekoSensorEntityDescription] = [
         icon="mdi:timer-sand",
         value_fn=lambda device: device.backwash_duration,
     ),
+    # Observed backwash history.  All four are gated on _has_backwash rather
+    # than on their own value, because they are unknown until a cycle has
+    # actually been seen — see supported_fn.
+    #
+    # last_backwash is the *observed* one: the integration watched the backwash
+    # valve stay open, so the cycle definitely happened.
+    #
+    # The scheduled/manual split is *derived* from it by a heuristic comparing
+    # the start time against the configured schedule, and that heuristic can
+    # get it wrong — the device never says why the valve opened.  Only the
+    # timestamps stay exact.  "(estimated)" therefore marks just
+    # next_scheduled_backwash, the one value that is calculated rather than
+    # measured.  See backwash_tracker.BackwashTracker._classify.
     AsekoSensorEntityDescription(
         key="last_backwash",
         translation_key="last_backwash",
         device_class=SensorDeviceClass.TIMESTAMP,
         icon="mdi:clock-check-outline",
         value_fn=lambda device: device.last_backwash,
+        supported_fn=_has_backwash,
+    ),
+    # last_scheduled_backwash is not here: it is a writable datetime entity
+    # (see datetime.py) so it can be set from the UI in one click, rather than
+    # a read-only sensor plus a helper and a script to feed it.
+    AsekoSensorEntityDescription(
+        key="last_manual_backwash",
+        translation_key="last_manual_backwash",
+        device_class=SensorDeviceClass.TIMESTAMP,
+        icon="mdi:hand-back-right-outline",
+        value_fn=lambda device: device.last_manual_backwash,
+        supported_fn=_has_backwash,
     ),
     AsekoSensorEntityDescription(
-        key="next_backwash",
-        translation_key="next_backwash",
+        # Renamed from "next_backwash" — see MIGRATED_UNIQUE_ID_SUFFIXES.
+        key="next_scheduled_backwash",
+        translation_key="next_scheduled_backwash",
         device_class=SensorDeviceClass.TIMESTAMP,
         icon="mdi:clock-alert-outline",
-        value_fn=lambda device: device.next_backwash,
+        value_fn=lambda device: device.next_scheduled_backwash,
+        supported_fn=_has_backwash,
+        # No source attribute: this is always projected from
+        # last_scheduled_backwash, so that sensor's source is this one's too.
     ),
 ]
+
+# Sensor keys that were renamed after release.  The unique_id is
+# f"{serial_number}{key}", so renaming a key orphans the registry entry: the
+# old entity goes unavailable forever and a fresh one appears beside it under a
+# new entity_id, losing its history.  async_migrate_unique_ids rewrites them at
+# setup instead.  Old suffix → new suffix; entries are matched on the suffix
+# because the serial number prefix varies per device.
+MIGRATED_UNIQUE_ID_SUFFIXES: dict[str, str] = {
+    # v1.7.x → next: renamed for symmetry with last_scheduled_backwash, and
+    # because the value only ever projects the *scheduled* cycle.
+    "next_backwash": "next_scheduled_backwash",
+}
 
 # ---------- Connection status sensor ----------
 
@@ -657,6 +725,51 @@ def async_remove_retired_entities(
         registry.async_remove(entry.entity_id)
 
 
+@callback
+def async_migrate_unique_ids(
+    hass: HomeAssistant, config_entry: AsekoLocalConfigEntry
+) -> None:
+    """Rewrite registry unique_ids for sensor keys that have been renamed.
+
+    Runs before the entities are added, so each renamed sensor keeps its
+    entity_id, its history and any automation pointing at it.
+
+    Nothing happens when there is no old entry, so this is a no-op on fresh
+    installs and on every setup after the first.
+    """
+    registry = er.async_get(hass)
+    existing = {
+        entry.unique_id
+        for entry in er.async_entries_for_config_entry(registry, config_entry.entry_id)
+    }
+
+    for entry in er.async_entries_for_config_entry(registry, config_entry.entry_id):
+        if entry.domain != "sensor":
+            continue
+        for old_suffix, new_suffix in MIGRATED_UNIQUE_ID_SUFFIXES.items():
+            if not entry.unique_id.endswith(old_suffix):
+                continue
+            new_unique_id = entry.unique_id[: -len(old_suffix)] + new_suffix
+            if new_unique_id in existing:
+                # Both ids present — the new entity was already created (e.g. a
+                # partially completed earlier migration).  Renaming onto it
+                # would raise, so leave the stale one for the user to delete.
+                _LOGGER.debug(
+                    ">>> [sensor] Skipping unique_id migration %s → %s: target exists",
+                    entry.unique_id,
+                    new_unique_id,
+                )
+                break
+            _LOGGER.info(
+                "Migrating Aseko sensor unique_id %s → %s",
+                entry.unique_id,
+                new_unique_id,
+            )
+            registry.async_update_entity(entry.entity_id, new_unique_id=new_unique_id)
+            existing.add(new_unique_id)
+            break
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: AsekoLocalConfigEntry,
@@ -665,6 +778,7 @@ async def async_setup_entry(
     """Set up the Aseko device sensors."""
 
     async_remove_retired_entities(hass, config_entry)
+    async_migrate_unique_ids(hass, config_entry)
 
     coordinator = config_entry.runtime_data.coordinator
     devices = coordinator.get_devices() or []
@@ -717,7 +831,17 @@ def _build_sensor_entities(
                 val,
             )
 
-            if val is None:
+            # Without a supported_fn, a value of None means "device does not
+            # report this".  With one, the device decides presence and the
+            # sensor may legitimately start out unknown.
+            if description.supported_fn is not None:
+                if not description.supported_fn(device):
+                    _LOGGER.debug(
+                        "   - Skipped unsupported sensor: %s",
+                        key,
+                    )
+                    continue
+            elif val is None:
                 _LOGGER.debug(
                     "   - Skipped non-available sensor: %s (value=None)",
                     key,

--- a/custom_components/aseko_local/services.yaml
+++ b/custom_components/aseko_local/services.yaml
@@ -1,3 +1,60 @@
+set_last_scheduled_backwash:
+  name: Set last scheduled backwash
+  description: >
+    Records when the unit last ran its scheduled backwash, so the "next
+    scheduled backwash" projection can start without waiting a whole interval
+    for the first cycle the integration observes itself. The device never
+    transmits its backwash history, so this has to be entered by hand.
+
+    The value is marked as manually entered (source: manual) on the
+    "last scheduled backwash" sensor. The last write wins: a date entered here
+    always applies, whatever was stored before, and a scheduled cycle detected
+    afterwards replaces it in turn.
+  fields:
+    timestamp:
+      name: Last scheduled backwash
+      description: >
+        When the scheduled backwash last ran. Must be in the past.
+      required: true
+      example: "2026-08-01 12:30:00"
+      selector:
+        datetime:
+    serial_number:
+      name: Serial number
+      description: >
+        Which device to set. Leave empty to set it on every Aseko device that
+        has a backwash valve.
+      required: false
+      example: 110071590
+      selector:
+        number:
+          mode: box
+          min: 0
+          step: 1
+
+clear_last_scheduled_backwash:
+  name: Clear last scheduled backwash
+  description: >
+    Forgets the last scheduled backwash, returning it to unknown. The undo for
+    a mistyped date entered with set_last_scheduled_backwash.
+
+    If the integration has an older backwash on record and no manual cycle has
+    been observed, clearing this also re-derives the scheduled/manual split
+    from that record on the next frame.
+  fields:
+    serial_number:
+      name: Serial number
+      description: >
+        Which device to clear. Leave empty to clear it on every Aseko device
+        that has a backwash valve.
+      required: false
+      example: 110071590
+      selector:
+        number:
+          mode: box
+          min: 0
+          step: 1
+
 reset_consumption:
   name: Reset consumption
   description: >

--- a/custom_components/aseko_local/translations/cs.json
+++ b/custom_components/aseko_local/translations/cs.json
@@ -35,6 +35,11 @@
     }
   },
   "entity": {
+    "datetime": {
+      "last_scheduled_backwash": {
+        "name": "Poslední plánované zpětné proplachování"
+      }
+    },
     "binary_sensor": {
       "electrolyzer_active": {
         "name": "Elektrolyzér aktivní"
@@ -213,8 +218,11 @@
       "last_backwash": {
         "name": "Poslední zpětné proplachování"
       },
-      "next_backwash": {
-        "name": "Príští zpětné proplachování"
+      "last_manual_backwash": {
+        "name": "Poslední ruční zpětné proplachování"
+      },
+      "next_scheduled_backwash": {
+        "name": "Příští plánované zpětné proplachování (odhad)"
       },
       "backwash_every_n_days": {
         "name": "Interval zpětného proplachování"

--- a/custom_components/aseko_local/translations/de.json
+++ b/custom_components/aseko_local/translations/de.json
@@ -35,6 +35,11 @@
     }
   },
   "entity": {
+    "datetime": {
+      "last_scheduled_backwash": {
+        "name": "Letzte geplante Rückspülung"
+      }
+    },
     "binary_sensor": {
       "electrolyzer_active": {
         "name": "Elektrolyseur aktiv"
@@ -227,8 +232,11 @@
       "last_backwash": {
         "name": "Letzte Rückspülung"
       },
-      "next_backwash": {
-        "name": "Nächste Rückspülung"
+      "last_manual_backwash": {
+        "name": "Letzte manuelle Rückspülung"
+      },
+      "next_scheduled_backwash": {
+        "name": "Nächste geplante Rückspülung (geschätzt)"
       },
       "backwash_every_n_days": {
         "name": "Rückspülintervall"

--- a/custom_components/aseko_local/translations/en.json
+++ b/custom_components/aseko_local/translations/en.json
@@ -35,6 +35,11 @@
     }
   },
   "entity": {
+    "datetime": {
+      "last_scheduled_backwash": {
+        "name": "Last scheduled backwash"
+      }
+    },
     "binary_sensor": {
       "electrolyzer_active": {
         "name": "Electrolyzer active"
@@ -213,8 +218,11 @@
       "last_backwash": {
         "name": "Last backwash"
       },
-      "next_backwash": {
-        "name": "Next backwash"
+      "last_manual_backwash": {
+        "name": "Last manual backwash"
+      },
+      "next_scheduled_backwash": {
+        "name": "Next scheduled backwash (estimated)"
       },
       "backwash_every_n_days": {
         "name": "Backwash interval"

--- a/custom_components/aseko_local/translations/fr.json
+++ b/custom_components/aseko_local/translations/fr.json
@@ -35,6 +35,11 @@
         }
     },
     "entity": {
+        "datetime": {
+            "last_scheduled_backwash": {
+                "name": "Dernier contre-lavage programmé"
+            }
+        },
         "binary_sensor": {
             "electrolyzer_active": {
                 "name": "Électrolyseur actif"
@@ -227,8 +232,11 @@
             "last_backwash": {
                 "name": "Dernière contre-lavage"
             },
-            "next_backwash": {
-                "name": "Prochain contre-lavage"
+            "last_manual_backwash": {
+                "name": "Dernier contre-lavage manuel"
+            },
+            "next_scheduled_backwash": {
+                "name": "Prochain contre-lavage programmé (estimé)"
             },
             "backwash_every_n_days": {
                 "name": "Intervalle de contre-lavage"

--- a/docs/device analyzes/profi_device_analysis.md
+++ b/docs/device analyzes/profi_device_analysis.md
@@ -245,8 +245,8 @@ mapping is expected to be the same.
 ## Backwash & backwash schedule (assumed same as HOME/SALT/OXY)
 
 PROFI is documented in the manual to have a backwash valve. The decoder fills the
-backwash fields in `_fill_backwash_active` and `_fill_backwash_schedule` with the
-same byte positions as HOME/SALT/OXY:
+backwash fields in `_fill_backwash_active` and in `decode()` with the same byte
+positions as HOME/SALT/OXY:
 
 - `byte[68]` = backwash every N days
 - `byte[69:71]` = backwash time (HH:MM)

--- a/docs/device analyzes/salt_device_analysis.md
+++ b/docs/device analyzes/salt_device_analysis.md
@@ -253,6 +253,30 @@ after it closes.  A cycle running while somebody is at the menu the button
 lives on is manual by observation, and `backwash_tracker` uses it as such
 rather than inferring from the clock — see `_service_menu_open`.
 
+Confirmed a second time on 2026-08-28, in six diagnostics taken across one
+by-hand cycle (SALT, `backwash_every_n_days = 15`, `backwash_time = 08:30`,
+`backwash_duration = 100 s`):
+
+| Frame time | `byte[29]` | Backwash | `byte[37]` | Menu |
+|---|---|---|---|---|
+| 17:30:40 | `0x48` | – | `0xd3` | – |
+| 17:31:02 | `0x48` | – | `0xd7` | **open** |
+| 17:32:10 | `0x49` | **on** | `0xd7` | **open** |
+| 17:32:20 | `0x49` | **on** | `0xd7` | **open** |
+| 17:32:40 | `0x48` | – | `0xd3` | – |
+
+The menu bit is up at least 68 s before the valve is first seen open and is
+down again in the first frame that shows it shut, so it brackets the cycle on
+both sides — which is why `backwash_tracker` latches it across the window
+instead of reading it when the window closes.  The unit stayed `online` and
+`filtration_pump_running` throughout, and `filtration_schedule` reads
+`timer_period_1` in every frame: `0xd7` and `0xd3` differ only in `0x04`.
+
+Note what this capture does *not* settle: at 17:32 it is nowhere near the
+configured 08:30, so the time-only rule would have called it manual anyway.
+It confirms that the signal is present and correctly bracketed, not that it
+overrides a wrong answer — that case is still the 2026-08-11 capture's.
+
 ---
 
 ## Byte Map – Sub-frame 2 (config / setpoints)

--- a/tests/test_aseko_decoder.py
+++ b/tests/test_aseko_decoder.py
@@ -133,6 +133,15 @@ def test_decode_home() -> None:
     assert device.backwash_every_n_days == 3
     assert device.backwash_time == time(2, 30)
     assert device.backwash_duration == 20
+    # The frame carries the backwash *configuration* only; it never says when a
+    # cycle last ran.  The decoder must therefore leave the history unknown
+    # instead of deriving it from the schedule — the coordinator fills these in
+    # from BackwashTracker once a real relay window has been observed.
+    assert device.last_backwash is None
+    assert device.last_scheduled_backwash is None
+    assert device.last_manual_backwash is None
+    assert device.last_backwash_trigger is None
+    assert device.next_scheduled_backwash is None
     # HOME has 4 independent pump ports — byte[37] routing does not apply.
     # byte[54] = required_floc, byte[72] = required_algicide (same layout as OXY).
     # Base bytes: data[54]=5, data[72]=0 (default zero).
@@ -419,7 +428,7 @@ def test_decode_net() -> None:
     assert device.backwash_time is None
     assert device.backwash_duration is None
     assert device.last_backwash is None
-    assert device.next_backwash is None
+    assert device.next_scheduled_backwash is None
     assert device.backwash_active is None
     # NET has no filling valve, so the water_level group is empty too.
     assert device.water_level is None
@@ -514,7 +523,7 @@ def test_decode_net_no_backwash_with_garbage_bytes() -> None:
     assert device.backwash_time is None
     assert device.backwash_duration is None
     assert device.last_backwash is None
-    assert device.next_backwash is None
+    assert device.next_scheduled_backwash is None
     assert device.backwash_active is None
     assert device.water_level is None
     assert device.water_level_low_alarm is None

--- a/tests/test_backwash_tracker.py
+++ b/tests/test_backwash_tracker.py
@@ -1,32 +1,75 @@
 """Tests for BackwashTracker.
 
 Models a real-world backwash cycle: the relay must stay on for at least
-60 seconds (MIN_BACKWASH_DURATION) for the event to be recorded.
+60 seconds (MIN_BACKWASH_DURATION) for the event to be recorded, and each
+recorded cycle is classified as scheduled or manual from its start time.
 """
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, time, timedelta, timezone
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 
+from custom_components.aseko_local.aseko_data import (
+    AsekoBackwashSource,
+    AsekoBackwashTrigger,
+)
 from custom_components.aseko_local.backwash_tracker import (
     BackwashTracker,
     MAX_FRAME_GAP,
+    SCHEDULED_MATCH_TOLERANCE,
 )
 
 T0 = datetime(2026, 6, 14, 21, 0, 0, tzinfo=timezone.utc)
+
+# The unit's configured backwash time, matching T0's time of day, so a cycle
+# starting at T0 counts as the unit's own scheduled run.
+SCHEDULE_AT = time(21, 0)
+SCHEDULE_EVERY_N_DAYS = 3
 
 
 # ── helpers ──────────────────────────────────────────────────────────────────
 
 
-def _device(backwash_active: bool | None) -> Any:
-    """Minimal stand-in for AsekoDevice with only the field the tracker reads."""
+def _device(
+    backwash_active: bool | None,
+    *,
+    backwash_time: time | None = None,
+    backwash_every_n_days: int | None = None,
+) -> Any:
+    """Minimal stand-in for AsekoDevice with only the fields the tracker reads.
+
+    The schedule defaults to "not configured", which classifies every recorded
+    cycle as manual — the right default for the tests that only care about the
+    relay-window state machine.
+    """
     dev = MagicMock()
     dev.backwash_active = backwash_active
+    dev.backwash_time = backwash_time
+    dev.backwash_every_n_days = backwash_every_n_days
     return dev
+
+
+def _scheduled_device(backwash_active: bool | None) -> Any:
+    """Stand-in for a device with an enabled backwash schedule at SCHEDULE_AT."""
+    return _device(
+        backwash_active,
+        backwash_time=SCHEDULE_AT,
+        backwash_every_n_days=SCHEDULE_EVERY_N_DAYS,
+    )
+
+
+def _run_cycle(
+    tracker: BackwashTracker,
+    start: datetime,
+    duration: timedelta = timedelta(seconds=90),
+    device_factory=_scheduled_device,
+) -> None:
+    """Drive one complete relay on → off window through the tracker."""
+    tracker.update(device_factory(True), start)
+    tracker.update(device_factory(False), start + duration)
 
 
 def _hass() -> MagicMock:
@@ -193,10 +236,502 @@ async def test_async_load_from_empty_store():
     assert tracker.last_backwash is None
 
 
-async def test_async_save_skipped_when_no_event():
-    """async_save is a no-op when nothing has been recorded yet."""
-    hass = _hass()
-    tracker = BackwashTracker(hass, serial_number=110071590)
-    # last_backwash is None → async_save returns without touching the store.
+async def test_async_save_writes_nulls_rather_than_skipping():
+    """An empty state must be written, not skipped.
+
+    Skipping made clearing a no-op on disk: the cleared value came back on the
+    next restart.  Callers only reach async_save after a change, so writing
+    unconditionally costs nothing.
+    """
+    tracker = BackwashTracker(_hass(), serial_number=110071590)
+    tracker._store.async_save = AsyncMock()  # type: ignore[method-assign]
+
     await tracker.async_save()
-    hass.async_create_task.assert_not_called()
+
+    saved = tracker._store.async_save.call_args.args[0]  # type: ignore[attr-defined]
+    assert saved["last_backwash"] is None
+    assert saved["last_scheduled_backwash"] is None
+
+
+# ── scheduled vs. manual classification ─────────────────────────────────────
+
+
+def test_nothing_recorded_starts_unknown():
+    """A fresh tracker reports every field as unknown, not as a schedule guess."""
+    tracker = BackwashTracker(_hass(), serial_number=110071590)
+
+    assert tracker.last_backwash is None
+    assert tracker.last_scheduled_backwash is None
+    assert tracker.last_manual_backwash is None
+    assert tracker.last_trigger is None
+    assert tracker.next_scheduled_backwash(_scheduled_device(False), T0) is None
+
+
+def test_cycle_at_scheduled_time_is_scheduled():
+    """A cycle starting at the configured backwash_time is the unit's own run."""
+    tracker = BackwashTracker(_hass(), serial_number=110071590)
+
+    _run_cycle(tracker, T0)
+
+    assert tracker.last_trigger is AsekoBackwashTrigger.SCHEDULED
+    assert tracker.last_scheduled_backwash == T0 + timedelta(seconds=45)
+    assert tracker.last_backwash == tracker.last_scheduled_backwash
+    assert tracker.last_manual_backwash is None
+
+
+def test_cycle_just_inside_tolerance_is_scheduled():
+    """The unit's clock may drift from HA's — the tolerance window absorbs it."""
+    tracker = BackwashTracker(_hass(), serial_number=110071590)
+
+    _run_cycle(tracker, T0 + SCHEDULED_MATCH_TOLERANCE - timedelta(seconds=1))
+
+    assert tracker.last_trigger is AsekoBackwashTrigger.SCHEDULED
+
+
+def test_cycle_outside_tolerance_is_manual():
+    """A cycle well away from the scheduled time was started by hand."""
+    tracker = BackwashTracker(_hass(), serial_number=110071590)
+
+    started = T0 + timedelta(hours=2)
+    _run_cycle(tracker, started)
+
+    assert tracker.last_trigger is AsekoBackwashTrigger.MANUAL
+    assert tracker.last_manual_backwash == started + timedelta(seconds=45)
+    assert tracker.last_backwash == tracker.last_manual_backwash
+    assert tracker.last_scheduled_backwash is None
+
+
+def test_cycle_is_manual_when_schedule_disabled():
+    """interval 0 = automatic backwash off → the unit cannot have started it."""
+    tracker = BackwashTracker(_hass(), serial_number=110071590)
+
+    def _disabled(active):
+        return _device(active, backwash_time=SCHEDULE_AT, backwash_every_n_days=0)
+
+    _run_cycle(tracker, T0, device_factory=_disabled)
+
+    assert tracker.last_trigger is AsekoBackwashTrigger.MANUAL
+
+
+def test_cycle_is_manual_when_schedule_unconfigured():
+    """No backwash_time in the frame (0xFF) → nothing to match against."""
+    tracker = BackwashTracker(_hass(), serial_number=110071590)
+
+    _run_cycle(tracker, T0, device_factory=_device)
+
+    assert tracker.last_trigger is AsekoBackwashTrigger.MANUAL
+
+
+def test_scheduled_time_near_midnight_matches_across_days():
+    """A cycle at 00:05 still matches a 23:55 schedule on the previous day."""
+    tracker = BackwashTracker(_hass(), serial_number=110071590)
+
+    def _near_midnight(active):
+        return _device(
+            active,
+            backwash_time=time(23, 55),
+            backwash_every_n_days=SCHEDULE_EVERY_N_DAYS,
+        )
+
+    # 00:05 the next day — 10 minutes after the scheduled slot, but on the
+    # other side of the date boundary.
+    _run_cycle(
+        tracker,
+        datetime(2026, 6, 15, 0, 5, 0, tzinfo=timezone.utc),
+        device_factory=_near_midnight,
+    )
+
+    assert tracker.last_trigger is AsekoBackwashTrigger.SCHEDULED
+
+
+def test_manual_cycle_keeps_earlier_scheduled_record():
+    """A manual run must not overwrite the last scheduled one (it drives 'next')."""
+    tracker = BackwashTracker(_hass(), serial_number=110071590)
+
+    _run_cycle(tracker, T0)
+    scheduled = tracker.last_scheduled_backwash
+    assert scheduled is not None
+
+    manual_start = T0 + timedelta(days=1, hours=4)
+    _run_cycle(tracker, manual_start)
+
+    assert tracker.last_trigger is AsekoBackwashTrigger.MANUAL
+    assert tracker.last_manual_backwash == manual_start + timedelta(seconds=45)
+    assert tracker.last_scheduled_backwash == scheduled
+    # "Last backwash" tracks whichever came last, regardless of kind.
+    assert tracker.last_backwash == tracker.last_manual_backwash
+
+
+# ── next-backwash projection ────────────────────────────────────────────────
+
+
+def test_next_scheduled_backwash_unknown_after_manual_only():
+    """A manual cycle says nothing about the unit's schedule phase."""
+    tracker = BackwashTracker(_hass(), serial_number=110071590)
+    device = _scheduled_device(False)
+
+    _run_cycle(tracker, T0 + timedelta(hours=2))
+
+    assert tracker.last_manual_backwash is not None
+    assert tracker.next_scheduled_backwash(device, T0 + timedelta(hours=3)) is None
+
+
+def test_next_scheduled_backwash_projected_from_last_scheduled():
+    """next = last scheduled cycle + interval, snapped to the configured time."""
+    tracker = BackwashTracker(_hass(), serial_number=110071590)
+    device = _scheduled_device(False)
+
+    _run_cycle(tracker, T0)
+
+    # Recorded at the window midpoint (T0 + 45 s), but the projection snaps to
+    # the configured 21:00 slot — that is when the unit will actually fire.
+    assert tracker.next_scheduled_backwash(
+        device, T0 + timedelta(minutes=5)
+    ) == datetime(2026, 6, 17, 21, 0, 0, tzinfo=timezone.utc)
+
+
+def test_next_scheduled_backwash_rolls_forward_past_missed_cycles():
+    """Cycles missed while HA was down must not leave 'next' stuck in the past."""
+    tracker = BackwashTracker(_hass(), serial_number=110071590)
+    device = _scheduled_device(False)
+
+    _run_cycle(tracker, T0)
+
+    # Ten days later: 06-17, 06-20 and 06-23 have all come and gone.
+    now = T0 + timedelta(days=10)
+    assert tracker.next_scheduled_backwash(device, now) == datetime(
+        2026, 6, 26, 21, 0, 0, tzinfo=timezone.utc
+    )
+
+
+def test_next_scheduled_backwash_none_when_schedule_disabled():
+    """With automatic backwash switched off there is no next cycle to project."""
+    tracker = BackwashTracker(_hass(), serial_number=110071590)
+
+    _run_cycle(tracker, T0)
+    assert tracker.last_scheduled_backwash is not None
+
+    disabled = _device(False, backwash_time=SCHEDULE_AT, backwash_every_n_days=0)
+    assert tracker.next_scheduled_backwash(disabled, T0 + timedelta(minutes=5)) is None
+
+
+# ── persistence of the classification ───────────────────────────────────────
+
+
+async def test_async_load_restores_classified_state():
+    """A stored payload round-trips into all four public fields."""
+    tracker = BackwashTracker(_hass(), serial_number=110071590)
+    stored = {
+        "last_backwash": (T0 + timedelta(days=1)).isoformat(),
+        "last_scheduled_backwash": T0.isoformat(),
+        "last_manual_backwash": (T0 + timedelta(days=1)).isoformat(),
+        "last_trigger": "manual",
+    }
+    tracker._store.async_load = AsyncMock(return_value=stored)  # type: ignore[method-assign]
+
+    await tracker.async_load()
+
+    assert tracker.last_backwash == T0 + timedelta(days=1)
+    assert tracker.last_scheduled_backwash == T0
+    assert tracker.last_manual_backwash == T0 + timedelta(days=1)
+    assert tracker.last_trigger is AsekoBackwashTrigger.MANUAL
+
+
+async def test_async_load_tolerates_version_1_payload():
+    """Stores written before classification existed keep their timestamp.
+
+    The trigger of that pre-upgrade cycle is genuinely unknown, so it stays
+    None rather than being guessed at.
+    """
+    tracker = BackwashTracker(_hass(), serial_number=110071590)
+    tracker._store.async_load = AsyncMock(  # type: ignore[method-assign]
+        return_value={"last_backwash": T0.isoformat()}
+    )
+
+    await tracker.async_load()
+
+    assert tracker.last_backwash == T0
+    assert tracker.last_scheduled_backwash is None
+    assert tracker.last_manual_backwash is None
+    assert tracker.last_trigger is None
+
+
+async def test_async_save_persists_classification():
+    """The saved payload carries everything async_load reads back."""
+    tracker = BackwashTracker(_hass(), serial_number=110071590)
+    tracker._store.async_save = AsyncMock()  # type: ignore[method-assign]
+
+    _run_cycle(tracker, T0)
+    await tracker.async_save()
+
+    saved = tracker._store.async_save.call_args.args[0]  # type: ignore[attr-defined]
+    assert saved["last_backwash"] == (T0 + timedelta(seconds=45)).isoformat()
+    assert saved["last_scheduled_backwash"] == (T0 + timedelta(seconds=45)).isoformat()
+    assert saved["last_manual_backwash"] is None
+    assert saved["last_trigger"] == "scheduled"
+
+
+# ── manual seeding and provenance ───────────────────────────────────────────
+
+
+def test_manual_seed_marks_source_and_drives_projection():
+    """A seeded date starts the projection and is labelled as manual."""
+    tracker = BackwashTracker(_hass(), serial_number=110071590)
+    device = _scheduled_device(False)
+
+    seeded = T0 - timedelta(days=1)
+    tracker.set_last_scheduled_backwash(seeded)
+
+    assert tracker.last_scheduled_backwash == seeded
+    assert tracker.last_scheduled_source is AsekoBackwashSource.MANUAL
+    # Seeded 2026-06-13 21:00, interval 3 days -> 2026-06-16 21:00.
+    assert tracker.next_scheduled_backwash(device, T0) == datetime(
+        2026, 6, 16, 21, 0, 0, tzinfo=timezone.utc
+    )
+
+
+def test_manual_seed_does_not_touch_observed_last_backwash():
+    """last_backwash means "we watched this happen" — typing a date does not."""
+    tracker = BackwashTracker(_hass(), serial_number=110071590)
+
+    tracker.set_last_scheduled_backwash(T0 - timedelta(days=1))
+
+    assert tracker.last_backwash is None
+    assert tracker.last_manual_backwash is None
+    assert tracker.last_trigger is None
+
+
+def test_cycle_detected_after_a_seed_supersedes_it():
+    """The seed stood in for a real cycle; once one is detected, it takes over."""
+    tracker = BackwashTracker(_hass(), serial_number=110071590)
+
+    tracker.set_last_scheduled_backwash(T0 - timedelta(days=1))
+    assert tracker.last_scheduled_source is AsekoBackwashSource.MANUAL
+
+    _run_cycle(tracker, T0)
+
+    assert tracker.last_scheduled_backwash == T0 + timedelta(seconds=45)
+    assert tracker.last_scheduled_source is AsekoBackwashSource.OBSERVED
+
+
+def test_cycle_detected_after_a_later_dated_seed_still_supersedes_it():
+    """Last write wins — the stored timestamps are never compared.
+
+    Even a seed dated after the detected cycle gives way, because the cycle
+    was recorded later and is the more current answer.
+    """
+    tracker = BackwashTracker(_hass(), serial_number=110071590)
+
+    tracker.set_last_scheduled_backwash(T0 + timedelta(days=5))
+    _run_cycle(tracker, T0)
+
+    assert tracker.last_scheduled_backwash == T0 + timedelta(seconds=45)
+    assert tracker.last_scheduled_source is AsekoBackwashSource.OBSERVED
+
+
+def test_manual_seed_overrides_an_observed_value():
+    """A manual entry replaces a detected one — the user has a reason."""
+    tracker = BackwashTracker(_hass(), serial_number=110071590)
+
+    _run_cycle(tracker, T0)
+    assert tracker.last_scheduled_source is AsekoBackwashSource.OBSERVED
+
+    corrected = T0 - timedelta(days=10)
+    tracker.set_last_scheduled_backwash(corrected)
+
+    assert tracker.last_scheduled_backwash == corrected
+    assert tracker.last_scheduled_source is AsekoBackwashSource.MANUAL
+
+
+def test_observed_manual_cycle_leaves_the_seed_alone():
+    """A detected *manual* backwash says nothing about the schedule phase."""
+    tracker = BackwashTracker(_hass(), serial_number=110071590)
+
+    seeded = T0 - timedelta(days=1)
+    tracker.set_last_scheduled_backwash(seeded)
+    _run_cycle(tracker, T0 + timedelta(hours=3))  # far from backwash_time
+
+    assert tracker.last_trigger is AsekoBackwashTrigger.MANUAL
+    assert tracker.last_scheduled_backwash == seeded
+    assert tracker.last_scheduled_source is AsekoBackwashSource.MANUAL
+
+
+def test_no_source_while_nothing_is_known():
+    """No value, no provenance — the attribute stays absent rather than lying."""
+    tracker = BackwashTracker(_hass(), serial_number=110071590)
+
+    assert tracker.last_scheduled_source is None
+
+
+async def test_manual_seed_is_persisted_before_any_observation():
+    """async_save must not bail out just because last_backwash is still None."""
+    tracker = BackwashTracker(_hass(), serial_number=110071590)
+    tracker._store.async_save = AsyncMock()  # type: ignore[method-assign]
+
+    seeded = T0 - timedelta(days=1)
+    tracker.set_last_scheduled_backwash(seeded)
+    await tracker.async_save()
+
+    saved = tracker._store.async_save.call_args.args[0]  # type: ignore[attr-defined]
+    assert saved["last_backwash"] is None
+    assert saved["last_scheduled_backwash"] == seeded.isoformat()
+    assert saved["last_scheduled_source"] == "manual"
+
+
+async def test_async_load_restores_manual_source():
+    """A seeded value survives a restart still marked as manual."""
+    tracker = BackwashTracker(_hass(), serial_number=110071590)
+    tracker._store.async_load = AsyncMock(  # type: ignore[method-assign]
+        return_value={
+            "last_scheduled_backwash": T0.isoformat(),
+            "last_scheduled_source": "manual",
+        }
+    )
+
+    await tracker.async_load()
+
+    assert tracker.last_scheduled_backwash == T0
+    assert tracker.last_scheduled_source is AsekoBackwashSource.MANUAL
+
+
+async def test_async_load_treats_sourceless_stored_value_as_observed():
+    """Stores written before provenance existed can only hold observed values."""
+    tracker = BackwashTracker(_hass(), serial_number=110071590)
+    tracker._store.async_load = AsyncMock(  # type: ignore[method-assign]
+        return_value={
+            "last_backwash": T0.isoformat(),
+            "last_scheduled_backwash": T0.isoformat(),
+        }
+    )
+
+    await tracker.async_load()
+
+    assert tracker.last_scheduled_source is AsekoBackwashSource.OBSERVED
+
+
+# ── backfilling an old store ────────────────────────────────────────────────
+
+
+def test_backfill_classifies_a_pre_split_record_as_scheduled():
+    """A store holding only last_backwash gets classified on the first frame.
+
+    Stores written before the scheduled/manual split existed would otherwise
+    leave both new sensors empty until the next real cycle, up to a whole
+    interval away — even though the schedule needed to classify the stored
+    value arrives in every frame.
+    """
+    tracker = BackwashTracker(_hass(), serial_number=110071590)
+    tracker._last_backwash = T0  # type: ignore[attr-defined]
+
+    tracker.update(_scheduled_device(False), T0 + timedelta(minutes=5))
+
+    assert tracker.last_scheduled_backwash == T0
+    assert tracker.last_scheduled_source is AsekoBackwashSource.OBSERVED
+    assert tracker.last_trigger is AsekoBackwashTrigger.SCHEDULED
+    assert tracker.last_manual_backwash is None
+
+
+def test_backfill_classifies_a_pre_split_record_as_manual():
+    """Same, for a stored cycle that did not run at the scheduled time."""
+    tracker = BackwashTracker(_hass(), serial_number=110071590)
+    off_schedule = T0 + timedelta(hours=4)
+    tracker._last_backwash = off_schedule  # type: ignore[attr-defined]
+
+    tracker.update(_scheduled_device(False), off_schedule + timedelta(minutes=5))
+
+    assert tracker.last_manual_backwash == off_schedule
+    assert tracker.last_trigger is AsekoBackwashTrigger.MANUAL
+    assert tracker.last_scheduled_backwash is None
+
+
+def test_backfill_waits_for_a_frame_that_carries_the_schedule():
+    """Without backwash_time there is nothing to classify against — retry later."""
+    tracker = BackwashTracker(_hass(), serial_number=110071590)
+    tracker._last_backwash = T0  # type: ignore[attr-defined]
+
+    tracker.update(_device(False), T0 + timedelta(minutes=5))
+    assert tracker.last_scheduled_backwash is None
+    assert tracker.last_manual_backwash is None
+
+    tracker.update(_scheduled_device(False), T0 + timedelta(minutes=10))
+    assert tracker.last_scheduled_backwash == T0
+
+
+def test_backfill_does_not_touch_an_already_split_store():
+    """Once either bucket is filled the record is current — leave it alone."""
+    tracker = BackwashTracker(_hass(), serial_number=110071590)
+    seeded = T0 - timedelta(days=3)
+    tracker._last_backwash = T0  # type: ignore[attr-defined]
+    tracker.set_last_scheduled_backwash(seeded)
+
+    tracker.update(_scheduled_device(False), T0 + timedelta(minutes=5))
+
+    assert tracker.last_scheduled_backwash == seeded
+    assert tracker.last_scheduled_source is AsekoBackwashSource.MANUAL
+
+
+def test_backfill_is_a_no_op_on_an_empty_store():
+    """Nothing stored, nothing to classify."""
+    tracker = BackwashTracker(_hass(), serial_number=110071590)
+
+    tracker.update(_scheduled_device(False), T0)
+
+    assert tracker.last_backwash is None
+    assert tracker.last_scheduled_backwash is None
+    assert tracker.last_manual_backwash is None
+    assert tracker.last_trigger is None
+
+
+# ── clearing ────────────────────────────────────────────────────────────────
+
+
+def test_clear_returns_the_value_to_unknown():
+    """The undo for a mistyped date."""
+    tracker = BackwashTracker(_hass(), serial_number=110071590)
+    tracker.set_last_scheduled_backwash(T0 - timedelta(days=1))
+
+    tracker.clear_last_scheduled_backwash()
+
+    assert tracker.last_scheduled_backwash is None
+    assert tracker.last_scheduled_source is None
+
+
+def test_clear_rearms_the_backfill():
+    """After clearing, an older stored cycle is classified again.
+
+    This is what makes clearing useful rather than merely destructive: the
+    schedule falls back to whatever the integration actually observed.
+    """
+    tracker = BackwashTracker(_hass(), serial_number=110071590)
+    tracker._last_backwash = T0  # type: ignore[attr-defined]
+    tracker.set_last_scheduled_backwash(T0 - timedelta(days=30))
+
+    tracker.clear_last_scheduled_backwash()
+    tracker.update(_scheduled_device(False), T0 + timedelta(minutes=5))
+
+    assert tracker.last_scheduled_backwash == T0
+    assert tracker.last_scheduled_source is AsekoBackwashSource.OBSERVED
+
+
+def test_clear_is_a_no_op_when_already_unknown():
+    """Nothing stored, nothing to clear — and no pointless write."""
+    tracker = BackwashTracker(_hass(), serial_number=110071590)
+
+    tracker.clear_last_scheduled_backwash()
+
+    assert tracker.last_scheduled_backwash is None
+    tracker._hass.async_create_task.assert_not_called()  # type: ignore[attr-defined]
+
+
+async def test_clear_is_persisted():
+    """Clearing must reach the store, or the old value returns on restart."""
+    tracker = BackwashTracker(_hass(), serial_number=110071590)
+    tracker._store.async_save = AsyncMock()  # type: ignore[method-assign]
+    tracker.set_last_scheduled_backwash(T0)
+
+    tracker.clear_last_scheduled_backwash()
+    await tracker.async_save()
+
+    saved = tracker._store.async_save.call_args.args[0]  # type: ignore[attr-defined]
+    assert saved["last_scheduled_backwash"] is None
+    assert saved["last_scheduled_source"] is None

--- a/tests/test_backwash_tracker.py
+++ b/tests/test_backwash_tracker.py
@@ -78,9 +78,15 @@ def _hass() -> MagicMock:
     ``Store.__init__`` requires ``hass.config.path(...)`` to resolve to a real
     path-like value, so we return a ``Path`` instead of letting the default
     ``MagicMock`` raise ``AttributeError`` deep in the constructor.
+
+    The tracker hands ``async_save()`` to ``async_create_task``.  A plain
+    ``MagicMock`` swallows the coroutine without awaiting it, which raises a
+    RuntimeWarning per call; closing it keeps the call recorded (tests assert on
+    it) while leaving nothing pending.
     """
     hass = MagicMock()
     hass.config.path.side_effect = lambda *parts: "/tmp/aseko_test/" + "/".join(parts)
+    hass.async_create_task.side_effect = lambda coro, *args, **kwargs: coro.close()
     return hass
 
 

--- a/tests/test_backwash_tracker.py
+++ b/tests/test_backwash_tracker.py
@@ -511,6 +511,7 @@ async def test_async_load_accepts_an_unknown_trigger():
 async def test_async_save_writes_an_unknown_trigger():
     """The verdict survives a restart rather than being re-derived."""
     tracker = BackwashTracker(_hass(), serial_number=110071590)
+    tracker._store.async_save = AsyncMock()  # type: ignore[method-assign]
 
     _run_service_menu_cycle(tracker, T0 + timedelta(hours=2), False)
     await tracker.async_save()

--- a/tests/test_backwash_tracker.py
+++ b/tests/test_backwash_tracker.py
@@ -295,21 +295,31 @@ def test_cycle_just_inside_tolerance_is_scheduled():
     assert tracker.last_trigger is AsekoBackwashTrigger.SCHEDULED
 
 
-def test_cycle_outside_tolerance_is_manual():
-    """A cycle well away from the scheduled time was started by hand."""
+def test_cycle_outside_tolerance_is_unknown():
+    """A cycle away from the scheduled time is recorded, not attributed.
+
+    The unit's timer does not explain it, which is not the same as knowing a
+    person started it — that would need the menu bit, and this device is not
+    reporting it.  So the cycle lands in last_backwash and nowhere else.
+    """
     tracker = BackwashTracker(_hass(), serial_number=110071590)
 
     started = T0 + timedelta(hours=2)
     _run_cycle(tracker, started)
 
-    assert tracker.last_trigger is AsekoBackwashTrigger.MANUAL
-    assert tracker.last_manual_backwash == started + timedelta(seconds=45)
-    assert tracker.last_backwash == tracker.last_manual_backwash
+    assert tracker.last_trigger is AsekoBackwashTrigger.UNKNOWN
+    assert tracker.last_backwash == started + timedelta(seconds=45)
+    assert tracker.last_manual_backwash is None
     assert tracker.last_scheduled_backwash is None
 
 
-def test_cycle_is_manual_when_schedule_disabled():
-    """interval 0 = automatic backwash off → the unit cannot have started it."""
+def test_cycle_is_unknown_when_schedule_disabled():
+    """interval 0 = automatic backwash off, so there is nothing to match.
+
+    It is tempting to call this manual — the unit's own timer is off, so what
+    else could it be?  A fault-triggered cycle, for one.  The frame does not
+    say, so neither do we.
+    """
     tracker = BackwashTracker(_hass(), serial_number=110071590)
 
     def _disabled(active):
@@ -317,16 +327,19 @@ def test_cycle_is_manual_when_schedule_disabled():
 
     _run_cycle(tracker, T0, device_factory=_disabled)
 
-    assert tracker.last_trigger is AsekoBackwashTrigger.MANUAL
+    assert tracker.last_trigger is AsekoBackwashTrigger.UNKNOWN
+    assert tracker.last_manual_backwash is None
+    assert tracker.last_scheduled_backwash is None
 
 
-def test_cycle_is_manual_when_schedule_unconfigured():
+def test_cycle_is_unknown_when_schedule_unconfigured():
     """No backwash_time in the frame (0xFF) → nothing to match against."""
     tracker = BackwashTracker(_hass(), serial_number=110071590)
 
     _run_cycle(tracker, T0, device_factory=_device)
 
-    assert tracker.last_trigger is AsekoBackwashTrigger.MANUAL
+    assert tracker.last_trigger is AsekoBackwashTrigger.UNKNOWN
+    assert tracker.last_manual_backwash is None
 
 
 def test_scheduled_time_near_midnight_matches_across_days():
@@ -360,13 +373,30 @@ def test_manual_cycle_keeps_earlier_scheduled_record():
     assert scheduled is not None
 
     manual_start = T0 + timedelta(days=1, hours=4)
-    _run_cycle(tracker, manual_start)
+    _run_service_menu_cycle(tracker, manual_start, True)
 
     assert tracker.last_trigger is AsekoBackwashTrigger.MANUAL
     assert tracker.last_manual_backwash == manual_start + timedelta(seconds=45)
     assert tracker.last_scheduled_backwash == scheduled
     # "Last backwash" tracks whichever came last, regardless of kind.
     assert tracker.last_backwash == tracker.last_manual_backwash
+
+
+def test_unknown_cycle_keeps_earlier_scheduled_record():
+    """An unattributed run must not move the schedule phase either."""
+    tracker = BackwashTracker(_hass(), serial_number=110071590)
+
+    _run_cycle(tracker, T0)
+    scheduled = tracker.last_scheduled_backwash
+    assert scheduled is not None
+
+    _run_cycle(tracker, T0 + timedelta(days=1, hours=4))
+
+    assert tracker.last_trigger is AsekoBackwashTrigger.UNKNOWN
+    assert tracker.last_scheduled_backwash == scheduled
+    assert tracker.last_manual_backwash is None
+    # It still happened, so it is the latest backwash.
+    assert tracker.last_backwash == T0 + timedelta(days=1, hours=4, seconds=45)
 
 
 # ── next-backwash projection ────────────────────────────────────────────────
@@ -377,9 +407,20 @@ def test_next_scheduled_backwash_unknown_after_manual_only():
     tracker = BackwashTracker(_hass(), serial_number=110071590)
     device = _scheduled_device(False)
 
-    _run_cycle(tracker, T0 + timedelta(hours=2))
+    _run_service_menu_cycle(tracker, T0 + timedelta(hours=2), True)
 
     assert tracker.last_manual_backwash is not None
+    assert tracker.next_scheduled_backwash(device, T0 + timedelta(hours=3)) is None
+
+
+def test_next_scheduled_backwash_unknown_after_unattributed_only():
+    """An unattributed cycle says nothing about the schedule phase either."""
+    tracker = BackwashTracker(_hass(), serial_number=110071590)
+    device = _scheduled_device(False)
+
+    _run_cycle(tracker, T0 + timedelta(hours=2))
+
+    assert tracker.last_trigger is AsekoBackwashTrigger.UNKNOWN
     assert tracker.next_scheduled_backwash(device, T0 + timedelta(hours=3)) is None
 
 
@@ -442,6 +483,37 @@ async def test_async_load_restores_classified_state():
     assert tracker.last_scheduled_backwash == T0
     assert tracker.last_manual_backwash == T0 + timedelta(days=1)
     assert tracker.last_trigger is AsekoBackwashTrigger.MANUAL
+
+
+async def test_async_load_accepts_an_unknown_trigger():
+    """UNKNOWN round-trips through the store like the other two."""
+    tracker = BackwashTracker(_hass(), serial_number=110071590)
+    tracker._store.async_load = AsyncMock(  # type: ignore[method-assign]
+        return_value={
+            "last_backwash": T0.isoformat(),
+            "last_trigger": "unknown",
+        }
+    )
+
+    await tracker.async_load()
+
+    assert tracker.last_backwash == T0
+    assert tracker.last_trigger is AsekoBackwashTrigger.UNKNOWN
+    assert tracker.last_scheduled_backwash is None
+    assert tracker.last_manual_backwash is None
+
+
+async def test_async_save_writes_an_unknown_trigger():
+    """The verdict survives a restart rather than being re-derived."""
+    tracker = BackwashTracker(_hass(), serial_number=110071590)
+
+    _run_cycle(tracker, T0 + timedelta(hours=2))
+    await tracker.async_save()
+
+    saved = tracker._store.async_save.call_args.args[0]  # type: ignore[attr-defined]
+    assert saved["last_trigger"] == "unknown"
+    assert saved["last_manual_backwash"] is None
+    assert saved["last_scheduled_backwash"] is None
 
 
 async def test_async_load_tolerates_version_1_payload():
@@ -556,7 +628,8 @@ def test_observed_manual_cycle_leaves_the_seed_alone():
 
     seeded = T0 - timedelta(days=1)
     tracker.set_last_scheduled_backwash(seeded)
-    _run_cycle(tracker, T0 + timedelta(hours=3))  # far from backwash_time
+    # far from backwash_time, and observed from the settings menu
+    _run_service_menu_cycle(tracker, T0 + timedelta(hours=3), True)
 
     assert tracker.last_trigger is AsekoBackwashTrigger.MANUAL
     assert tracker.last_scheduled_backwash == seeded
@@ -638,16 +711,35 @@ def test_backfill_classifies_a_pre_split_record_as_scheduled():
     assert tracker.last_manual_backwash is None
 
 
-def test_backfill_classifies_a_pre_split_record_as_manual():
-    """Same, for a stored cycle that did not run at the scheduled time."""
+def test_backfill_leaves_an_unmatched_pre_split_record_unattributed():
+    """A stored cycle that did not run at the scheduled time stays unattributed.
+
+    The menu bit is not recoverable after the fact, so the schedule is the
+    only thing left to check — and it does not match.  The record keeps its
+    place in last_backwash and fills neither half of the split.
+    """
     tracker = BackwashTracker(_hass(), serial_number=110071590)
     off_schedule = T0 + timedelta(hours=4)
     tracker._last_backwash = off_schedule  # type: ignore[attr-defined]
 
     tracker.update(_scheduled_device(False), off_schedule + timedelta(minutes=5))
 
-    assert tracker.last_manual_backwash == off_schedule
-    assert tracker.last_trigger is AsekoBackwashTrigger.MANUAL
+    assert tracker.last_trigger is AsekoBackwashTrigger.UNKNOWN
+    assert tracker.last_manual_backwash is None
+    assert tracker.last_scheduled_backwash is None
+
+
+def test_backfill_does_not_retry_an_unattributed_record():
+    """The verdict does not change frame to frame, so it is reached once."""
+    tracker = BackwashTracker(_hass(), serial_number=110071590)
+    off_schedule = T0 + timedelta(hours=4)
+    tracker._last_backwash = off_schedule  # type: ignore[attr-defined]
+
+    tracker.update(_scheduled_device(False), off_schedule + timedelta(minutes=5))
+    tracker.update(_scheduled_device(False), off_schedule + timedelta(minutes=10))
+
+    assert tracker._backfill_attempted is True  # type: ignore[attr-defined]
+    assert tracker.last_manual_backwash is None
     assert tracker.last_scheduled_backwash is None
 
 

--- a/tests/test_backwash_tracker.py
+++ b/tests/test_backwash_tracker.py
@@ -15,6 +15,7 @@ from unittest.mock import AsyncMock, MagicMock
 from custom_components.aseko_local.aseko_data import (
     AsekoBackwashSource,
     AsekoBackwashTrigger,
+    AsekoDeviceType,
 )
 from custom_components.aseko_local.backwash_tracker import (
     BackwashTracker,
@@ -741,3 +742,116 @@ async def test_clear_is_persisted():
     saved = tracker._store.async_save.call_args.args[0]  # type: ignore[attr-defined]
     assert saved["last_scheduled_backwash"] is None
     assert saved["last_scheduled_source"] is None
+
+
+# ── the settings menu as an observed signal (SALT byte[37] bit 0x04) ─────────
+
+
+def _salt_device(
+    backwash_active: bool | None,
+    menu_open: bool,
+    device_type: AsekoDeviceType = AsekoDeviceType.SALT,
+) -> Any:
+    """A scheduled device that also reports a device type and the menu flag."""
+    dev = _scheduled_device(backwash_active)
+    dev.device_type = device_type
+    dev.service_menu_open = menu_open
+    return dev
+
+
+def _run_service_menu_cycle(
+    tracker: BackwashTracker,
+    start: datetime,
+    menu_during: bool,
+    device_type: AsekoDeviceType = AsekoDeviceType.SALT,
+) -> None:
+    """Drive a cycle that ends with the menu flag already dropped.
+
+    Mirrors the captured cycle: the unit clears bit 0x04 a frame or two
+    after the valve closes, so the closing frame no longer carries it.
+    """
+    tracker.update(_salt_device(True, menu_during, device_type), start)
+    tracker.update(
+        _salt_device(True, menu_during, device_type),
+        start + timedelta(seconds=45),
+    )
+    tracker.update(
+        _salt_device(False, False, device_type),
+        start + timedelta(seconds=90),
+    )
+
+
+def test_service_menu_during_the_window_means_manual():
+    """A SALT cycle run from the settings menu is manual, whatever the clock says.
+
+    This is the case the time-only rule gets wrong: started by hand, but
+    within tolerance of the configured time, so it used to be filed as the
+    unit's own scheduled run and would have moved the next-backwash
+    projection with it.
+    """
+    tracker = BackwashTracker(_hass(), serial_number=110071590)
+
+    _run_service_menu_cycle(tracker, T0, True)
+
+    assert tracker.last_trigger is AsekoBackwashTrigger.MANUAL
+    assert tracker.last_manual_backwash is not None
+    assert tracker.last_scheduled_backwash is None
+
+
+def test_service_menu_is_latched_across_the_whole_window():
+    """The flag counts even though the closing frame has already lost it.
+
+    Reading the mode at the end of the window would miss every real cycle:
+    in the capture the bit went out ~20 s after the valve closed, before
+    the frame that ends the window arrived.
+    """
+    tracker = BackwashTracker(_hass(), serial_number=110071590)
+
+    tracker.update(_salt_device(True, True), T0)
+    # the flag is already back down for the rest of the window
+    tracker.update(
+        _salt_device(True, False),
+        T0 + timedelta(seconds=45),
+    )
+    tracker.update(
+        _salt_device(False, False),
+        T0 + timedelta(seconds=90),
+    )
+
+    assert tracker.last_trigger is AsekoBackwashTrigger.MANUAL
+
+
+def test_without_the_service_menu_the_schedule_still_decides():
+    """The flag only ever adds evidence; its absence changes nothing."""
+    tracker = BackwashTracker(_hass(), serial_number=110071590)
+
+    _run_service_menu_cycle(tracker, T0, False)
+
+    assert tracker.last_trigger is AsekoBackwashTrigger.SCHEDULED
+    assert tracker.last_scheduled_backwash is not None
+
+
+def test_service_menu_signal_does_not_apply_to_home():
+    """On HOME the same bit is a standing pump override, not a person.
+
+    It can sit set indefinitely, so honouring it there would refile every
+    scheduled cycle that happened to run while it was on.
+    """
+    tracker = BackwashTracker(_hass(), serial_number=110071590)
+
+    _run_service_menu_cycle(tracker, T0, True, AsekoDeviceType.HOME)
+
+    assert tracker.last_trigger is AsekoBackwashTrigger.SCHEDULED
+
+
+def test_service_menu_flag_does_not_leak_into_the_next_cycle():
+    """Each window starts from a clean slate."""
+    tracker = BackwashTracker(_hass(), serial_number=110071590)
+
+    _run_service_menu_cycle(tracker, T0, True)
+    assert tracker.last_trigger is AsekoBackwashTrigger.MANUAL
+
+    later = T0 + timedelta(days=SCHEDULE_EVERY_N_DAYS)
+    _run_service_menu_cycle(tracker, later, False)
+
+    assert tracker.last_trigger is AsekoBackwashTrigger.SCHEDULED

--- a/tests/test_backwash_tracker.py
+++ b/tests/test_backwash_tracker.py
@@ -295,17 +295,30 @@ def test_cycle_just_inside_tolerance_is_scheduled():
     assert tracker.last_trigger is AsekoBackwashTrigger.SCHEDULED
 
 
-def test_cycle_outside_tolerance_is_unknown():
-    """A cycle away from the scheduled time is recorded, not attributed.
-
-    The unit's timer does not explain it, which is not the same as knowing a
-    person started it — that would need the menu bit, and this device is not
-    reporting it.  So the cycle lands in last_backwash and nowhere else.
-    """
+def test_cycle_outside_tolerance_is_manual_without_the_menu_signal():
+    """On a device that cannot report the menu, elimination is all there is."""
     tracker = BackwashTracker(_hass(), serial_number=110071590)
 
     started = T0 + timedelta(hours=2)
     _run_cycle(tracker, started)
+
+    assert tracker.last_trigger is AsekoBackwashTrigger.MANUAL
+    assert tracker.last_manual_backwash == started + timedelta(seconds=45)
+    assert tracker.last_backwash == tracker.last_manual_backwash
+    assert tracker.last_scheduled_backwash is None
+
+
+def test_cycle_outside_tolerance_is_unknown_on_salt():
+    """Where the menu bit exists, "matched nothing" is a real answer.
+
+    The unit would have said if somebody had been at it, and it did not.  So
+    the cycle is recorded as having happened and attributed to neither side,
+    rather than called manual because nothing else fit.
+    """
+    tracker = BackwashTracker(_hass(), serial_number=110071590)
+
+    started = T0 + timedelta(hours=2)
+    _run_service_menu_cycle(tracker, started, False)
 
     assert tracker.last_trigger is AsekoBackwashTrigger.UNKNOWN
     assert tracker.last_backwash == started + timedelta(seconds=45)
@@ -313,13 +326,8 @@ def test_cycle_outside_tolerance_is_unknown():
     assert tracker.last_scheduled_backwash is None
 
 
-def test_cycle_is_unknown_when_schedule_disabled():
-    """interval 0 = automatic backwash off, so there is nothing to match.
-
-    It is tempting to call this manual — the unit's own timer is off, so what
-    else could it be?  A fault-triggered cycle, for one.  The frame does not
-    say, so neither do we.
-    """
+def test_cycle_is_manual_when_schedule_disabled():
+    """interval 0 = automatic backwash off → the unit cannot have started it."""
     tracker = BackwashTracker(_hass(), serial_number=110071590)
 
     def _disabled(active):
@@ -327,19 +335,16 @@ def test_cycle_is_unknown_when_schedule_disabled():
 
     _run_cycle(tracker, T0, device_factory=_disabled)
 
-    assert tracker.last_trigger is AsekoBackwashTrigger.UNKNOWN
-    assert tracker.last_manual_backwash is None
-    assert tracker.last_scheduled_backwash is None
+    assert tracker.last_trigger is AsekoBackwashTrigger.MANUAL
 
 
-def test_cycle_is_unknown_when_schedule_unconfigured():
+def test_cycle_is_manual_when_schedule_unconfigured():
     """No backwash_time in the frame (0xFF) → nothing to match against."""
     tracker = BackwashTracker(_hass(), serial_number=110071590)
 
     _run_cycle(tracker, T0, device_factory=_device)
 
-    assert tracker.last_trigger is AsekoBackwashTrigger.UNKNOWN
-    assert tracker.last_manual_backwash is None
+    assert tracker.last_trigger is AsekoBackwashTrigger.MANUAL
 
 
 def test_scheduled_time_near_midnight_matches_across_days():
@@ -390,7 +395,7 @@ def test_unknown_cycle_keeps_earlier_scheduled_record():
     scheduled = tracker.last_scheduled_backwash
     assert scheduled is not None
 
-    _run_cycle(tracker, T0 + timedelta(days=1, hours=4))
+    _run_service_menu_cycle(tracker, T0 + timedelta(days=1, hours=4), False)
 
     assert tracker.last_trigger is AsekoBackwashTrigger.UNKNOWN
     assert tracker.last_scheduled_backwash == scheduled
@@ -418,7 +423,7 @@ def test_next_scheduled_backwash_unknown_after_unattributed_only():
     tracker = BackwashTracker(_hass(), serial_number=110071590)
     device = _scheduled_device(False)
 
-    _run_cycle(tracker, T0 + timedelta(hours=2))
+    _run_service_menu_cycle(tracker, T0 + timedelta(hours=2), False)
 
     assert tracker.last_trigger is AsekoBackwashTrigger.UNKNOWN
     assert tracker.next_scheduled_backwash(device, T0 + timedelta(hours=3)) is None
@@ -507,7 +512,7 @@ async def test_async_save_writes_an_unknown_trigger():
     """The verdict survives a restart rather than being re-derived."""
     tracker = BackwashTracker(_hass(), serial_number=110071590)
 
-    _run_cycle(tracker, T0 + timedelta(hours=2))
+    _run_service_menu_cycle(tracker, T0 + timedelta(hours=2), False)
     await tracker.async_save()
 
     saved = tracker._store.async_save.call_args.args[0]  # type: ignore[attr-defined]
@@ -711,18 +716,35 @@ def test_backfill_classifies_a_pre_split_record_as_scheduled():
     assert tracker.last_manual_backwash is None
 
 
-def test_backfill_leaves_an_unmatched_pre_split_record_unattributed():
-    """A stored cycle that did not run at the scheduled time stays unattributed.
+def test_backfill_classifies_a_pre_split_record_as_manual():
+    """Same, for a stored cycle that did not run at the scheduled time.
 
-    The menu bit is not recoverable after the fact, so the schedule is the
-    only thing left to check — and it does not match.  The record keeps its
-    place in last_backwash and fills neither half of the split.
+    This device does not report the menu, so the elimination rule applies to
+    the backfilled record exactly as it does to a live one.
     """
     tracker = BackwashTracker(_hass(), serial_number=110071590)
     off_schedule = T0 + timedelta(hours=4)
     tracker._last_backwash = off_schedule  # type: ignore[attr-defined]
 
     tracker.update(_scheduled_device(False), off_schedule + timedelta(minutes=5))
+
+    assert tracker.last_manual_backwash == off_schedule
+    assert tracker.last_trigger is AsekoBackwashTrigger.MANUAL
+    assert tracker.last_scheduled_backwash is None
+
+
+def test_backfill_leaves_an_unmatched_salt_record_unattributed():
+    """On SALT the menu bit is not recoverable after the fact.
+
+    So a stored cycle that does not match the schedule cannot be attributed
+    at all: it keeps its place in last_backwash and fills neither half.  The
+    next real cycle is classified properly, menu bit and all.
+    """
+    tracker = BackwashTracker(_hass(), serial_number=110071590)
+    off_schedule = T0 + timedelta(hours=4)
+    tracker._last_backwash = off_schedule  # type: ignore[attr-defined]
+
+    tracker.update(_salt_device(False, False), off_schedule + timedelta(minutes=5))
 
     assert tracker.last_trigger is AsekoBackwashTrigger.UNKNOWN
     assert tracker.last_manual_backwash is None
@@ -735,8 +757,8 @@ def test_backfill_does_not_retry_an_unattributed_record():
     off_schedule = T0 + timedelta(hours=4)
     tracker._last_backwash = off_schedule  # type: ignore[attr-defined]
 
-    tracker.update(_scheduled_device(False), off_schedule + timedelta(minutes=5))
-    tracker.update(_scheduled_device(False), off_schedule + timedelta(minutes=10))
+    tracker.update(_salt_device(False, False), off_schedule + timedelta(minutes=5))
+    tracker.update(_salt_device(False, False), off_schedule + timedelta(minutes=10))
 
     assert tracker._backfill_attempted is True  # type: ignore[attr-defined]
     assert tracker.last_manual_backwash is None

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -12,6 +12,7 @@ from custom_components.aseko_local.binary_sensor import (
 )
 from custom_components.aseko_local.sensor import (
     RETIRED_UNIQUE_ID_SUFFIXES as RETIRED_SENSOR_IDS,
+    async_migrate_unique_ids,
     async_remove_retired_entities as async_remove_retired_sensors,
     async_setup_entry,
     AsekoLocalSensorEntity,
@@ -243,7 +244,8 @@ async def test_async_setup_salt_redox(hass) -> None:
     # Create a MagicMock for ConfigEntry with runtime_data attribute
     dummy_entry = MagicMock(spec=ConfigEntry)
     # entry_id is an instance attribute, so spec= does not provide it, but
-    # async_setup_entry needs it to clean up retired entities.
+    # async_setup_entry needs it to clean up retired entities and to run the
+    # unique_id migration pass.
     dummy_entry.entry_id = "test_entry_id"
     dummy_entry.runtime_data = type(
         "RuntimeData", (), {"coordinator": DummyCoordinator()}
@@ -283,7 +285,11 @@ async def test_async_setup_salt_redox(hass) -> None:
     # (water_flow, electrolyzer_active, filtration, ph_minus)
     # + 2 consumption (ph_minus canister + total) + 1 connection_status
     # + 3 new backwash config sensors (every_n_days, time, duration)
-    # + 2 new backwash schedule sensors (last_backwash, next_backwash)
+    # + 3 backwash history sensors (last_backwash, last_manual_backwash,
+    #   next_scheduled_backwash) — created for every device with a backwash
+    #   valve even though they read "unknown" until a cycle is seen.
+    #   last_scheduled_backwash is a datetime entity, not a sensor, so it is
+    #   not in this platform's count.
     # + 1 new backwash_active binary sensor
     # + 1 new heating_active binary sensor
     # byte[37] reshuffle, net zero:
@@ -292,7 +298,21 @@ async def test_async_setup_salt_redox(hass) -> None:
     #   +1 filtration_schedule sensor  — what the unit runs unattended
     #   +1 service_menu binary sensor  — bit 0x04, a device state, not a
     #      filtration one
-    assert len(added_entities) == 40
+    assert len(added_entities) == 41
+    # Nothing has been observed yet, so the history is unknown rather than
+    # guessed from the schedule.
+    backwash_history = {
+        e.entity_description.key: e.native_value
+        for e in added_entities
+        if getattr(e.entity_description, "key", None)
+        in {
+            "last_backwash",
+            "last_manual_backwash",
+            "next_scheduled_backwash",
+        }
+    }
+    assert len(backwash_history) == 3
+    assert all(value is None for value in backwash_history.values())
     assert any(
         getattr(e.entity_description, "key", None) != "water_flow_to_probes"
         for e in added_entities
@@ -355,7 +375,8 @@ async def test_async_setup_salt_clf(hass) -> None:
     # Create a MagicMock for ConfigEntry with runtime_data attribute
     dummy_entry = MagicMock(spec=ConfigEntry)
     # entry_id is an instance attribute, so spec= does not provide it, but
-    # async_setup_entry needs it to clean up retired entities.
+    # async_setup_entry needs it to clean up retired entities and to run the
+    # unique_id migration pass.
     dummy_entry.entry_id = "test_entry_id"
     dummy_entry.runtime_data = type(
         "RuntimeData", (), {"coordinator": DummyCoordinator()}
@@ -396,7 +417,9 @@ async def test_async_setup_salt_clf(hass) -> None:
     # (water_flow, electrolyzer_active, filtration, ph_minus)
     # + 2 consumption (ph_minus canister + total) + 1 connection_status
     # + 3 new backwash config sensors (every_n_days, time, duration)
-    # + 2 new backwash schedule sensors (last_backwash, next_backwash)
+    # + 4 backwash history sensors (last_backwash, last_scheduled_backwash,
+    #   last_manual_backwash, next_scheduled_backwash; last_scheduled_backwash
+    #   is a datetime entity, counted by that platform instead)
     # + 1 new backwash_active binary sensor
     # + 1 new heating_active binary sensor
     # byte[37] reshuffle, net zero:
@@ -405,7 +428,7 @@ async def test_async_setup_salt_clf(hass) -> None:
     #   +1 filtration_schedule sensor  — what the unit runs unattended
     #   +1 service_menu binary sensor  — bit 0x04, a device state, not a
     #      filtration one
-    assert len(added_entities) == 41
+    assert len(added_entities) == 42
     assert any(
         getattr(e.entity_description, "key", None) != "water_flow_to_probes"
         for e in added_entities
@@ -461,7 +484,8 @@ async def test_async_setup_net_clf(hass) -> None:
     # Create a MagicMock for ConfigEntry with runtime_data attribute
     dummy_entry = MagicMock(spec=ConfigEntry)
     # entry_id is an instance attribute, so spec= does not provide it, but
-    # async_setup_entry needs it to clean up retired entities.
+    # async_setup_entry needs it to clean up retired entities and to run the
+    # unique_id migration pass.
     dummy_entry.entry_id = "test_entry_id"
     dummy_entry.runtime_data = type(
         "RuntimeData", (), {"coordinator": DummyCoordinator()}
@@ -506,10 +530,12 @@ async def test_async_setup_net_clf(hass) -> None:
     # + 1 heating_active binary sensor
     # Issue #129: NET has no backwash valve and no filling valve, so the
     # backwash / water_level / max_filling_time groups are *all* suppressed.
-    # The 5 backwash config + schedule sensors that the old code created
-    # (every_n_days, time, duration, last_backwash, next_backwash) plus
+    # The backwash config + history sensors that the old code created
+    # (every_n_days, time, duration, last_backwash, next_scheduled_backwash) plus
     # max_filling_time are no longer created for NET, even when the frame
-    # carries non-0xFF data in those byte slots.
+    # carries non-0xFF data in those byte slots.  The history sensors are
+    # gated on the device having a backwash valve, not on their own value,
+    # so this stays true now that they start out unknown.
     assert len(added_entities) == 23
     assert not any(
         getattr(e.entity_description, "key", None) == "backwash_every_n_days"
@@ -528,7 +554,15 @@ async def test_async_setup_net_clf(hass) -> None:
         for e in added_entities
     )
     assert not any(
-        getattr(e.entity_description, "key", None) == "next_backwash"
+        getattr(e.entity_description, "key", None) == "next_scheduled_backwash"
+        for e in added_entities
+    )
+    assert not any(
+        getattr(e.entity_description, "key", None) == "last_manual_backwash"
+        for e in added_entities
+    )
+    assert not any(
+        getattr(e.entity_description, "key", None) == "last_scheduled_backwash"
         for e in added_entities
     )
     assert not any(
@@ -586,7 +620,8 @@ async def test_async_setup_profi_clf_redox(hass) -> None:
     # Create a MagicMock for ConfigEntry with runtime_data attribute
     dummy_entry = MagicMock(spec=ConfigEntry)
     # entry_id is an instance attribute, so spec= does not provide it, but
-    # async_setup_entry needs it to clean up retired entities.
+    # async_setup_entry needs it to clean up retired entities and to run the
+    # unique_id migration pass.
     dummy_entry.entry_id = "test_entry_id"
     dummy_entry.runtime_data = type(
         "RuntimeData", (), {"coordinator": DummyCoordinator()}
@@ -628,14 +663,17 @@ async def test_async_setup_profi_clf_redox(hass) -> None:
     # + 4 alarm binary sensors (ph_too_many_doses, orp_too_many_doses,
     #   no_flow_to_probes, rapid_ph_change)
     # + 3 new backwash config sensors (every_n_days, time, duration)
-    # + 2 new backwash schedule sensors (last_backwash, next_backwash)
+    # + 4 backwash history sensors (last_backwash, last_scheduled_backwash,
+    #   last_manual_backwash, next_scheduled_backwash; last_scheduled_backwash
+    #   is a datetime entity, counted by that platform instead)
     # + 1 max_filling_time sensor (data[76:78])
     #
     # Regular sensors (16): free_chlorine, required_free_chlorine,
     #   free_chlorine_mv, ph, required_ph, rx, water_temp, required_water_temp,
     #   flowrate_ph_minus, flowrate_floc,
     #   backwash_every_n_days, backwash_time, backwash_duration,
-    #   last_backwash, next_backwash
+    #   last_backwash, last_scheduled_backwash, last_manual_backwash,
+    #   next_scheduled_backwash
     # Binary sensors (6): water_flow_to_probes, pump_running, cl_pump_running,
     #   ph_minus_pump_running, floc_pump_running, water_filling_active
     # Heating-related (1 binary): heating_active
@@ -662,7 +700,9 @@ async def test_async_setup_profi_clf_redox(hass) -> None:
     #   +1 filtration_schedule sensor  — what the unit runs unattended
     #   +1 service_menu binary sensor  — bit 0x04, a device state, not a
     #      filtration one
-    assert len(added_entities) == 43
+    # + 1 last_manual_backwash sensor; last_scheduled_backwash is a datetime
+    #   entity, counted by that platform rather than here
+    assert len(added_entities) == 44
     assert any(
         getattr(e.entity_description, "key", None) == "free_chlorine"
         for e in added_entities
@@ -864,3 +904,92 @@ async def test_retired_filtration_mode_sensor_is_removed(
 
     assert registry.async_get(retired.entity_id) is None
     assert registry.async_get(kept.entity_id) is not None
+
+
+# ── unique_id migration ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_migrate_next_backwash_unique_id(hass, mock_config_entry) -> None:
+    """The renamed next_backwash sensor keeps its entity_id and history.
+
+    Renaming a sensor key changes the unique_id, which would otherwise orphan
+    the existing registry entry: the old entity would go permanently
+    unavailable and a second one would appear beside it.
+    """
+    registry = er.async_get(hass)
+    old = registry.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        "1234next_backwash",
+        config_entry=mock_config_entry,
+        suggested_object_id="aseko_next_backwash",
+    )
+
+    async_migrate_unique_ids(hass, mock_config_entry)
+
+    migrated = registry.async_get(old.entity_id)
+    assert migrated is not None
+    assert migrated.unique_id == "1234next_scheduled_backwash"
+    # Same registry entry, so the entity_id — and everything keyed on it — survives.
+    assert migrated.entity_id == old.entity_id
+
+
+@pytest.mark.asyncio
+async def test_migrate_unique_ids_is_idempotent(hass, mock_config_entry) -> None:
+    """Running the migration again leaves the already-migrated entry alone."""
+    registry = er.async_get(hass)
+    entry = registry.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        "1234next_scheduled_backwash",
+        config_entry=mock_config_entry,
+    )
+
+    async_migrate_unique_ids(hass, mock_config_entry)
+    async_migrate_unique_ids(hass, mock_config_entry)
+
+    assert (
+        registry.async_get(entry.entity_id).unique_id == "1234next_scheduled_backwash"
+    )
+
+
+@pytest.mark.asyncio
+async def test_migrate_unique_ids_skips_when_target_exists(
+    hass, mock_config_entry
+) -> None:
+    """A stale old entry is left in place rather than colliding with the new one.
+
+    async_update_entity would raise if the target unique_id is already taken,
+    which would break setup for the whole config entry.
+    """
+    registry = er.async_get(hass)
+    old = registry.async_get_or_create(
+        "sensor", DOMAIN, "1234next_backwash", config_entry=mock_config_entry
+    )
+    new = registry.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        "1234next_scheduled_backwash",
+        config_entry=mock_config_entry,
+    )
+
+    async_migrate_unique_ids(hass, mock_config_entry)
+
+    assert registry.async_get(old.entity_id).unique_id == "1234next_backwash"
+    assert registry.async_get(new.entity_id).unique_id == "1234next_scheduled_backwash"
+
+
+@pytest.mark.asyncio
+async def test_migrate_unique_ids_leaves_other_sensors_untouched(
+    hass, mock_config_entry
+) -> None:
+    """Only the renamed keys are rewritten."""
+    registry = er.async_get(hass)
+    entry = registry.async_get_or_create(
+        "sensor", DOMAIN, "1234last_backwash", config_entry=mock_config_entry
+    )
+
+    async_migrate_unique_ids(hass, mock_config_entry)
+
+    assert registry.async_get(entry.entity_id).unique_id == "1234last_backwash"


### PR DESCRIPTION
## Summary

The backwash history sensors were derived from the configured schedule and the
frame timestamp. The frame carries the backwash **configuration** (bytes 68–71)
and the live valve bit, but never the **history** — so the schedule alone cannot
say whether a cycle actually ran. The sensors showed a confident timestamp for a
backwash that may never have happened.

They now report only what was observed, the observed history is split into
scheduled and manual, and the value the device cannot tell us — when its last
scheduled cycle ran — can be entered by hand.

## Live confirmation of `byte[29]` bit `0x01`

The mapping was previously taken from JS-DE-Tech without a capture. A diagnostics
series spanning a manually started backwash on an ASIN AQUA Salt (v7) confirms it:

| time | `byte[29]` | bits | backwash | filtration | electrolyzer |
|---|---|---|---|---|---|
| 13:26:30 | `0x48` | `01001000` | — | ON | — |
| **13:26:43** | **`0x49`** | `01001001` | **ON** | ON | — |
| 13:28:09 | `0x49` | `01001001` | **ON** | ON | — |
| 13:28:29 | `0x48` | `01001000` | — | ON | — |
| 13:28:38 | `0x58` | `01011000` | — | ON | ON |

The 86–106 s relay window matches the unit's configured `backwash_duration` of
100 s (`byte[71] = 0x0a`), no other actuator bit moved during it, and the
electrolyzer came back only after the cycle ended.

## Entities

Two different things can be uncertain here, and they are tracked separately:
how a **timestamp** was obtained, and which **bucket** a cycle was filed into.

| Entity | Description | Timestamp | Bucket |
|---|---|---|---|
| `sensor.last_backwash` | Last cycle, whatever started it | Observed | n/a — holds every cycle |
| `datetime.last_scheduled_backwash` 🆕 | Last cycle that looked scheduled — **settable** | Observed *or* entered — see `source` | Estimated |
| `sensor.last_manual_backwash` 🆕 | Last cycle that did not | Observed | Estimated |
| `sensor.next_scheduled_backwash` | Projected next automatic cycle | **Calculated** | Inherited |

A cycle the integration watched has an exact timestamp; what is estimated is only
which of the two buckets it belongs in. Only `next_scheduled_backwash` holds a
timestamp that was computed rather than measured, so it is the only one carrying
"(estimated)" in its translated name. The classification caveat lives where it
belongs instead: in the README, in `_classify`, and per-value in the `source`
attribute. Translations updated for `en`, `cs`, `de`, `fr`.

`last_scheduled_backwash` is a settable `datetime` rather than a read-only sensor
so the date can be entered by clicking it and picking one in the dialog — no
helper, no script, no confirm button.

All four read "unknown" until a cycle is observed or a date is entered.

## Classification is a heuristic

The device never reports *why* the valve opened, so scheduled vs manual is a guess
based on the only signal available — the time the valve opened. Within ±15 min of
`backwash_time` on a unit with an enabled schedule counts as scheduled; anything
else is manual. `_classify` and the README document the specific ways it misfires:
a manual cycle near the scheduled time, a manual cycle at exactly `backwash_time`
on a non-scheduled day (only the time of day is checked, not the day), clock drift
beyond the tolerance, and a cycle the unit runs for some other reason.

`next_scheduled_backwash` is projected from the last scheduled cycle, snapped to
`backwash_time` and stepped past cycles missed while HA was down, so it inherits
any error in that classification. It carries no `source` of its own — it is always
projected from `last_scheduled_backwash`, so that entity's source covers both.

## Services

* `aseko_local.set_last_scheduled_backwash` — seed the schedule phase from an
  automation instead of waiting out a whole interval for the first observed cycle.
* `aseko_local.clear_last_scheduled_backwash` — the undo for a mistyped date.

Both reject an unknown serial number, and `set` rejects a future timestamp, with a
`ServiceValidationError` rather than silently doing nothing.

**Last write wins**, and the stored timestamps are never compared: a manual entry
always applies, and a scheduled cycle detected afterwards replaces it, because the
value that stood in for a real cycle has been overtaken by one.

Seeding deliberately leaves `last_backwash` alone — that sensor means "the
integration watched this happen", and a typed-in date has not been watched.

## Upgrading

**Backfill.** A store written before the scheduled/manual split holds only
`last_backwash`, which would leave both new entities empty until the next cycle —
up to a whole interval away. That stored cycle *was* one or the other, and the
schedule needed to classify it arrives in every frame, so it is classified on the
first frame after the upgrade and filed under whichever it belongs to. It runs only
while both are empty, so it can never overwrite a real cycle, and it retries on
later frames if the first carried no schedule.

**Rename.** `sensor.next_backwash` → `sensor.next_scheduled_backwash`. The key
feeds `unique_id`, so a bare rename would orphan the registry entry — the old
entity would go permanently unavailable and a second would appear beside it without
history. `async_migrate_unique_ids` rewrites the registry at setup, so the entity
keeps its `entity_id`, its recorded history and any automation pointing at it.
Handles fresh installs, repeated runs, and the case where both ids already exist.

**Store** stays at version 1 — the new keys are optional on load, so an existing
store keeps working.

## Bug fixes found along the way

* The coordinator wrote `last_backwash` onto the incoming device **after**
  `AsekoData.set()` had already copied its attributes onto the stored object. For
  an already-known device the live-tracked value therefore never reached the
  entities — only the schedule-derived estimate was ever visible.
* `async_save` skipped the write entirely while nothing was recorded, which would
  have made clearing useless: the cleared value stayed on disk and returned on the
  next restart.

## Implementation notes

* `AsekoSensorEntityDescription` grows `supported_fn`, so a sensor that is
  legitimately unknown until an event occurs is still created, while staying
  suppressed on device types without a backwash valve (Issue #129).
* The backwash state is surfaced in diagnostics, so a dump answers "did a backwash
  run?" without decoding bit `0x01` by hand across a series of frames.

## Testing

217 passing. New coverage for: scheduled/manual classification including the
midnight boundary, disabled and unconfigured schedules, the projection rolling past
missed cycles, last-write-wins in both directions, the backfill and its guards,
clearing and its persistence, v1-store compatibility, entity creation while
unknown, NET suppression, and all four unique_id migration paths.

Verified on a live ASIN AQUA Salt (v7) across the full cycle: a manually started
backwash was detected and classified as manual, a seeded date drove the projection
and was labelled `manual`, clearing returned it to unknown and re-derived the split
from the stored cycle, and a real scheduled backwash then took over and flipped the
source to `observed` with the projection recomputed to +15 days.

> `tests/test_init.py` has 4 pre-existing failures on Windows (event-loop
> threading); verified identical on an unmodified tree.

## Related

Refines the backwash support added in #120 (#100, #129) — that PR derived
`last_backwash`/`next_backwash` from the configured schedule, which this replaces
with observed history. Builds on the device-type gating from #130.

Does **not** close #148: that asks for an ON/OFF entity reflecting whether the
backwash *feature* is enabled, which is a configuration flag rather than history.
It does however provide the live `byte[29]` bit `0x01` capture that was being asked
for in that thread.