### PR TITLE
FIX - byte[37] filtration decoding on non-HOME devices, and split mode from schedule

### DIFF
--- a/custom_components/aseko_local/aseko_data.py
+++ b/custom_components/aseko_local/aseko_data.py
@@ -68,24 +68,33 @@ class AsekoFiltrationSchedule(Enum):
 class AsekoFiltrationMode(Enum):
     """What is driving the filtration pump right now.
 
-    byte[37] bit 0x04.  The schedule and the override are two independent
-    facts, and folding them into one value would lose whichever is not
-    being reported: while the user is in manual mode the unit is still
-    configured for a schedule, and it goes back to it on the way out.
+    byte[37] bit 0x04.  The schedule and this flag are two independent facts,
+    and folding them into one value would lose whichever is not being
+    reported: the unit stays configured for a schedule throughout, and goes
+    back to it afterwards.
 
-    SCHEDULE — the unit follows `filtration_schedule`.
-    MANUAL — the user has taken the pump over at the unit.  On SALT this
-        is a mode entered at the panel, and the unit stops transmitting
-        while in it, so MANUAL is typically the last thing reported
-        before the device goes offline.  On HOME firmware B it is a
-        standing override that forces the pump off.
+    SCHEDULE — the unit is running on `filtration_schedule`.
+    SERVICE_MENU — somebody has the unit's settings menu open.  That is the
+        menu filtration and backwash can be started by hand from, so the
+        schedule is not necessarily what is driving the pump while it is
+        open — but the bit says only that a person is there, not what they
+        did.  Measured on SALT: it appears on entering the menu, before
+        anything is touched, and the unit stops transmitting until they
+        leave, so this is typically the last state reported before the
+        device goes offline.
+
+        On HOME firmware B the same bit is documented by Issue #133 as a
+        standing manual override that forces the pump off, and the decoder
+        still treats it that way there (see `_fill_pump_states`).  Whether
+        the two are literally the same mechanism is unverified — there are
+        no HOME captures of the menu being opened.
 
     Enum values map to the translation keys under
     entity.sensor.filtration_mode.state.
     """
 
     SCHEDULE = "schedule"
-    MANUAL = "manual"
+    SERVICE_MENU = "service_menu"
 
 
 # ---------------------------------------------------------------------------

--- a/custom_components/aseko_local/aseko_data.py
+++ b/custom_components/aseko_local/aseko_data.py
@@ -52,9 +52,9 @@ class AsekoElectrolyzerDirection(Enum):
 class AsekoFiltrationSchedule(Enum):
     """The filtration schedule the unit is configured for (Issue #133).
 
-    byte[37] bits 0x10 / 0x20.  Independent of whether the schedule is
-    currently in charge — see `AsekoFiltrationMode` — so it keeps reading
-    the same while the user drives the pump by hand.
+    byte[37] bits 0x10 / 0x20.  What the unit runs when nobody is at it —
+    see `AsekoDevice.service_menu_open`, which is decoded from the same
+    byte but says nothing about filtration.
 
     Enum values map to the translation keys under
     entity.sensor.filtration_schedule.state.
@@ -63,38 +63,6 @@ class AsekoFiltrationSchedule(Enum):
     NONSTOP_24H = "nonstop_24h"
     TIMER_PERIOD_1 = "timer_period_1"
     TIMER_PERIOD_1_AND_2 = "timer_period_1_and_2"
-
-
-class AsekoFiltrationMode(Enum):
-    """What is driving the filtration pump right now.
-
-    byte[37] bit 0x04.  The schedule and this flag are two independent facts,
-    and folding them into one value would lose whichever is not being
-    reported: the unit stays configured for a schedule throughout, and goes
-    back to it afterwards.
-
-    SCHEDULE — the unit is running on `filtration_schedule`.
-    SERVICE_MENU — somebody has the unit's settings menu open.  That is the
-        menu filtration and backwash can be started by hand from, so the
-        schedule is not necessarily what is driving the pump while it is
-        open — but the bit says only that a person is there, not what they
-        did.  Measured on SALT: it appears on entering the menu, before
-        anything is touched, and the unit stops transmitting until they
-        leave, so this is typically the last state reported before the
-        device goes offline.
-
-        On HOME firmware B the same bit is documented by Issue #133 as a
-        standing manual override that forces the pump off, and the decoder
-        still treats it that way there (see `_fill_pump_states`).  Whether
-        the two are literally the same mechanism is unverified — there are
-        no HOME captures of the menu being opened.
-
-    Enum values map to the translation keys under
-    entity.sensor.filtration_mode.state.
-    """
-
-    SCHEDULE = "schedule"
-    SERVICE_MENU = "service_menu"
 
 
 # ---------------------------------------------------------------------------
@@ -220,14 +188,18 @@ class AsekoDevice:
     # and both are worth showing, so the two are kept apart.
     filtration_schedule: AsekoFiltrationSchedule | None = None
 
-    # What is driving the pump right now — byte [37] bit 0x04 (Issue #133).
-    # Set for every device type in FILTRATION_TYPES = {SALT, HOME, OXY, PROFI};
-    # NET is excluded, it has no filtration output (Issue #66).
+    # Somebody has the unit's settings menu open — byte [37] bit 0x04.
     #
-    # Deliberately not folded together with `filtration_schedule`: reporting
-    # one value would mean dropping the schedule whenever it reads "manual",
-    # which is the moment you most want to know what the unit goes back to.
-    filtration_mode: AsekoFiltrationMode | None = None
+    # Not a filtration state, despite living in the same byte: it says a
+    # person is standing at the unit, and nothing about what they are doing.
+    # The menu is where filtration and backwash can be started by hand, but
+    # the unit stops transmitting while it is open, so whether anything was
+    # touched — and what — is not observable at all.  It may well override
+    # filtration; there is no way to see that from here.
+    #
+    # Only the bit-flag firmware encodes it.  Left None on firmware A, where
+    # bit 0x04 belongs to the transitional edit states, and on NET.
+    service_menu_open: bool | None = None
 
     # Alarm/error bitmasks — bytes [12] (HOME dosing warnings) and [13]
     # byte [12] 0x20 = chlorine/disinfection dosing warning (HOME ✅, issue #134)

--- a/custom_components/aseko_local/aseko_data.py
+++ b/custom_components/aseko_local/aseko_data.py
@@ -49,20 +49,42 @@ class AsekoElectrolyzerDirection(Enum):
     WAITING = "waiting"
 
 
-class AsekoFiltrationMode(Enum):
-    """Enumeration of the 4 filtration schedule states.
+class AsekoFiltrationSchedule(Enum):
+    """The filtration schedule the unit is configured for (Issue #133).
 
-    Surfaced by the new `filtration_mode` sensor (Issue #133) and used
-    internally to override `filtration_pump_running` when the user has
-    manually switched the pump off on a HOME v7 device (firmware B).
+    byte[37] bits 0x10 / 0x20.  Independent of whether the schedule is
+    currently in charge — see `AsekoFiltrationMode` — so it keeps reading
+    the same while the user drives the pump by hand.
 
-    Enum values map directly to the translation keys in
-    translations/{en,de,cs,fr}.json under entity.sensor.filtration_mode.state.
+    Enum values map to the translation keys under
+    entity.sensor.filtration_schedule.state.
     """
 
     NONSTOP_24H = "nonstop_24h"
     TIMER_PERIOD_1 = "timer_period_1"
     TIMER_PERIOD_1_AND_2 = "timer_period_1_and_2"
+
+
+class AsekoFiltrationMode(Enum):
+    """What is driving the filtration pump right now.
+
+    byte[37] bit 0x04.  The schedule and the override are two independent
+    facts, and folding them into one value would lose whichever is not
+    being reported: while the user is in manual mode the unit is still
+    configured for a schedule, and it goes back to it on the way out.
+
+    SCHEDULE — the unit follows `filtration_schedule`.
+    MANUAL — the user has taken the pump over at the unit.  On SALT this
+        is a mode entered at the panel, and the unit stops transmitting
+        while in it, so MANUAL is typically the last thing reported
+        before the device goes offline.  On HOME firmware B it is a
+        standing override that forces the pump off.
+
+    Enum values map to the translation keys under
+    entity.sensor.filtration_mode.state.
+    """
+
+    SCHEDULE = "schedule"
     MANUAL = "manual"
 
 
@@ -183,29 +205,19 @@ class AsekoDevice:
     # Water filling active — byte [29] bit 0x02
     water_filling_active: bool | None = None
 
-    # Filtration mode — byte [37]
-    # True = nonstop 24 h (0x43), False = timer (0x53), None = transitional/unknown
-    filtration_nonstop24: bool | None = None
+    # The filtration schedule the unit is configured for — byte [37]
+    # bits 0x10 / 0x20, which the manual override (bit 0x04) does not
+    # touch.  A unit can be in manual mode *and* configured for nonstop,
+    # and both are worth showing, so the two are kept apart.
+    filtration_schedule: AsekoFiltrationSchedule | None = None
 
-    # Filtration mode — 4-state enum (Issue #133).
-    # Set for every device type in FILTRATION_TYPES = {SALT, HOME, OXY, PROFI}.
-    # NET is excluded — no filtration output (see Issue #66).
+    # What is driving the pump right now — byte [37] bit 0x04 (Issue #133).
+    # Set for every device type in FILTRATION_TYPES = {SALT, HOME, OXY, PROFI};
+    # NET is excluded, it has no filtration output (Issue #66).
     #
-    # Every device type in FILTRATION_TYPES encodes the 4-state mode directly
-    # in byte[37] with two firmware variants:
-    #   Firmware A (serial 110128063, byte 4 = 0x02): high nibble 0x4 / 0x5
-    #     0x43 → NONSTOP_24H
-    #     0x53 → TIMER_PERIOD_1_AND_2 (cannot distinguish P1 vs P1&P2)
-    #     0x47 / 0x57 → leave as None (transitional edit state)
-    #   Firmware B (serial 110169464, byte 4 = 0x03): high nibble 0x0 / 0x1 / 0x3
-    #     0x01 → NONSTOP_24H
-    #     0x11 → TIMER_PERIOD_1
-    #     0x31 → TIMER_PERIOD_1_AND_2
-    #     0x15 → MANUAL (P1 + manual override, bit 0x04 set)
-    #     0x35 → MANUAL (P1&P2 + manual override, bit 0x04 set)
-    #
-    # This guarantees that a single `filtration_mode` sensor shows the
-    # same 4 states on every filtration-capable device.
+    # Deliberately not folded together with `filtration_schedule`: reporting
+    # one value would mean dropping the schedule whenever it reads "manual",
+    # which is the moment you most want to know what the unit goes back to.
     filtration_mode: AsekoFiltrationMode | None = None
 
     # Alarm/error bitmasks — bytes [12] (HOME dosing warnings) and [13]

--- a/custom_components/aseko_local/aseko_decoder.py
+++ b/custom_components/aseko_local/aseko_decoder.py
@@ -670,13 +670,13 @@ class AsekoDecoder:
             0x01 = nonstop 24h
             0x11 = P1 only
             0x31 = P1 & P2
-            0x15 = P1 + manual override     → MANUAL (bit 0x04 set)
-            0x35 = P1 & P2 + manual override → MANUAL (bit 0x04 set)
+            0x15 = P1 + manual override     → SERVICE_MENU (bit 0x04 set)
+            0x35 = P1 & P2 + manual override → SERVICE_MENU (bit 0x04 set)
 
-        Bit 0x04 is an override laid on top of a schedule that stays
-        configured underneath it, so the two are decoded into separate
-        fields: `filtration_mode` reports what is in charge right now
-        (MANUAL wins), `filtration_schedule` what the unit will go back to.
+        Bit 0x04 sits on top of a schedule that stays configured underneath
+        it, so the two are decoded into separate fields:
+        `filtration_mode` reports whether anyone is at the unit
+        (SERVICE_MENU wins), `filtration_schedule` what it runs otherwise.
 
         SALT uses the same mode bits as the new encoding above; its high
         nibble carries its own flags (0x80 = algicide routing) and bit 0x40 is
@@ -685,19 +685,24 @@ class AsekoDecoder:
             0xC3 = nonstop 24h
             0xD3 = P1 only
             0xF3 = P1 & P2
-            0xD7 / 0xF7 = the above plus manual mode → MANUAL (bit 0x04 set)
+            0xD7 / 0xF7 = the above plus the settings menu being open
+                          → SERVICE_MENU (bit 0x04 set)
 
         Because bit 0x40 is set in every SALT frame, the firmware-A branch is
         taken for HOME only; every other device type reads the bit flags.
 
-        On SALT, MANUAL is a mode the user enters at the unit to switch
-        filtration by hand, and the unit stops transmitting while it is in it
-        — the frame carrying the mode change is the last one until the user
-        leaves the mode again.  It therefore shows up as a brief flip to
-        MANUAL followed by the device going offline.  Note that this is the
-        opposite of the HOME firmware-B override, which forces the pump *off*:
-        on SALT the user may equally have switched the pump on, which is why
-        the pump-off override in `_fill_pump_states` is gated on HOME.
+        On SALT, bit 0x04 marks the unit's settings menu being open — the
+        menu filtration and backwash can be started by hand from.  It
+        appears on entering, before anything is touched, and the unit stops
+        transmitting until the user leaves, so the frame carrying it is the
+        last one for the duration.  It therefore shows up as a brief flip to
+        SERVICE_MENU followed by the device going offline, and says only
+        that somebody is there — not what they did.
+
+        That is why the HOME firmware-B pump-off override in
+        `_fill_pump_states` stays gated on HOME: there Issue #133 documents
+        the bit as a standing override that forces the pump *off*, while on
+        SALT the user may equally have switched it on.
 
         """
         if unit.device_type is None or unit.device_type not in FILTRATION_TYPES:
@@ -705,8 +710,9 @@ class AsekoDecoder:
 
         # The two independent halves of byte[37]: which schedule is configured,
         # and whether the user has taken the pump over by hand.  Folding them
-        # into one value would drop the schedule exactly when manual mode makes
-        # it interesting, so they stay apart all the way to the entities.
+        # into one value would drop the schedule exactly when somebody being
+        # at the unit makes it interesting, so they stay apart all the way to
+        # the entities.
         schedule: AsekoFiltrationSchedule | None = None
         manual = False
         b = data[37]
@@ -778,7 +784,7 @@ class AsekoDecoder:
 
         unit.filtration_schedule = schedule
         unit.filtration_mode = (
-            AsekoFiltrationMode.MANUAL if manual else AsekoFiltrationMode.SCHEDULE
+            AsekoFiltrationMode.SERVICE_MENU if manual else AsekoFiltrationMode.SCHEDULE
         )
 
     @staticmethod
@@ -813,15 +819,15 @@ class AsekoDecoder:
         # Issue #133: on HOME v7 firmware B, byte[29] bit 3 stays set even
         # when the user has manually switched the pump off on the unit
         # (the override state lives in byte[37], not byte[29]). Trust the
-        # explicit MANUAL mode flag instead of the schedule-driven bit.
+        # explicit byte[37] bit 0x04 flag instead of the schedule-driven bit.
         # Gated on HOME so SALT / OXY / NET / PROFI behaviour is unchanged.
         if (
             unit.device_type == AsekoDeviceType.HOME
-            and unit.filtration_mode == AsekoFiltrationMode.MANUAL
+            and unit.filtration_mode == AsekoFiltrationMode.SERVICE_MENU
             and unit.filtration_pump_running is True
         ):
             _LOGGER.debug(
-                "Manual OFF override active (filtration_mode=MANUAL) — "
+                "Manual OFF override active (byte[37] bit 0x04) — "
                 "forcing filtration_pump_running to False (byte[29]=0x%02x)",
                 data[29],
             )
@@ -840,7 +846,7 @@ class AsekoDecoder:
         #    FILTRATION_TYPES device.  The device keeps sending the last
         #    configured start2/stop2 times even when Period 2 is disabled
         #    (Issue #133 — verified on serial 110169464, firmware B: bytes
-        #    60-63 are stable across P1 only / P1&P2 / 24h / MANUAL
+        #    60-63 are stable across P1 only / P1&P2 / 24h / bit 0x04 set
         #    modes).  Reading them unconditionally is therefore safe; the
         #    *_time helpers normalise 0xFF bytes to None and the lazy-
         #    creation guard in sensor.py skips the entity when no value is
@@ -906,7 +912,7 @@ class AsekoDecoder:
         # algicide/flocculant is determined by whether the flowrate byte is set (≠ 0xFF).
         AsekoDecoder._fill_flowrate_data(device, data)
         # Filtration mode must be decoded before consumable data (Issue #133):
-        # the MANUAL state in byte[37] short-circuits
+        # the byte[37] bit 0x04 state short-circuits
         # `filtration_pump_running` in `_fill_consumable_data`.
         AsekoDecoder._fill_filtration_mode(device, data)
         AsekoDecoder._fill_consumable_data(device, data)

--- a/custom_components/aseko_local/aseko_decoder.py
+++ b/custom_components/aseko_local/aseko_decoder.py
@@ -8,7 +8,6 @@ from .aseko_data import (
     AsekoDevice,
     AsekoDeviceType,
     AsekoElectrolyzerDirection,
-    AsekoFiltrationMode,
     AsekoFiltrationSchedule,
     AsekoProbeType,
 )
@@ -650,8 +649,8 @@ class AsekoDecoder:
         unit.alarm_rapid_ph_change = bool(data[13] & 0x08)
 
     @staticmethod
-    def _fill_filtration_mode(unit: AsekoDevice, data: bytes) -> None:
-        """Decode filtration mode into `filtration_mode` (enum).
+    def _fill_filtration_schedule(unit: AsekoDevice, data: bytes) -> None:
+        """Decode byte[37] into `filtration_schedule` and `service_menu_open`.
 
         Runs for every device type in FILTRATION_TYPES = {SALT, HOME, OXY, PROFI}.
         NET is excluded — it has no filtration output (see Issue #66).
@@ -670,13 +669,13 @@ class AsekoDecoder:
             0x01 = nonstop 24h
             0x11 = P1 only
             0x31 = P1 & P2
-            0x15 = P1 + manual override     → SERVICE_MENU (bit 0x04 set)
-            0x35 = P1 & P2 + manual override → SERVICE_MENU (bit 0x04 set)
+            0x15 = P1, settings menu open   → service_menu_open True
+            0x35 = P1 & P2, settings menu open → service_menu_open True
 
-        Bit 0x04 sits on top of a schedule that stays configured underneath
-        it, so the two are decoded into separate fields:
-        `filtration_mode` reports whether anyone is at the unit
-        (SERVICE_MENU wins), `filtration_schedule` what it runs otherwise.
+        Bit 0x04 is not a filtration state at all: it says somebody has the
+        unit's settings menu open.  It is decoded into `service_menu_open`,
+        separately from `filtration_schedule`, which keeps reporting what
+        the unit runs when nobody is at it.
 
         SALT uses the same mode bits as the new encoding above; its high
         nibble carries its own flags (0x80 = algicide routing) and bit 0x40 is
@@ -686,7 +685,7 @@ class AsekoDecoder:
             0xD3 = P1 only
             0xF3 = P1 & P2
             0xD7 / 0xF7 = the above plus the settings menu being open
-                          → SERVICE_MENU (bit 0x04 set)
+                          → service_menu_open True (bit 0x04 set)
 
         Because bit 0x40 is set in every SALT frame, the firmware-A branch is
         taken for HOME only; every other device type reads the bit flags.
@@ -696,8 +695,9 @@ class AsekoDecoder:
         appears on entering, before anything is touched, and the unit stops
         transmitting until the user leaves, so the frame carrying it is the
         last one for the duration.  It therefore shows up as a brief flip to
-        SERVICE_MENU followed by the device going offline, and says only
-        that somebody is there — not what they did.
+        service_menu_open going True, followed by the device going offline.
+        It says only that somebody is there — not what they did, and not
+        what happened to filtration while they were.
 
         That is why the HOME firmware-B pump-off override in
         `_fill_pump_states` stays gated on HOME: there Issue #133 documents
@@ -714,7 +714,7 @@ class AsekoDecoder:
         # at the unit makes it interesting, so they stay apart all the way to
         # the entities.
         schedule: AsekoFiltrationSchedule | None = None
-        manual = False
+        menu: bool | None = None
         b = data[37]
 
         # Firmware A (high nibble 0x4/0x5, serial 110128063, byte 4 = 0x02) uses
@@ -750,7 +750,7 @@ class AsekoDecoder:
                 elif (b & 0x30) == 0x30:
                     schedule = AsekoFiltrationSchedule.TIMER_PERIOD_1_AND_2
 
-                manual = bool(b & AsekoByte37Masks.HOME_FWB_MANUAL_OVERRIDE)
+                menu = bool(b & AsekoByte37Masks.HOME_FWB_MANUAL_OVERRIDE)
 
         # Fallback for unrecognised firmware A values (Issue #135):
         # serial 110175608 (byte 4=0x03 REDOX HOME) has values 0x45/0x49/0x41
@@ -778,14 +778,12 @@ class AsekoDecoder:
             else:
                 schedule = AsekoFiltrationSchedule.TIMER_PERIOD_1
 
-        if schedule is None and not manual:
+        if schedule is None and menu is None:
             # Nothing readable in this frame — say so rather than guess.
             return
 
         unit.filtration_schedule = schedule
-        unit.filtration_mode = (
-            AsekoFiltrationMode.SERVICE_MENU if manual else AsekoFiltrationMode.SCHEDULE
-        )
+        unit.service_menu_open = menu
 
     @staticmethod
     def _fill_consumable_data(unit: AsekoDevice, data: bytes) -> None:
@@ -823,7 +821,7 @@ class AsekoDecoder:
         # Gated on HOME so SALT / OXY / NET / PROFI behaviour is unchanged.
         if (
             unit.device_type == AsekoDeviceType.HOME
-            and unit.filtration_mode == AsekoFiltrationMode.SERVICE_MENU
+            and unit.service_menu_open is True
             and unit.filtration_pump_running is True
         ):
             _LOGGER.debug(
@@ -914,7 +912,7 @@ class AsekoDecoder:
         # Filtration mode must be decoded before consumable data (Issue #133):
         # the byte[37] bit 0x04 state short-circuits
         # `filtration_pump_running` in `_fill_consumable_data`.
-        AsekoDecoder._fill_filtration_mode(device, data)
+        AsekoDecoder._fill_filtration_schedule(device, data)
         AsekoDecoder._fill_consumable_data(device, data)
         AsekoDecoder._fill_home_water_level_data(device, data)
         AsekoDecoder._fill_alarm_data(device, data)

--- a/custom_components/aseko_local/aseko_decoder.py
+++ b/custom_components/aseko_local/aseko_decoder.py
@@ -695,6 +695,9 @@ class AsekoDecoder:
 
         The legacy `filtration_nonstop24` boolean field is kept for
         backwards compatibility and is derived from `filtration_mode` here.
+        It no longer has an entity of its own — `filtration_mode` reports all
+        four modes rather than just whether it is nonstop — but it stays in
+        the decoded device, and so in diagnostics.
         """
         if unit.device_type is None or unit.device_type not in FILTRATION_TYPES:
             return

--- a/custom_components/aseko_local/aseko_decoder.py
+++ b/custom_components/aseko_local/aseko_decoder.py
@@ -672,6 +672,27 @@ class AsekoDecoder:
             0x15 = P1 + manual override     → MANUAL (bit 0x04 set)
             0x35 = P1 & P2 + manual override → MANUAL (bit 0x04 set)
 
+        SALT uses the same mode bits as the new encoding above; its high
+        nibble carries its own flags (0x80 = algicide routing) and bit 0x40 is
+        set in every frame.  Confirmed on an ASIN AQUA Salt, in both directions
+        of every transition:
+            0xC3 = nonstop 24h
+            0xD3 = P1 only
+            0xF3 = P1 & P2
+            0xD7 / 0xF7 = the above plus manual mode → MANUAL (bit 0x04 set)
+
+        Because bit 0x40 is set in every SALT frame, the firmware-A branch is
+        taken for HOME only; every other device type reads the bit flags.
+
+        On SALT, MANUAL is a mode the user enters at the unit to switch
+        filtration by hand, and the unit stops transmitting while it is in it
+        — the frame carrying the mode change is the last one until the user
+        leaves the mode again.  It therefore shows up as a brief flip to
+        MANUAL followed by the device going offline.  Note that this is the
+        opposite of the HOME firmware-B override, which forces the pump *off*:
+        on SALT the user may equally have switched the pump on, which is why
+        the pump-off override in `_fill_pump_states` is gated on HOME.
+
         The legacy `filtration_nonstop24` boolean field is kept for
         backwards compatibility and is derived from `filtration_mode` here.
         """
@@ -689,8 +710,15 @@ class AsekoDecoder:
         #   bit 2 (0x04) = manual override active
         #   bit 4 (0x10) = period 1 enabled
         #   bit 5 (0x20) = period 2 enabled
+        # Firmware A is a HOME encoding, and bit 0x40 only discriminates it
+        # there.  On the other FILTRATION_TYPES that bit is part of an
+        # unrelated configuration value — SALT sets it in every frame — so
+        # routing them by it sent them into a branch of HOME-specific exact
+        # values they can never match.
+        is_home = unit.device_type == AsekoDeviceType.HOME
+
         if b != UNSPECIFIED_VALUE:
-            if b & 0x40:
+            if is_home and b & 0x40:
                 # Firmware A: high nibble 0x4/0x5.
                 if b == 0x43:
                     mode = AsekoFiltrationMode.NONSTOP_24H
@@ -716,10 +744,16 @@ class AsekoDecoder:
         # Transitional edit states (0x47, 0x57) have bit 1 set — keep them
         # as None.  All other unrecognised firmware A values fall back to
         # schedule-derived mode.
+        #
+        # HOME-only, like the branch it backs up.  It derives the mode from
+        # the filtration schedule bytes, and those are reported unchanged in
+        # every mode on SALT — identical across nonstop, P1, P1&P2 and manual
+        # — so for a SALT it could only ever return one constant answer.
         if (
             mode is None
+            and is_home
             and b & 0x40
-            and not (b & AsekoByte37Masks.HOME_FWA_TRANSITIONAL_MASK)
+            and not b & AsekoByte37Masks.HOME_FWA_TRANSITIONAL_MASK
         ):
             p1_set = data[56] != UNSPECIFIED_VALUE and data[57] != UNSPECIFIED_VALUE
             p2_set = data[60] != UNSPECIFIED_VALUE and data[61] != UNSPECIFIED_VALUE

--- a/custom_components/aseko_local/aseko_decoder.py
+++ b/custom_components/aseko_local/aseko_decoder.py
@@ -9,6 +9,7 @@ from .aseko_data import (
     AsekoDeviceType,
     AsekoElectrolyzerDirection,
     AsekoFiltrationMode,
+    AsekoFiltrationSchedule,
     AsekoProbeType,
 )
 from .aseko_v7_helpers import (
@@ -672,6 +673,11 @@ class AsekoDecoder:
             0x15 = P1 + manual override     → MANUAL (bit 0x04 set)
             0x35 = P1 & P2 + manual override → MANUAL (bit 0x04 set)
 
+        Bit 0x04 is an override laid on top of a schedule that stays
+        configured underneath it, so the two are decoded into separate
+        fields: `filtration_mode` reports what is in charge right now
+        (MANUAL wins), `filtration_schedule` what the unit will go back to.
+
         SALT uses the same mode bits as the new encoding above; its high
         nibble carries its own flags (0x80 = algicide routing) and bit 0x40 is
         set in every frame.  Confirmed on an ASIN AQUA Salt, in both directions
@@ -693,67 +699,66 @@ class AsekoDecoder:
         on SALT the user may equally have switched the pump on, which is why
         the pump-off override in `_fill_pump_states` is gated on HOME.
 
-        The legacy `filtration_nonstop24` boolean field is kept for
-        backwards compatibility and is derived from `filtration_mode` here.
-        It no longer has an entity of its own — `filtration_mode` reports all
-        four modes rather than just whether it is nonstop — but it stays in
-        the decoded device, and so in diagnostics.
         """
         if unit.device_type is None or unit.device_type not in FILTRATION_TYPES:
             return
 
-        mode: AsekoFiltrationMode | None = None
+        # The two independent halves of byte[37]: which schedule is configured,
+        # and whether the user has taken the pump over by hand.  Folding them
+        # into one value would drop the schedule exactly when manual mode makes
+        # it interesting, so they stay apart all the way to the entities.
+        schedule: AsekoFiltrationSchedule | None = None
+        manual = False
         b = data[37]
 
-        # byte[37] carries the mode flag for every FILTRATION_TYPES device
-        # (SALT, HOME, OXY, PROFI).  Firmware A (high nibble 0x4/0x5,
-        # serial 110128063, byte 4 = 0x02) uses exact byte values.
-        # Firmware B (high nibble 0x0/0x1/0x3, serial 110169464, byte 4 = 0x03)
-        # uses bit flags:
+        # Firmware A (high nibble 0x4/0x5, serial 110128063, byte 4 = 0x02) uses
+        # exact byte values and encodes no manual state.  Firmware B (high nibble
+        # 0x0/0x1/0x3, serial 110169464, byte 4 = 0x03) uses bit flags:
         #   bit 2 (0x04) = manual override active
         #   bit 4 (0x10) = period 1 enabled
         #   bit 5 (0x20) = period 2 enabled
+        #
         # Firmware A is a HOME encoding, and bit 0x40 only discriminates it
-        # there.  On the other FILTRATION_TYPES that bit is part of an
-        # unrelated configuration value — SALT sets it in every frame — so
-        # routing them by it sent them into a branch of HOME-specific exact
-        # values they can never match.
+        # there.  On the other FILTRATION_TYPES that bit is part of an unrelated
+        # configuration value — SALT sets it in every frame — so routing them by
+        # it sent them into a branch of HOME-specific exact values they can
+        # never match.
         is_home = unit.device_type == AsekoDeviceType.HOME
 
         if b != UNSPECIFIED_VALUE:
             if is_home and b & 0x40:
                 # Firmware A: high nibble 0x4/0x5.
                 if b == 0x43:
-                    mode = AsekoFiltrationMode.NONSTOP_24H
+                    schedule = AsekoFiltrationSchedule.NONSTOP_24H
                 elif b == 0x53:
-                    mode = AsekoFiltrationMode.TIMER_PERIOD_1_AND_2
+                    schedule = AsekoFiltrationSchedule.TIMER_PERIOD_1_AND_2
                 # 0x47 / 0x57 → transitional edit state, leave as None.
             else:
-                # Firmware B: high nibble 0x0/0x1/0x3.
-                if b & 0x04:
-                    # Manual override active — bit 2 set.
-                    # Observed values: 0x15 (P1 + override),
-                    # 0x35 (P1&P2 + override).
-                    mode = AsekoFiltrationMode.MANUAL
-                elif (b & 0x30) == 0x00:
-                    mode = AsekoFiltrationMode.NONSTOP_24H
+                # Firmware B.  0x20 without 0x10 has never been seen — period 2
+                # is only offered on top of period 1 — and leaves the schedule
+                # unset rather than guessed.
+                if (b & 0x30) == 0x00:
+                    schedule = AsekoFiltrationSchedule.NONSTOP_24H
                 elif (b & 0x30) == 0x10:
-                    mode = AsekoFiltrationMode.TIMER_PERIOD_1
+                    schedule = AsekoFiltrationSchedule.TIMER_PERIOD_1
                 elif (b & 0x30) == 0x30:
-                    mode = AsekoFiltrationMode.TIMER_PERIOD_1_AND_2
+                    schedule = AsekoFiltrationSchedule.TIMER_PERIOD_1_AND_2
+
+                manual = bool(b & AsekoByte37Masks.HOME_FWB_MANUAL_OVERRIDE)
+
         # Fallback for unrecognised firmware A values (Issue #135):
         # serial 110175608 (byte 4=0x03 REDOX HOME) has values 0x45/0x49/0x41
         # that don't match the known CLF HOME patterns (0x43/0x53/0x47/0x57).
-        # Transitional edit states (0x47, 0x57) have bit 1 set — keep them
-        # as None.  All other unrecognised firmware A values fall back to
-        # schedule-derived mode.
+        # Transitional edit states (0x47, 0x57) have bit 1 set — keep them as
+        # None.  All other unrecognised firmware A values fall back to the
+        # schedule bytes.
         #
-        # HOME-only, like the branch it backs up.  It derives the mode from
-        # the filtration schedule bytes, and those are reported unchanged in
-        # every mode on SALT — identical across nonstop, P1, P1&P2 and manual
-        # — so for a SALT it could only ever return one constant answer.
+        # HOME-only, like the branch it backs up.  It reads the filtration
+        # times, and those are reported unchanged in every mode on SALT —
+        # identical across nonstop, P1, P1&P2 and manual — so for a SALT it
+        # could only ever return one constant answer.
         if (
-            mode is None
+            schedule is None
             and is_home
             and b & 0x40
             and not b & AsekoByte37Masks.HOME_FWA_TRANSITIONAL_MASK
@@ -761,18 +766,20 @@ class AsekoDecoder:
             p1_set = data[56] != UNSPECIFIED_VALUE and data[57] != UNSPECIFIED_VALUE
             p2_set = data[60] != UNSPECIFIED_VALUE and data[61] != UNSPECIFIED_VALUE
             if not p1_set:
-                mode = AsekoFiltrationMode.NONSTOP_24H
+                schedule = AsekoFiltrationSchedule.NONSTOP_24H
             elif p2_set or bool(b & FILTRATION_PERIOD2_ENABLED_MASK):
-                mode = AsekoFiltrationMode.TIMER_PERIOD_1_AND_2
+                schedule = AsekoFiltrationSchedule.TIMER_PERIOD_1_AND_2
             else:
-                mode = AsekoFiltrationMode.TIMER_PERIOD_1
+                schedule = AsekoFiltrationSchedule.TIMER_PERIOD_1
 
-        if mode is None:
+        if schedule is None and not manual:
+            # Nothing readable in this frame — say so rather than guess.
             return
 
-        unit.filtration_mode = mode
-        # Mirror onto the legacy boolean for backwards compatibility.
-        unit.filtration_nonstop24 = mode == AsekoFiltrationMode.NONSTOP_24H
+        unit.filtration_schedule = schedule
+        unit.filtration_mode = (
+            AsekoFiltrationMode.MANUAL if manual else AsekoFiltrationMode.SCHEDULE
+        )
 
     @staticmethod
     def _fill_consumable_data(unit: AsekoDevice, data: bytes) -> None:

--- a/custom_components/aseko_local/binary_sensor.py
+++ b/custom_components/aseko_local/binary_sensor.py
@@ -114,6 +114,15 @@ BINARY_SENSORS: tuple[AsekoLocalBinarySensorEntityDescription, ...] = (
         value_fn=lambda device: device.water_filling_active,
     ),
     AsekoLocalBinarySensorEntityDescription(
+        # byte[37] bit 0x04.  A device state, not a filtration one: while it
+        # is on the unit sends nothing, so what is being done in there — to
+        # filtration or anything else — cannot be seen from here.
+        key="service_menu",
+        translation_key="service_menu",
+        icon="mdi:tune",
+        value_fn=lambda device: device.service_menu_open,
+    ),
+    AsekoLocalBinarySensorEntityDescription(
         key="alarm_ph_too_many_doses",
         translation_key="alarm_ph_too_many_doses",
         icon="mdi:alert",
@@ -153,8 +162,8 @@ BINARY_SENSORS: tuple[AsekoLocalBinarySensorEntityDescription, ...] = (
 # them at setup instead.  Suffixes, because the serial prefix varies.
 RETIRED_UNIQUE_ID_SUFFIXES: frozenset[str] = frozenset(
     {
-        # Superseded by sensor.filtration_mode, which reports all four
-        # modes instead of just "nonstop or not" (Issue #133).
+        # Superseded by sensor.filtration_schedule, which names the schedule
+        # instead of answering only "nonstop or not" (Issue #133).
         "filtration_nonstop24",
     }
 )

--- a/custom_components/aseko_local/binary_sensor.py
+++ b/custom_components/aseko_local/binary_sensor.py
@@ -9,6 +9,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntityDescription,
 )
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import AsekoLocalConfigEntry
@@ -113,12 +114,6 @@ BINARY_SENSORS: tuple[AsekoLocalBinarySensorEntityDescription, ...] = (
         value_fn=lambda device: device.water_filling_active,
     ),
     AsekoLocalBinarySensorEntityDescription(
-        key="filtration_nonstop24",
-        translation_key="filtration_nonstop24",
-        icon="mdi:clock-check",
-        value_fn=lambda device: device.filtration_nonstop24,
-    ),
-    AsekoLocalBinarySensorEntityDescription(
         key="alarm_ph_too_many_doses",
         translation_key="alarm_ph_too_many_doses",
         icon="mdi:alert",
@@ -151,12 +146,57 @@ BINARY_SENSORS: tuple[AsekoLocalBinarySensorEntityDescription, ...] = (
 )
 
 
+# Binary sensor keys that no longer exist.  The unique_id is
+# f"{serial_number}{key}", so a removed key leaves its registry entry
+# behind: the entity would sit in the UI as unavailable forever, with no
+# hint that it is not coming back.  async_remove_retired_entities deletes
+# them at setup instead.  Suffixes, because the serial prefix varies.
+RETIRED_UNIQUE_ID_SUFFIXES: frozenset[str] = frozenset(
+    {
+        # Superseded by sensor.filtration_mode, which reports all four
+        # modes instead of just "nonstop or not" (Issue #133).
+        "filtration_nonstop24",
+    }
+)
+
+
+@callback
+def async_remove_retired_entities(
+    hass: HomeAssistant, config_entry: AsekoLocalConfigEntry
+) -> None:
+    """Delete registry entries for binary sensors that no longer exist.
+
+    Runs before the entities are added, so the retired one never gets a
+    chance to be restored as unavailable.
+
+    Nothing happens when there is no matching entry, so this is a no-op on
+    fresh installs and on every setup after the first.
+    """
+    registry = er.async_get(hass)
+
+    for entry in er.async_entries_for_config_entry(registry, config_entry.entry_id):
+        if entry.domain != "binary_sensor":
+            continue
+        if not any(
+            entry.unique_id.endswith(suffix) for suffix in RETIRED_UNIQUE_ID_SUFFIXES
+        ):
+            continue
+        _LOGGER.info(
+            "Removing retired Aseko binary sensor %s (unique_id %s)",
+            entry.entity_id,
+            entry.unique_id,
+        )
+        registry.async_remove(entry.entity_id)
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: AsekoLocalConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Aseko device binary sensors."""
+
+    async_remove_retired_entities(hass, config_entry)
 
     coordinator = config_entry.runtime_data.coordinator
     devices = coordinator.get_devices()

--- a/custom_components/aseko_local/manifest.json
+++ b/custom_components/aseko_local/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/hopkins-tk/home-assistant-aseko-local/issues",
   "requirements": [],
-  "version": "v1.7.4"
+  "version": "v1.8.0"
 }

--- a/custom_components/aseko_local/sensor.py
+++ b/custom_components/aseko_local/sensor.py
@@ -21,6 +21,7 @@ from homeassistant.const import (
     UnitOfVolume,
 )
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
@@ -187,6 +188,18 @@ CONSUMPTION_SENSORS: list[AsekoConsumptionSensorEntityDescription] = [
 ]
 
 # ---------- Fixed (system-level) sensors ----------
+
+# Sensor keys that no longer exist.  The registry entry outlives the
+# description, so without this the old entity sits in the UI as unavailable
+# forever.  Suffixes, because the unique_id is prefixed with the serial.
+RETIRED_UNIQUE_ID_SUFFIXES: frozenset[str] = frozenset(
+    {
+        # byte[37] bit 0x04 is not a filtration state — it marks the unit's
+        # settings menu being open, and is now binary_sensor.service_menu.
+        # What is left of the old sensor is filtration_schedule.
+        "filtration_mode",
+    }
+)
 
 SENSORS: list[AsekoSensorEntityDescription] = [
     AsekoSensorEntityDescription(
@@ -517,29 +530,12 @@ SENSORS: list[AsekoSensorEntityDescription] = [
         ),
     ),
     AsekoSensorEntityDescription(
-        key="filtration_mode",
-        translation_key="filtration_mode",
-        icon="mdi:pump",
-        device_class=SensorDeviceClass.ENUM,
-        # Whether the unit is running its schedule or somebody has the
-        # settings menu open — not which schedule, that is
-        # filtration_schedule, and it stays readable either way.
-        options=[
-            "schedule",
-            "service_menu",
-        ],
-        value_fn=lambda device: (
-            device.filtration_mode.value if device.filtration_mode is not None else None
-        ),
-    ),
-    AsekoSensorEntityDescription(
         key="filtration_schedule",
         translation_key="filtration_schedule",
         icon="mdi:calendar-clock",
         device_class=SensorDeviceClass.ENUM,
-        # No "manual": that is a mode, not a schedule.  Keeps reporting
-        # what the unit is configured for while the override is on, which
-        # is the one time filtration_mode cannot say.
+        # What the unit runs when nobody is at it.  byte[37] bit 0x04 is a
+        # separate fact and lives on binary_sensor.service_menu.
         options=[
             "nonstop_24h",
             "timer_period_1",
@@ -634,12 +630,41 @@ CONNECTION_STATUS_SENSOR = AsekoSensorEntityDescription(
 # ---------- Setup ----------
 
 
+@callback
+def async_remove_retired_entities(
+    hass: HomeAssistant, config_entry: AsekoLocalConfigEntry
+) -> None:
+    """Delete registry entries for sensors that no longer exist.
+
+    Runs before the entities are added, so a retired one never gets a
+    chance to come back as unavailable.  A no-op once there is nothing
+    left to remove.
+    """
+    registry = er.async_get(hass)
+
+    for entry in er.async_entries_for_config_entry(registry, config_entry.entry_id):
+        if entry.domain != "sensor":
+            continue
+        if not any(
+            entry.unique_id.endswith(suffix) for suffix in RETIRED_UNIQUE_ID_SUFFIXES
+        ):
+            continue
+        _LOGGER.info(
+            "Removing retired Aseko sensor %s (unique_id %s)",
+            entry.entity_id,
+            entry.unique_id,
+        )
+        registry.async_remove(entry.entity_id)
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: AsekoLocalConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the Aseko device sensors."""
+
+    async_remove_retired_entities(hass, config_entry)
 
     coordinator = config_entry.runtime_data.coordinator
     devices = coordinator.get_devices() or []

--- a/custom_components/aseko_local/sensor.py
+++ b/custom_components/aseko_local/sensor.py
@@ -521,14 +521,33 @@ SENSORS: list[AsekoSensorEntityDescription] = [
         translation_key="filtration_mode",
         icon="mdi:pump",
         device_class=SensorDeviceClass.ENUM,
+        # Whether the schedule is in charge, not which schedule it is —
+        # that is filtration_schedule, and it stays readable either way.
         options=[
-            "nonstop_24h",
-            "timer_period_1",
-            "timer_period_1_and_2",
+            "schedule",
             "manual",
         ],
         value_fn=lambda device: (
             device.filtration_mode.value if device.filtration_mode is not None else None
+        ),
+    ),
+    AsekoSensorEntityDescription(
+        key="filtration_schedule",
+        translation_key="filtration_schedule",
+        icon="mdi:calendar-clock",
+        device_class=SensorDeviceClass.ENUM,
+        # No "manual": that is a mode, not a schedule.  Keeps reporting
+        # what the unit is configured for while the override is on, which
+        # is the one time filtration_mode cannot say.
+        options=[
+            "nonstop_24h",
+            "timer_period_1",
+            "timer_period_1_and_2",
+        ],
+        value_fn=lambda device: (
+            device.filtration_schedule.value
+            if device.filtration_schedule is not None
+            else None
         ),
     ),
     AsekoSensorEntityDescription(

--- a/custom_components/aseko_local/sensor.py
+++ b/custom_components/aseko_local/sensor.py
@@ -521,11 +521,12 @@ SENSORS: list[AsekoSensorEntityDescription] = [
         translation_key="filtration_mode",
         icon="mdi:pump",
         device_class=SensorDeviceClass.ENUM,
-        # Whether the schedule is in charge, not which schedule it is —
-        # that is filtration_schedule, and it stays readable either way.
+        # Whether the unit is running its schedule or somebody has the
+        # settings menu open — not which schedule, that is
+        # filtration_schedule, and it stays readable either way.
         options=[
             "schedule",
-            "manual",
+            "service_menu",
         ],
         value_fn=lambda device: (
             device.filtration_mode.value if device.filtration_mode is not None else None

--- a/custom_components/aseko_local/translations/cs.json
+++ b/custom_components/aseko_local/translations/cs.json
@@ -78,9 +78,6 @@
       "water_filling_active": {
         "name": "Plnění vody aktivní"
       },
-      "filtration_nonstop24": {
-        "name": "Filtrace nonstop 24h"
-      },
       "alarm_ph_too_many_doses": {
         "name": "Příliš mnoho dávek pH"
       },

--- a/custom_components/aseko_local/translations/cs.json
+++ b/custom_components/aseko_local/translations/cs.json
@@ -103,7 +103,7 @@
         "name": "Režim filtrace",
         "state": {
           "schedule": "Podle rozvrhu",
-          "manual": "Ruční ovládání"
+          "service_menu": "Otevřené menu přístroje"
         }
       },
       "pool_volume": { "name": "Objem bazénu" },

--- a/custom_components/aseko_local/translations/cs.json
+++ b/custom_components/aseko_local/translations/cs.json
@@ -102,10 +102,8 @@
       "filtration_mode": {
         "name": "Režim filtrace",
         "state": {
-          "nonstop_24h": "Nonstop 24 h",
-          "timer_period_1": "Časové období 1",
-          "timer_period_1_and_2": "Časová období 1 a 2",
-          "manual": "Ruční režim"
+          "schedule": "Podle rozvrhu",
+          "manual": "Ruční ovládání"
         }
       },
       "pool_volume": { "name": "Objem bazénu" },
@@ -281,6 +279,14 @@
       },
       "oxy_total_consumed": {
         "name": "Spotřeba OXY Pure (celkem)"
+      },
+      "filtration_schedule": {
+        "name": "Rozvrh filtrace",
+        "state": {
+          "nonstop_24h": "Nonstop 24 h",
+          "timer_period_1": "Časové období 1",
+          "timer_period_1_and_2": "Časová období 1 a 2"
+        }
       }
     },
     "number": {

--- a/custom_components/aseko_local/translations/cs.json
+++ b/custom_components/aseko_local/translations/cs.json
@@ -92,6 +92,9 @@
       },
       "backwash_active": {
         "name": "Zpětné proplachování aktivní"
+      },
+      "service_menu": {
+        "name": "Servisní menu"
       }
     },
     "sensor": {
@@ -99,13 +102,6 @@
       "filtration_1_stop": { "name": "Filtrace 1 konec" },
       "filtration_2_start": { "name": "Filtrace 2 začátek" },
       "filtration_2_stop": { "name": "Filtrace 2 konec" },
-      "filtration_mode": {
-        "name": "Režim filtrace",
-        "state": {
-          "schedule": "Podle rozvrhu",
-          "service_menu": "Otevřené menu přístroje"
-        }
-      },
       "pool_volume": { "name": "Objem bazénu" },
       "delay_after_startup": { "name": "Prodleva po startu" },
       "delay_after_dose": { "name": "Prodleva po dávce" },

--- a/custom_components/aseko_local/translations/de.json
+++ b/custom_components/aseko_local/translations/de.json
@@ -111,7 +111,7 @@
         "name": "Filtriermodus",
         "state": {
           "schedule": "Nach Plan",
-          "manual": "Handbetrieb"
+          "service_menu": "Menü am Gerät offen"
         }
       },
       "pool_volume": {

--- a/custom_components/aseko_local/translations/de.json
+++ b/custom_components/aseko_local/translations/de.json
@@ -78,9 +78,6 @@
       "water_filling_active": {
         "name": "Wasserauffüllung aktiv"
       },
-      "filtration_nonstop24": {
-        "name": "Filtration Nonstop 24h"
-      },
       "alarm_ph_too_many_doses": {
         "name": "pH-Alarm: zu viele Dosierungen"
       },

--- a/custom_components/aseko_local/translations/de.json
+++ b/custom_components/aseko_local/translations/de.json
@@ -110,10 +110,8 @@
       "filtration_mode": {
         "name": "Filtriermodus",
         "state": {
-          "nonstop_24h": "24 h durchgehend",
-          "timer_period_1": "Zeitperiode 1",
-          "timer_period_1_and_2": "Zeitperioden 1 & 2",
-          "manual": "Manueller Betriebsmodus"
+          "schedule": "Nach Plan",
+          "manual": "Handbetrieb"
         }
       },
       "pool_volume": {
@@ -295,6 +293,14 @@
       },
       "oxy_total_consumed": {
         "name": "OXY Pure verbraucht (gesamt)"
+      },
+      "filtration_schedule": {
+        "name": "Filtrationsplan",
+        "state": {
+          "nonstop_24h": "24 h durchgehend",
+          "timer_period_1": "Zeitperiode 1",
+          "timer_period_1_and_2": "Zeitperioden 1 & 2"
+        }
       }
     },
     "number": {

--- a/custom_components/aseko_local/translations/de.json
+++ b/custom_components/aseko_local/translations/de.json
@@ -92,6 +92,9 @@
       },
       "backwash_active": {
         "name": "Rückspülung aktiv"
+      },
+      "service_menu": {
+        "name": "Servicemenü"
       }
     },
     "sensor": {
@@ -106,13 +109,6 @@
       },
       "filtration_2_stop": {
         "name": "Filtration 2 Stopp"
-      },
-      "filtration_mode": {
-        "name": "Filtriermodus",
-        "state": {
-          "schedule": "Nach Plan",
-          "service_menu": "Menü am Gerät offen"
-        }
       },
       "pool_volume": {
         "name": "Poolvolumen"

--- a/custom_components/aseko_local/translations/en.json
+++ b/custom_components/aseko_local/translations/en.json
@@ -103,7 +103,7 @@
         "name": "Filtration mode",
         "state": {
           "schedule": "Following schedule",
-          "manual": "Manual operation"
+          "service_menu": "Settings menu open"
         }
       },
       "pool_volume": { "name": "Pool volume" },

--- a/custom_components/aseko_local/translations/en.json
+++ b/custom_components/aseko_local/translations/en.json
@@ -102,10 +102,8 @@
       "filtration_mode": {
         "name": "Filtration mode",
         "state": {
-          "nonstop_24h": "24h nonstop",
-          "timer_period_1": "Time period 1",
-          "timer_period_1_and_2": "Time periods 1 & 2",
-          "manual": "Manual operation mode"
+          "schedule": "Following schedule",
+          "manual": "Manual operation"
         }
       },
       "pool_volume": { "name": "Pool volume" },
@@ -281,6 +279,14 @@
       },
       "oxy_total_consumed": {
         "name": "OXY Pure consumed (total)"
+      },
+      "filtration_schedule": {
+        "name": "Filtration schedule",
+        "state": {
+          "nonstop_24h": "24h nonstop",
+          "timer_period_1": "Time period 1",
+          "timer_period_1_and_2": "Time periods 1 & 2"
+        }
       }
     },
     "number": {

--- a/custom_components/aseko_local/translations/en.json
+++ b/custom_components/aseko_local/translations/en.json
@@ -78,9 +78,6 @@
       "water_filling_active": {
         "name": "Water filling active"
       },
-      "filtration_nonstop24": {
-        "name": "Filtration nonstop 24h"
-      },
       "alarm_ph_too_many_doses": {
         "name": "Too many doses of pH"
       },

--- a/custom_components/aseko_local/translations/en.json
+++ b/custom_components/aseko_local/translations/en.json
@@ -92,6 +92,9 @@
       },
       "backwash_active": {
         "name": "Backwash active"
+      },
+      "service_menu": {
+        "name": "Service menu"
       }
     },
     "sensor": {
@@ -99,13 +102,6 @@
       "filtration_1_stop": { "name": "Filtration 1 stop" },
       "filtration_2_start": { "name": "Filtration 2 start" },
       "filtration_2_stop": { "name": "Filtration 2 stop" },
-      "filtration_mode": {
-        "name": "Filtration mode",
-        "state": {
-          "schedule": "Following schedule",
-          "service_menu": "Settings menu open"
-        }
-      },
       "pool_volume": { "name": "Pool volume" },
       "delay_after_startup": { "name": "Delay after startup" },
       "delay_after_dose": { "name": "Delay after dose" },

--- a/custom_components/aseko_local/translations/fr.json
+++ b/custom_components/aseko_local/translations/fr.json
@@ -110,10 +110,8 @@
             "filtration_mode": {
                 "name": "Mode de filtration",
                 "state": {
-                  "nonstop_24h": "24 h en continu",
-                  "timer_period_1": "Plage horaire 1",
-                  "timer_period_1_and_2": "Plages horaires 1 et 2",
-                  "manual": "Mode manuel"
+                    "schedule": "Selon le programme",
+                    "manual": "Commande manuelle"
                 }
             },
             "pool_volume": {
@@ -295,6 +293,14 @@
             },
             "oxy_total_consumed": {
                 "name": "OXY Pure consommé (total)"
+            },
+            "filtration_schedule": {
+                "name": "Programme de filtration",
+                "state": {
+                    "nonstop_24h": "24 h en continu",
+                    "timer_period_1": "Plage horaire 1",
+                    "timer_period_1_and_2": "Plages horaires 1 et 2"
+                }
             }
         },
         "number": {

--- a/custom_components/aseko_local/translations/fr.json
+++ b/custom_components/aseko_local/translations/fr.json
@@ -111,7 +111,7 @@
                 "name": "Mode de filtration",
                 "state": {
                     "schedule": "Selon le programme",
-                    "manual": "Commande manuelle"
+                    "service_menu": "Menu de l'appareil ouvert"
                 }
             },
             "pool_volume": {

--- a/custom_components/aseko_local/translations/fr.json
+++ b/custom_components/aseko_local/translations/fr.json
@@ -78,9 +78,6 @@
             "water_filling_active": {
                 "name": "Remplissage d'eau actif"
             },
-            "filtration_nonstop24": {
-                "name": "Filtration nonstop 24h"
-            },
             "alarm_ph_too_many_doses": {
                 "name": "Alarme pH : trop de doses"
             },

--- a/custom_components/aseko_local/translations/fr.json
+++ b/custom_components/aseko_local/translations/fr.json
@@ -92,6 +92,9 @@
             },
             "backwash_active": {
                 "name": "Contre-lavage actif"
+            },
+            "service_menu": {
+                "name": "Menu de service"
             }
         },
         "sensor": {
@@ -106,13 +109,6 @@
             },
             "filtration_2_stop": {
                 "name": "Fin filtration 2"
-            },
-            "filtration_mode": {
-                "name": "Mode de filtration",
-                "state": {
-                    "schedule": "Selon le programme",
-                    "service_menu": "Menu de l'appareil ouvert"
-                }
             },
             "pool_volume": {
                 "name": "Volume du bassin"

--- a/docs/device analyzes/home_device_analysis.md
+++ b/docs/device analyzes/home_device_analysis.md
@@ -20,7 +20,7 @@ position. The two revisions are referred to throughout this document as
 | Serial (known) | 110128063 (`0x06906bbf`) | 110169464 (`0x06912578`) |
 | | 110175608* (`0x06912578`, REDOX) | |
 | `byte[37]` mode values | high nibble `0x4` / `0x5` | high nibble `0x0` / `0x1` / `0x3` |
-| Known states | nonstop 24h, timer, transitional, | nonstop 24h, P1, P1&P2, each ± manual override, transitional |
+| Known states | nonstop 24h, timer, transitional, | nonstop 24h, P1, P1&P2, each ± bit 0x04, transitional |
 | | heating ON, heating OFF, unconfigured | |
 | Source | This file (Issue #110, #135) | [Issue #133](../temp/Issue-133.md) |
 | Period 2 enable flag | bit 5 (`0x20`) — same as firmware B | bit 5 (`0x20`) |
@@ -207,7 +207,7 @@ share the `alarm_orp_too_many_doses` sensor.
 | Water flow to probes      | False            | NO                | ✓     |
 | Filtration pump running   | False            | STOP              | ✓     |
 | filtration_schedule       | NONSTOP_24H      | NONSTOP 24H       | ✓ (Issue #110) |
-| filtration_mode           | SCHEDULE         | (not in manual)   | ✓ |
+| filtration_mode           | SCHEDULE         | (nobody at the unit) | ✓ |
 | water_level               | 8 cm             | --- (level meter disabled) | ✓ (frame value) |
 | water_level_low_alarm     | 13 cm            | (config)          | ✓ (Issue #110) |
 | water_level_filling_on    | 33 cm            | (config)          | ✓ (Issue #110) |
@@ -368,13 +368,19 @@ discussion](https://github.com/hopkins-tk/home-assistant-aseko-local/issues/110)
 bit 3 (`filtration_pump_running`) is still set in the frame — the firmware does
 not clear the schedule-driven bit on manual override. The decoder compensates
 by short-circuiting `filtration_pump_running` to `False` whenever
-`filtration_mode == MANUAL`.
+`filtration_mode == SERVICE_MENU`.
 
 This override stays **HOME-only**, and SALT captures are now the reason why
-rather than just a lack of evidence: on SALT the same bit means the user is
-at the panel driving the pump, which they may equally have switched *on*.
-Forcing the pump off there would invent a state the unit never reported.
-See `salt_device_analysis.md` §byte[37] – filtration mode and schedule.
+rather than just a lack of evidence: there the same bit marks the settings
+menu being open, which says a person is at the unit and nothing about what
+they did — they may equally have switched the pump *on*.  Forcing it off
+would invent a state the unit never reported.  See
+`salt_device_analysis.md` §byte[37] – filtration mode and schedule.
+
+Whether HOME's bit is literally the same menu flag is **unverified**: the
+four Issue #133 frames were downloaded one per mode, so a HOME unit going
+quiet the way SALT does would not have shown up in them.  If it does, the
+override here is reading a menu session rather than a standing override.
 
 **Note on Period 2 schedule bytes (Issue #133)**: All Aseko devices in
 `FILTRATION_TYPES` (SALT, HOME, OXY, PROFI) keep sending the last-configured
@@ -437,9 +443,9 @@ frames — including the OFF frame. The override state lives in `byte[37]` bit 2
 this HOME-only behaviour in `_fill_consumable_data` (see `_fill_filtration_mode`
 in `aseko_decoder.py`).
 
-Bit 2 is decoded into `filtration_mode` (`SCHEDULE` / `MANUAL`) and the
+Bit 2 is decoded into `filtration_mode` (`SCHEDULE` / `SERVICE_MENU`) and the
 schedule bits into `filtration_schedule`, so the schedule stays readable while
-the override is on — the two are independent and one value cannot carry both.
+the bit is set — the two are independent and one value cannot carry both.
 
 ### `byte[22]` — Variable-speed filtration pump (Issue #137)
 
@@ -497,13 +503,13 @@ Tests for the HOME decoder live in `tests/test_aseko_decoder.py`:
 | `test_filtration_mode_new_encoding_24h` | Issue #133 firmware B: `byte[37]=0x01` → schedule `NONSTOP_24H` |
 | `test_filtration_mode_new_encoding_p1` | Issue #133 firmware B: `byte[37]=0x11` → schedule `TIMER_PERIOD_1` |
 | `test_filtration_mode_new_encoding_p1_and_p2` | Issue #133 firmware B: `byte[37]=0x31` → schedule `TIMER_PERIOD_1_AND_2` |
-| `test_filtration_mode_new_encoding_manual_p1_and_p2` | Issue #133 firmware B: `byte[37]=0x35` → mode `MANUAL` |
+| `test_filtration_mode_new_encoding_manual_p1_and_p2` | Issue #133 firmware B: `byte[37]=0x35` → mode `SERVICE_MENU` |
 | `test_filtration_mode_old_encoding_24h` | Issue #110 firmware A: `byte[37]=0x43` → schedule `NONSTOP_24H` |
 | `test_filtration_mode_old_encoding_timer` | Issue #110 firmware A: `byte[37]=0x53` → schedule `TIMER_PERIOD_1_AND_2` |
 | `test_filtration_mode_salt_uses_the_firmware_b_bits` | SALT: all six captured `byte[37]` values → mode + schedule |
-| `test_filtration_schedule_survives_manual_mode` | `0xC3` → `0xC7` → `0xC3`: the schedule reads the same throughout |
+| `test_filtration_schedule_survives_the_service_menu` | `0xC3` → `0xC7` → `0xC3`: the schedule reads the same throughout |
 | `test_filtration_pump_running_off_when_manual_override` | Issue #133: `byte[37]=0x35` forces `filtration_pump_running=False` |
-| `test_filtration_pump_running_on_when_not_override` | Regression guard: `byte[29]&0x08` still drives the entity outside MANUAL |
+| `test_filtration_pump_running_on_when_not_override` | Regression guard: `byte[29]&0x08` still drives the entity while bit 0x04 is clear |
 | `test_filtration_pump_running_not_overridden_on_salt` | Override short-circuit is HOME-only |
 | `test_decode_filtration_period2_disabled` | Issue #133: bytes 60-63 stay populated; mode flips to `TIMER_PERIOD_1` |
 | `test_decode_filtration_period2_bytes_unspecified` | Issue #133: bytes 60-63 = 0xFF → `start2`/`stop2` = `None` (entity skipped) |

--- a/docs/device analyzes/home_device_analysis.md
+++ b/docs/device analyzes/home_device_analysis.md
@@ -20,7 +20,7 @@ position. The two revisions are referred to throughout this document as
 | Serial (known) | 110128063 (`0x06906bbf`) | 110169464 (`0x06912578`) |
 | | 110175608* (`0x06912578`, REDOX) | |
 | `byte[37]` mode values | high nibble `0x4` / `0x5` | high nibble `0x0` / `0x1` / `0x3` |
-| Known states | nonstop 24h, timer, transitional, | nonstop 24h, P1, P1&P2, OFF manual, transitional |
+| Known states | nonstop 24h, timer, transitional, | nonstop 24h, P1, P1&P2, each ± manual override, transitional |
 | | heating ON, heating OFF, unconfigured | |
 | Source | This file (Issue #110, #135) | [Issue #133](../temp/Issue-133.md) |
 | Period 2 enable flag | bit 5 (`0x20`) — same as firmware B | bit 5 (`0x20`) |
@@ -206,7 +206,8 @@ share the `alarm_orp_too_many_doses` sensor.
 | Water temperature         | 37.9°C           | 38.2°C            | ✓ (Δt)|
 | Water flow to probes      | False            | NO                | ✓     |
 | Filtration pump running   | False            | STOP              | ✓     |
-| filtration_nonstop24      | True             | NONSTOP 24H       | ✓ (Issue #110) |
+| filtration_schedule       | NONSTOP_24H      | NONSTOP 24H       | ✓ (Issue #110) |
+| filtration_mode           | SCHEDULE         | (not in manual)   | ✓ |
 | water_level               | 8 cm             | --- (level meter disabled) | ✓ (frame value) |
 | water_level_low_alarm     | 13 cm            | (config)          | ✓ (Issue #110) |
 | water_level_filling_on    | 33 cm            | (config)          | ✓ (Issue #110) |
@@ -218,7 +219,7 @@ share the `alarm_orp_too_many_doses` sensor.
 | required_floc             | 10 ml/h          | 10 ml/h           | ✓ (fixed) |
 | required_algicide         | 0 ml/m³/day      | 0 ml/m³/day       | ✓ (fixed) |
 | required_water_temperature | 25°C            | --- (disabled)    | ⚠ Open Item 3 |
-| Filtration schedule       | 08:00–16:00 / 18:00–22:00 (last-configured) | NONSTOP 24H | ✓ (mode from `byte[37]`, schedule bytes always present) |
+| Filtration times          | 08:00–16:00 / 18:00–22:00 (last-configured) | NONSTOP 24H | ✓ (schedule from `byte[37]`, time bytes always present) |
 | backwash_every_n_days     | 3                | every 3 days      | ✓     |
 | backwash_time             | 21:00            | starts at 21:00   | ✓     |
 | backwash_duration         | 120 s            | 02:00 min         | ✓     |
@@ -300,10 +301,15 @@ firmware B: serial 110169464, byte 4 = 0x03 — see [Issue #133](../temp/Issue-1
 | Antifreeze ON (nonstop)†‡     | `0x81`     | (n/o)      | `1000_0001` / —              |
 
 † Bit 1 is clear (`0x02`) in all three heating-health values. When `byte[37]` & `0x40` is set
-  but bit-1 is clear, the decoder falls back to schedule-derived filtration mode (see
-  `_fill_filtration_mode` in `aseko_decoder.py`). The actual filtration mode is
-  determined from the schedule bytes and the `PERIOD2_ENABLED_MASK` (`0x20`).
+  but bit-1 is clear, the decoder falls back to a schedule derived from the
+  filtration times (see `_fill_filtration_mode` in `aseko_decoder.py`), using
+  the time bytes and the `PERIOD2_ENABLED_MASK` (`0x20`).
   `heating_control_enabled` is decoded separately from bit 3 (`0x08`).
+
+  Both this fallback and the firmware-A branch above it are **HOME-only**.
+  Bit `0x40` only discriminates the two encodings here: SALT sets it in every
+  frame, and reports the filtration times unchanged in every mode, so for a
+  SALT the fallback could only ever return one constant answer.
 
 ‡ When antifreeze is ON, `byte[55]` drops from the normal heating setpoint
   (eg. 27°C) to the antifreeze setpoint (e.g. 4°C, 5°C or 9°C whatever user sets).
@@ -362,8 +368,13 @@ discussion](https://github.com/hopkins-tk/home-assistant-aseko-local/issues/110)
 bit 3 (`filtration_pump_running`) is still set in the frame — the firmware does
 not clear the schedule-driven bit on manual override. The decoder compensates
 by short-circuiting `filtration_pump_running` to `False` whenever
-`filtration_mode == MANUAL`. This is a HOME-only behaviour; no SALT/OXY/PROFI
-OFF frame has been captured yet.
+`filtration_mode == MANUAL`.
+
+This override stays **HOME-only**, and SALT captures are now the reason why
+rather than just a lack of evidence: on SALT the same bit means the user is
+at the panel driving the pump, which they may equally have switched *on*.
+Forcing the pump off there would invent a state the unit never reported.
+See `salt_device_analysis.md` §byte[37] – filtration mode and schedule.
 
 **Note on Period 2 schedule bytes (Issue #133)**: All Aseko devices in
 `FILTRATION_TYPES` (SALT, HOME, OXY, PROFI) keep sending the last-configured
@@ -379,7 +390,7 @@ the controller back from "P1 & P2" to "P1 only" (the entity registry
 protects the entity, but the value is read as `None`).  Post-fix, bytes
 60-63 are read unconditionally for any device in `FILTRATION_TYPES` (so
 `start2`/`stop2` stay populated and the entity shows the last-configured
-time); the `filtration_mode` sensor separately reports `TIMER_PERIOD_1`
+time); the `filtration_schedule` sensor separately reports `TIMER_PERIOD_1`
 to tell the user that Period 2 is inactive.  This behaviour was
 verified against the four diagnostic files from
 [Issue #133](../temp/Issue-133.md) (serial 110169464, ASIN AQUA Home
@@ -425,6 +436,10 @@ frames — including the OFF frame. The override state lives in `byte[37]` bit 2
 (firmware B only, value `0x35`), not in `byte[29]`. The decoder compensates for
 this HOME-only behaviour in `_fill_consumable_data` (see `_fill_filtration_mode`
 in `aseko_decoder.py`).
+
+Bit 2 is decoded into `filtration_mode` (`SCHEDULE` / `MANUAL`) and the
+schedule bits into `filtration_schedule`, so the schedule stays readable while
+the override is on — the two are independent and one value cannot carry both.
 
 ### `byte[22]` — Variable-speed filtration pump (Issue #137)
 
@@ -479,12 +494,14 @@ Tests for the HOME decoder live in `tests/test_aseko_decoder.py`:
 | `test_decode_home_flowrates_unspecified` | 0xFF on flowrate bytes → `None` (pump not installed) |
 | `test_decode_home_algicide_pump_running` | Issue #115: `algicide_pump_running` binary sensor is registered |
 | `test_decode_home_floc_pump_running_independent` | HOME reports `floc_pump_running` correctly when only floc pump is installed |
-| `test_filtration_mode_new_encoding_24h` | Issue #133 firmware B: `byte[37]=0x01` → `NONSTOP_24H` |
-| `test_filtration_mode_new_encoding_p1` | Issue #133 firmware B: `byte[37]=0x11` → `TIMER_PERIOD_1` |
-| `test_filtration_mode_new_encoding_p1_and_p2` | Issue #133 firmware B: `byte[37]=0x31` → `TIMER_PERIOD_1_AND_2` |
-| `test_filtration_mode_new_encoding_manual_p1_and_p2` | Issue #133 firmware B: `byte[37]=0x35` → `MANUAL` |
-| `test_filtration_mode_old_encoding_24h` | Issue #110 firmware A: `byte[37]=0x43` → `NONSTOP_24H` |
-| `test_filtration_mode_old_encoding_timer` | Issue #110 firmware A: `byte[37]=0x53` → `TIMER_PERIOD_1_AND_2` |
+| `test_filtration_mode_new_encoding_24h` | Issue #133 firmware B: `byte[37]=0x01` → schedule `NONSTOP_24H` |
+| `test_filtration_mode_new_encoding_p1` | Issue #133 firmware B: `byte[37]=0x11` → schedule `TIMER_PERIOD_1` |
+| `test_filtration_mode_new_encoding_p1_and_p2` | Issue #133 firmware B: `byte[37]=0x31` → schedule `TIMER_PERIOD_1_AND_2` |
+| `test_filtration_mode_new_encoding_manual_p1_and_p2` | Issue #133 firmware B: `byte[37]=0x35` → mode `MANUAL` |
+| `test_filtration_mode_old_encoding_24h` | Issue #110 firmware A: `byte[37]=0x43` → schedule `NONSTOP_24H` |
+| `test_filtration_mode_old_encoding_timer` | Issue #110 firmware A: `byte[37]=0x53` → schedule `TIMER_PERIOD_1_AND_2` |
+| `test_filtration_mode_salt_uses_the_firmware_b_bits` | SALT: all six captured `byte[37]` values → mode + schedule |
+| `test_filtration_schedule_survives_manual_mode` | `0xC3` → `0xC7` → `0xC3`: the schedule reads the same throughout |
 | `test_filtration_pump_running_off_when_manual_override` | Issue #133: `byte[37]=0x35` forces `filtration_pump_running=False` |
 | `test_filtration_pump_running_on_when_not_override` | Regression guard: `byte[29]&0x08` still drives the entity outside MANUAL |
 | `test_filtration_pump_running_not_overridden_on_salt` | Override short-circuit is HOME-only |

--- a/docs/device analyzes/home_device_analysis.md
+++ b/docs/device analyzes/home_device_analysis.md
@@ -207,7 +207,7 @@ share the `alarm_orp_too_many_doses` sensor.
 | Water flow to probes      | False            | NO                | ✓     |
 | Filtration pump running   | False            | STOP              | ✓     |
 | filtration_schedule       | NONSTOP_24H      | NONSTOP 24H       | ✓ (Issue #110) |
-| filtration_mode           | SCHEDULE         | (nobody at the unit) | ✓ |
+| service_menu_open         | False            | (nobody at the unit) | ✓ |
 | water_level               | 8 cm             | --- (level meter disabled) | ✓ (frame value) |
 | water_level_low_alarm     | 13 cm            | (config)          | ✓ (Issue #110) |
 | water_level_filling_on    | 33 cm            | (config)          | ✓ (Issue #110) |
@@ -302,7 +302,7 @@ firmware B: serial 110169464, byte 4 = 0x03 — see [Issue #133](../temp/Issue-1
 
 † Bit 1 is clear (`0x02`) in all three heating-health values. When `byte[37]` & `0x40` is set
   but bit-1 is clear, the decoder falls back to a schedule derived from the
-  filtration times (see `_fill_filtration_mode` in `aseko_decoder.py`), using
+  filtration times (see `_fill_filtration_schedule` in `aseko_decoder.py`), using
   the time bytes and the `PERIOD2_ENABLED_MASK` (`0x20`).
   `heating_control_enabled` is decoded separately from bit 3 (`0x08`).
 
@@ -368,7 +368,7 @@ discussion](https://github.com/hopkins-tk/home-assistant-aseko-local/issues/110)
 bit 3 (`filtration_pump_running`) is still set in the frame — the firmware does
 not clear the schedule-driven bit on manual override. The decoder compensates
 by short-circuiting `filtration_pump_running` to `False` whenever
-`filtration_mode == SERVICE_MENU`.
+`service_menu_open is True`.
 
 This override stays **HOME-only**, and SALT captures are now the reason why
 rather than just a lack of evidence: there the same bit marks the settings
@@ -434,18 +434,18 @@ by live capture (see Open Item 7).
 | 6    | `0x40`| cl pump running             | see Open Item 7        |
 | 7    | `0x80`| pH− pump running            | see Open Item 7        |
 
-### `byte[29]` vs `filtration_mode` (firmware B manual OFF)
+### `byte[29]` vs `service_menu_open` (firmware B manual OFF)
 
 Cross-frame analysis of @dtpugh's four firmware B frames (24h nonstop, P1 only,
 P1 & P2, OFF manual) shows that `byte[29]` bit 3 stays set in **all four**
 frames — including the OFF frame. The override state lives in `byte[37]` bit 2
 (firmware B only, value `0x35`), not in `byte[29]`. The decoder compensates for
-this HOME-only behaviour in `_fill_consumable_data` (see `_fill_filtration_mode`
+this HOME-only behaviour in `_fill_consumable_data` (see `_fill_filtration_schedule`
 in `aseko_decoder.py`).
 
-Bit 2 is decoded into `filtration_mode` (`SCHEDULE` / `SERVICE_MENU`) and the
-schedule bits into `filtration_schedule`, so the schedule stays readable while
-the bit is set — the two are independent and one value cannot carry both.
+Bit 2 is decoded into `service_menu_open` (a plain bool) and the schedule bits
+into `filtration_schedule`.  They are unrelated facts sharing a byte: one says
+somebody is at the unit, the other what it runs when nobody is.
 
 ### `byte[22]` — Variable-speed filtration pump (Issue #137)
 
@@ -500,13 +500,13 @@ Tests for the HOME decoder live in `tests/test_aseko_decoder.py`:
 | `test_decode_home_flowrates_unspecified` | 0xFF on flowrate bytes → `None` (pump not installed) |
 | `test_decode_home_algicide_pump_running` | Issue #115: `algicide_pump_running` binary sensor is registered |
 | `test_decode_home_floc_pump_running_independent` | HOME reports `floc_pump_running` correctly when only floc pump is installed |
-| `test_filtration_mode_new_encoding_24h` | Issue #133 firmware B: `byte[37]=0x01` → schedule `NONSTOP_24H` |
-| `test_filtration_mode_new_encoding_p1` | Issue #133 firmware B: `byte[37]=0x11` → schedule `TIMER_PERIOD_1` |
-| `test_filtration_mode_new_encoding_p1_and_p2` | Issue #133 firmware B: `byte[37]=0x31` → schedule `TIMER_PERIOD_1_AND_2` |
-| `test_filtration_mode_new_encoding_manual_p1_and_p2` | Issue #133 firmware B: `byte[37]=0x35` → mode `SERVICE_MENU` |
-| `test_filtration_mode_old_encoding_24h` | Issue #110 firmware A: `byte[37]=0x43` → schedule `NONSTOP_24H` |
-| `test_filtration_mode_old_encoding_timer` | Issue #110 firmware A: `byte[37]=0x53` → schedule `TIMER_PERIOD_1_AND_2` |
-| `test_filtration_mode_salt_uses_the_firmware_b_bits` | SALT: all six captured `byte[37]` values → mode + schedule |
+| `test_filtration_schedule_new_encoding_24h` | Issue #133 firmware B: `byte[37]=0x01` → schedule `NONSTOP_24H` |
+| `test_filtration_schedule_new_encoding_p1` | Issue #133 firmware B: `byte[37]=0x11` → schedule `TIMER_PERIOD_1` |
+| `test_filtration_schedule_new_encoding_p1_and_p2` | Issue #133 firmware B: `byte[37]=0x31` → schedule `TIMER_PERIOD_1_AND_2` |
+| `test_service_menu_new_encoding_p1_and_p2` | Issue #133 firmware B: `byte[37]=0x35` → `service_menu_open` True |
+| `test_filtration_schedule_old_encoding_24h` | Issue #110 firmware A: `byte[37]=0x43` → schedule `NONSTOP_24H` |
+| `test_filtration_schedule_old_encoding_timer` | Issue #110 firmware A: `byte[37]=0x53` → schedule `TIMER_PERIOD_1_AND_2` |
+| `test_filtration_schedule_salt_uses_the_firmware_b_bits` | SALT: all six captured `byte[37]` values → schedule + menu flag |
 | `test_filtration_schedule_survives_the_service_menu` | `0xC3` → `0xC7` → `0xC3`: the schedule reads the same throughout |
 | `test_filtration_pump_running_off_when_manual_override` | Issue #133: `byte[37]=0x35` forces `filtration_pump_running=False` |
 | `test_filtration_pump_running_on_when_not_override` | Regression guard: `byte[29]&0x08` still drives the entity while bit 0x04 is clear |
@@ -531,7 +531,7 @@ Tests for the HOME decoder live in `tests/test_aseko_decoder.py`:
 - NET v8 analysis: `docs/device analyzes/net_v8_device_analysis.md`
 - Issue #110: byte[37] firmware A (`0x43` = nonstop 24h) — original finding, frames in this file
 - Issue #115: HOME `algicide_pump_running` missing — fixed by independent-pump-port branch
-- Issue #133: byte[37] firmware B (4-state mode + manual OFF) — fixed by `_fill_filtration_mode` rewrite.  Period 2 schedule bytes (60-63) are now read unconditionally for any device in `FILTRATION_TYPES` to avoid "unknown" entities when the user toggles the controller.  See the *Note on Period 2 schedule bytes (Issue #133)* under `byte[29]` vs `filtration_mode` below.
+- Issue #133: byte[37] firmware B (4-state mode + manual OFF) — fixed by `_fill_filtration_schedule` rewrite.  Period 2 schedule bytes (60-63) are now read unconditionally for any device in `FILTRATION_TYPES` to avoid "unknown" entities when the user toggles the controller.  See the *Note on Period 2 schedule bytes (Issue #133)* under `byte[29]` vs `service_menu_open` below.
 - Issue #135: `byte[37]` bit 3 (`0x08`) = heating control master enable on HOME firmware A
   (serial 110175608, REDOX HOME). Confirms `byte[55]` as target water temp setpoint.
   Working notes: [docs/temp/Issue-135.md](../temp/Issue-135.md).

--- a/docs/device analyzes/net_device_analysis.md
+++ b/docs/device analyzes/net_device_analysis.md
@@ -201,4 +201,4 @@ AsekoDeviceType.NET: AsekoActuatorMasks(
 | NET-in-DOSE-mode decoded as HOME? | ⚠️ Known bug — filed as separate issue, out of v1.4.0 scope |
 | byte[29] other bits on NET? | ⏳ Only `0x01` and `0x02` confirmed — no further pump outputs known |
 | ph_plus pump on NET? | ⏳ NET hardware may not have pH+ pump — not confirmed |
-| byte[37] = `0xFF` always on NET? | ✅ Confirmed — `0xFF` (UNSPECIFIED) in all captured frames.  NET is not in `FILTRATION_TYPES` anyway, so neither `filtration_mode` nor `filtration_schedule` is decoded for it |
+| byte[37] = `0xFF` always on NET? | ✅ Confirmed — `0xFF` (UNSPECIFIED) in all captured frames.  NET is not in `FILTRATION_TYPES` anyway, so neither `filtration_schedule` nor `service_menu_open` is decoded for it |

--- a/docs/device analyzes/net_device_analysis.md
+++ b/docs/device analyzes/net_device_analysis.md
@@ -201,4 +201,4 @@ AsekoDeviceType.NET: AsekoActuatorMasks(
 | NET-in-DOSE-mode decoded as HOME? | ⚠️ Known bug — filed as separate issue, out of v1.4.0 scope |
 | byte[29] other bits on NET? | ⏳ Only `0x01` and `0x02` confirmed — no further pump outputs known |
 | ph_plus pump on NET? | ⏳ NET hardware may not have pH+ pump — not confirmed |
-| byte[37] = `0xFF` always on NET? | ✅ Confirmed — `0xFF` (UNSPECIFIED) in all captured frames → `filtration_nonstop24 = None` |
+| byte[37] = `0xFF` always on NET? | ✅ Confirmed — `0xFF` (UNSPECIFIED) in all captured frames.  NET is not in `FILTRATION_TYPES` anyway, so neither `filtration_mode` nor `filtration_schedule` is decoded for it |

--- a/docs/device analyzes/oxy_device_analysis.md
+++ b/docs/device analyzes/oxy_device_analysis.md
@@ -266,7 +266,7 @@ since it exposes a filtration output).  The lazy-creation guard in
 only if the bytes are `0xFF` (the bytes have never been configured on the
 controller).  Once the entity is registered, it stays populated with the
 last-configured time even when the user disables Period 2 — the
-`filtration_mode` sensor (decoded from the `byte[37]` filtration-mode flag)
+`filtration_schedule` sensor (decoded from the `byte[37]` schedule bits)
 separately reports `TIMER_PERIOD_1` so the user knows the schedule is
 inactive.
 

--- a/docs/device analyzes/profi_device_analysis.md
+++ b/docs/device analyzes/profi_device_analysis.md
@@ -140,7 +140,7 @@ since it exposes a filtration output).  The lazy-creation guard in
 only if the bytes are `0xFF` (the bytes have never been configured on the
 controller).  Once the entity is registered, it stays populated with the
 last-configured time even when the user disables Period 2 — the
-`filtration_mode` sensor (decoded from the `byte[37]` filtration-mode flag)
+`filtration_schedule` sensor (decoded from the `byte[37]` schedule bits)
 separately reports `TIMER_PERIOD_1` so the user knows the schedule is
 inactive.
 

--- a/docs/device analyzes/salt_device_analysis.md
+++ b/docs/device analyzes/salt_device_analysis.md
@@ -161,19 +161,19 @@ keeps them apart because neither can stand in for the other:
 | Bits | Meaning | Field |
 |---|---|---|
 | `0x10` / `0x20` | which schedule is configured | `filtration_schedule` |
-| `0x04` | the unit's settings menu is open | `filtration_mode` |
+| `0x04` | the unit's settings menu is open | `service_menu_open` |
 
 Every combination below was captured on an ASIN AQUA Salt with the mode shown
 on the unit itself known, in both directions of each transition:
 
-| `byte[37]` | `filtration_mode` | `filtration_schedule` |
+| `byte[37]` | `service_menu_open` | `filtration_schedule` |
 |---|---|---|
-| `0xC3` | `SCHEDULE` | `NONSTOP_24H` |
-| `0xD3` | `SCHEDULE` | `TIMER_PERIOD_1` |
-| `0xF3` | `SCHEDULE` | `TIMER_PERIOD_1_AND_2` |
-| `0xC7` | `SERVICE_MENU` | `NONSTOP_24H` |
-| `0xD7` | `SERVICE_MENU` | `TIMER_PERIOD_1` |
-| `0xF7` | `SERVICE_MENU` | `TIMER_PERIOD_1_AND_2` |
+| `0xC3` | `False` | `NONSTOP_24H` |
+| `0xD3` | `False` | `TIMER_PERIOD_1` |
+| `0xF3` | `False` | `TIMER_PERIOD_1_AND_2` |
+| `0xC7` | `True` | `NONSTOP_24H` |
+| `0xD7` | `True` | `TIMER_PERIOD_1` |
+| `0xF7` | `True` | `TIMER_PERIOD_1_AND_2` |
 
 These are the same mode bits HOME firmware B uses; the constant `0xC0` in the
 high nibble is SALT's own configuration (`0x80` = algicide routing).
@@ -199,9 +199,9 @@ the user leaves.  Three diagnostics taken during one such session all
 contained the same frame, with `online` going false between them.  Two
 consequences:
 
-* `SERVICE_MENU` is typically the last thing reported before the device goes
-  offline, and `filtration_mode` then holds that value until the user comes
-  back out.  This is correct — it is the last thing the unit actually said.
+* `service_menu_open` going True is typically the last thing reported before
+  the device goes offline, and it stays True until the user comes back out.
+  This is correct — it is the last thing the unit actually said.
 * What the user *does* in there is not observable.  The pump state in that
   final frame is the state on the way in, not the result.  The unit will not
   let you leave until filtration is back in the state it was in before, so

--- a/docs/device analyzes/salt_device_analysis.md
+++ b/docs/device analyzes/salt_device_analysis.md
@@ -125,9 +125,9 @@ where the algicide-routing bit was clear — which caused already-registered
 entities to flip to "unknown" when the user toggled Period 2 on/off
 (Home Assistant protects the entity registry, so the entity stays but
 the value is read as `None`).  Post-fix, bytes 60-63 are read
-unconditionally for any device in `FILTRATION_TYPES` (SALT included) and
-`filtration_mode` is decoded directly from the `byte[37]` filtration-mode
-flag (see §byte[37] below).  Behaviour was originally verified on SALT by
+unconditionally for any device in `FILTRATION_TYPES` (SALT included), and
+the mode and schedule are decoded from the `byte[37]` bits (see
+§byte[37] – filtration mode and schedule below).  Behaviour was originally verified on SALT by
 diffing two frames
 captured in PR #122 (algicide mode toggle, `0xb3` ↔ `0x33`); the
 corresponding behaviour for HOME was confirmed in Issue #133 with
@@ -146,25 +146,65 @@ filtration output.
 | Algicide 11 → Flocculant 11 (type change) | `0x84` | bit 7 + bit 2 |
 | Algicide 10 → Flocculant 11 (both change) | `0x80` | bit 7 only |
 
-Bit 2 (`0x04`) appears related to dosage encoding. The full semantics of all bits are not
-confirmed.
+Bit 2 (`0x04`) was read here as dosage encoding.  **That reading is
+superseded**: `0x04` is the manual-mode flag, captured directly on an ASIN
+AQUA Salt across six byte[37] values and both directions of every transition
+(see §byte[37] – filtration mode and schedule below).  The XOR above came
+from two frames diffed in PR #122; the dosage change and a mode change most
+likely coincided in that pair.  The remaining bits are unconfirmed.
 
-### byte[37] also carries the filtration-mode flag
+### byte[37] – filtration mode and schedule
 
-Since Issue #133 the decoder reads the 4-state filtration mode directly from
-`byte[37]` for every `FILTRATION_TYPES` device (SALT included), using the same
-two firmware encodings as HOME — see
-[`home_device_analysis.md`](home_device_analysis.md) §"byte[37] – Filtration
-mode flag" for the full table.  In brief:
+`byte[37]` carries **two independent facts** about filtration, and the decoder
+keeps them apart because neither can stand in for the other:
 
-| `byte[37]` high nibble | Encoding | Filtration mode |
+| Bits | Meaning | Field |
 |---|---|---|
-| `0x4` / `0x5` (firmware A) | exact values | `0x43` → `NONSTOP_24H`, `0x53` → `TIMER_PERIOD_1_AND_2` |
-| `0x0` / `0x1` / `0x3` (firmware B) | bit flags | `0x04` → `MANUAL`; `(b & 0x30)` → `0x00`=`NONSTOP_24H`, `0x10`=`TIMER_PERIOD_1`, `0x30`=`TIMER_PERIOD_1_AND_2` |
+| `0x10` / `0x20` | which schedule is configured | `filtration_schedule` |
+| `0x04` | user has taken the pump over by hand | `filtration_mode` |
 
-Note the overlap with the third-pump routing / dosage encoding above: bit 2
-(`0x04`) is interpreted as the manual-override flag by the filtration-mode
-decode on SALT as well.
+Every combination below was captured on an ASIN AQUA Salt with the mode shown
+on the unit itself known, in both directions of each transition:
+
+| `byte[37]` | `filtration_mode` | `filtration_schedule` |
+|---|---|---|
+| `0xC3` | `SCHEDULE` | `NONSTOP_24H` |
+| `0xD3` | `SCHEDULE` | `TIMER_PERIOD_1` |
+| `0xF3` | `SCHEDULE` | `TIMER_PERIOD_1_AND_2` |
+| `0xC7` | `MANUAL` | `NONSTOP_24H` |
+| `0xD7` | `MANUAL` | `TIMER_PERIOD_1` |
+| `0xF7` | `MANUAL` | `TIMER_PERIOD_1_AND_2` |
+
+These are the same mode bits HOME firmware B uses; the constant `0xC0` in the
+high nibble is SALT's own configuration (`0x80` = algicide routing).
+
+**Bit `0x40` does not select the firmware variant here.** SALT sets it in every
+frame, so routing on it sent SALT into the HOME firmware-A branch, where it
+matched none of the exact values and came out with no mode at all.  The
+firmware-A branch — and the schedule-derived fallback behind it — are therefore
+HOME-only.  On SALT the fallback could not help anyway: the filtration times in
+bytes 56-63 are reported unchanged in every mode, so deriving the mode from
+them would return one constant answer whatever the unit is doing.
+
+**The unit goes quiet in manual mode.** Entering it produces exactly one more
+frame — the one carrying `0x04` — and then transmission stops until the user
+leaves the mode again.  Three diagnostics taken during one such excursion all
+contained the same frame, with `online` going false between them.  Two
+consequences:
+
+* `MANUAL` is typically the last thing reported before the device goes offline,
+  and `filtration_mode` then holds that value until the user comes back out.
+  This is correct — it is the last thing the unit actually said.
+* What the user *does* inside manual mode is not observable.  The pump state in
+  that final frame is the state on the way in, not the result.  The unit will
+  not let you leave manual mode until filtration is back in the state it was in
+  before, so the value Home Assistant is holding is right again by the time
+  frames resume.
+
+The exception is a manual **backwash**: there the unit keeps transmitting
+throughout, with `0x04` set from ~30 s before the valve opens until ~20 s after
+it closes.  `backwash_tracker` uses that as observed proof the cycle was manual
+rather than inferring it from the clock — see `_manual_mode_engaged`.
 
 ---
 

--- a/docs/device analyzes/salt_device_analysis.md
+++ b/docs/device analyzes/salt_device_analysis.md
@@ -147,7 +147,7 @@ filtration output.
 | Algicide 10 → Flocculant 11 (both change) | `0x80` | bit 7 only |
 
 Bit 2 (`0x04`) was read here as dosage encoding.  **That reading is
-superseded**: `0x04` is the manual-mode flag, captured directly on an ASIN
+superseded**: `0x04` marks the unit's settings menu, captured directly on an ASIN
 AQUA Salt across six byte[37] values and both directions of every transition
 (see §byte[37] – filtration mode and schedule below).  The XOR above came
 from two frames diffed in PR #122; the dosage change and a mode change most
@@ -161,7 +161,7 @@ keeps them apart because neither can stand in for the other:
 | Bits | Meaning | Field |
 |---|---|---|
 | `0x10` / `0x20` | which schedule is configured | `filtration_schedule` |
-| `0x04` | user has taken the pump over by hand | `filtration_mode` |
+| `0x04` | the unit's settings menu is open | `filtration_mode` |
 
 Every combination below was captured on an ASIN AQUA Salt with the mode shown
 on the unit itself known, in both directions of each transition:
@@ -171,9 +171,9 @@ on the unit itself known, in both directions of each transition:
 | `0xC3` | `SCHEDULE` | `NONSTOP_24H` |
 | `0xD3` | `SCHEDULE` | `TIMER_PERIOD_1` |
 | `0xF3` | `SCHEDULE` | `TIMER_PERIOD_1_AND_2` |
-| `0xC7` | `MANUAL` | `NONSTOP_24H` |
-| `0xD7` | `MANUAL` | `TIMER_PERIOD_1` |
-| `0xF7` | `MANUAL` | `TIMER_PERIOD_1_AND_2` |
+| `0xC7` | `SERVICE_MENU` | `NONSTOP_24H` |
+| `0xD7` | `SERVICE_MENU` | `TIMER_PERIOD_1` |
+| `0xF7` | `SERVICE_MENU` | `TIMER_PERIOD_1_AND_2` |
 
 These are the same mode bits HOME firmware B uses; the constant `0xC0` in the
 high nibble is SALT's own configuration (`0x80` = algicide routing).
@@ -186,25 +186,37 @@ HOME-only.  On SALT the fallback could not help anyway: the filtration times in
 bytes 56-63 are reported unchanged in every mode, so deriving the mode from
 them would return one constant answer whatever the unit is doing.
 
-**The unit goes quiet in manual mode.** Entering it produces exactly one more
-frame — the one carrying `0x04` — and then transmission stops until the user
-leaves the mode again.  Three diagnostics taken during one such excursion all
+**What the bit actually marks.** `0x04` appears the moment the settings menu
+is opened on the unit — the menu holding every Aseko setting, and the place
+filtration and backwash can be started by hand from.  It is set **before**
+anything is touched: three captures labelled "switched to manual mode, did
+nothing" carry it.  So on its own the bit says a person is standing at the
+unit, and nothing about what they did.
+
+**The unit goes quiet while the menu is open.** Opening it produces exactly
+one more frame — the one carrying `0x04` — and then transmission stops until
+the user leaves.  Three diagnostics taken during one such session all
 contained the same frame, with `online` going false between them.  Two
 consequences:
 
-* `MANUAL` is typically the last thing reported before the device goes offline,
-  and `filtration_mode` then holds that value until the user comes back out.
-  This is correct — it is the last thing the unit actually said.
-* What the user *does* inside manual mode is not observable.  The pump state in
-  that final frame is the state on the way in, not the result.  The unit will
-  not let you leave manual mode until filtration is back in the state it was in
-  before, so the value Home Assistant is holding is right again by the time
-  frames resume.
+* `SERVICE_MENU` is typically the last thing reported before the device goes
+  offline, and `filtration_mode` then holds that value until the user comes
+  back out.  This is correct — it is the last thing the unit actually said.
+* What the user *does* in there is not observable.  The pump state in that
+  final frame is the state on the way in, not the result.  The unit will not
+  let you leave until filtration is back in the state it was in before, so
+  the value Home Assistant is holding is right again by the time frames
+  resume.
 
-The exception is a manual **backwash**: there the unit keeps transmitting
-throughout, with `0x04` set from ~30 s before the valve opens until ~20 s after
-it closes.  `backwash_tracker` uses that as observed proof the cycle was manual
-rather than inferring it from the clock — see `_manual_mode_engaged`.
+Note this is **not** evidence that the schedule is suspended while the menu
+is open: in the 2026-08-11 capture the pump kept running throughout, and the
+configured period 1 covered that time of day anyway.
+
+The exception is a by-hand **backwash**: there the unit keeps transmitting
+throughout, with `0x04` set from ~30 s before the valve opens until ~20 s
+after it closes.  A cycle running while somebody is at the menu the button
+lives on is manual by observation, and `backwash_tracker` uses it as such
+rather than inferring from the clock — see `_service_menu_open`.
 
 ---
 

--- a/tests/test_aseko_decoder.py
+++ b/tests/test_aseko_decoder.py
@@ -264,14 +264,36 @@ def test_decode_filtration_period2_real_dtpugh_frames() -> None:
             return payload
         return None
 
+    # 04_off is the user switching to manual while both periods stay
+    # configured, which is why it carries a schedule as well as a mode.
     scenarios = {
-        "01_p1only.json": (0x11, AsekoFiltrationSchedule.TIMER_PERIOD_1),
-        "02_p1andp2.json": (0x31, AsekoFiltrationSchedule.TIMER_PERIOD_1_AND_2),
-        "03_24h.json": (0x01, AsekoFiltrationSchedule.NONSTOP_24H),
-        "04_off.json": (0x35, AsekoFiltrationMode.MANUAL),
+        "01_p1only.json": (
+            0x11,
+            AsekoFiltrationSchedule.TIMER_PERIOD_1,
+            AsekoFiltrationMode.SCHEDULE,
+        ),
+        "02_p1andp2.json": (
+            0x31,
+            AsekoFiltrationSchedule.TIMER_PERIOD_1_AND_2,
+            AsekoFiltrationMode.SCHEDULE,
+        ),
+        "03_24h.json": (
+            0x01,
+            AsekoFiltrationSchedule.NONSTOP_24H,
+            AsekoFiltrationMode.SCHEDULE,
+        ),
+        "04_off.json": (
+            0x35,
+            AsekoFiltrationSchedule.TIMER_PERIOD_1_AND_2,
+            AsekoFiltrationMode.SERVICE_MENU,
+        ),
     }
 
-    for filename, (expected_b37, expected_mode) in scenarios.items():
+    for filename, (
+        expected_b37,
+        expected_schedule,
+        expected_mode,
+    ) in scenarios.items():
         with open(diag_dir / filename) as f:
             frame = bytes.fromhex(_first_frame(json.load(f)))
         assert frame[37] == expected_b37, f"{filename}: byte 37 mismatch"
@@ -287,7 +309,12 @@ def test_decode_filtration_period2_real_dtpugh_frames() -> None:
         assert device.stop2 is not None, (
             f"{filename}: stop2 is None — entity would go 'unknown' (Issue #133)"
         )
-        # Mode entity correctly reports which schedule is active.
+        # The schedule entity reports which schedule is configured...
+        assert device.filtration_schedule == expected_schedule, (
+            f"{filename}: expected {expected_schedule}, "
+            f"got {device.filtration_schedule}"
+        )
+        # ...and the mode entity whether it is the one in charge.
         assert device.filtration_mode == expected_mode, (
             f"{filename}: expected {expected_mode}, got {device.filtration_mode}"
         )
@@ -1415,7 +1442,7 @@ def test_filtration_mode_new_encoding_manual_p1_and_p2() -> None:
     data = _make_home_bytes()
     data[37] = 0x35  # new encoding: P1 & P2 + manual override (bit 2 set)
     device = AsekoDecoder.decode(bytes(data))
-    assert device.filtration_mode == AsekoFiltrationMode.MANUAL
+    assert device.filtration_mode == AsekoFiltrationMode.SERVICE_MENU
 
 
 def test_filtration_mode_new_encoding_manual_p1_only() -> None:
@@ -1428,7 +1455,7 @@ def test_filtration_mode_new_encoding_manual_p1_only() -> None:
     data = _make_home_bytes()
     data[37] = 0x15  # P1 + manual override
     device = AsekoDecoder.decode(bytes(data))
-    assert device.filtration_mode == AsekoFiltrationMode.MANUAL
+    assert device.filtration_mode == AsekoFiltrationMode.SERVICE_MENU
 
 
 def test_filtration_mode_old_encoding_24h() -> None:
@@ -1546,7 +1573,7 @@ def test_filtration_pump_running_off_when_manual_override() -> None:
         data[37] = override_value  # OFF (manual override)
 
         device = AsekoDecoder.decode(bytes(data))
-        assert device.filtration_mode == AsekoFiltrationMode.MANUAL, (
+        assert device.filtration_mode == AsekoFiltrationMode.SERVICE_MENU, (
             f"byte[37]={override_value:#x}"
         )
         assert device.filtration_pump_running is False, f"byte[37]={override_value:#x}"
@@ -1578,7 +1605,7 @@ def test_filtration_pump_running_not_overridden_on_salt() -> None:
     data[37] = 0x35  # firmware B: P1 & P2 + manual override → MANUAL
 
     device = AsekoDecoder.decode(bytes(data))
-    assert device.filtration_mode == AsekoFiltrationMode.MANUAL
+    assert device.filtration_mode == AsekoFiltrationMode.SERVICE_MENU
     assert device.filtration_pump_running is True  # unchanged: byte[29] bit 3 wins
 
 
@@ -1996,11 +2023,15 @@ def test_home_issue_110_frame() -> None:
             AsekoFiltrationMode.SCHEDULE,
             AsekoFiltrationSchedule.TIMER_PERIOD_1_AND_2,
         ),
-        (0xC7, AsekoFiltrationMode.MANUAL, AsekoFiltrationSchedule.NONSTOP_24H),
-        (0xD7, AsekoFiltrationMode.MANUAL, AsekoFiltrationSchedule.TIMER_PERIOD_1),
+        (0xC7, AsekoFiltrationMode.SERVICE_MENU, AsekoFiltrationSchedule.NONSTOP_24H),
+        (
+            0xD7,
+            AsekoFiltrationMode.SERVICE_MENU,
+            AsekoFiltrationSchedule.TIMER_PERIOD_1,
+        ),
         (
             0xF7,
-            AsekoFiltrationMode.MANUAL,
+            AsekoFiltrationMode.SERVICE_MENU,
             AsekoFiltrationSchedule.TIMER_PERIOD_1_AND_2,
         ),
     ],
@@ -2070,11 +2101,12 @@ def test_filtration_mode_home_transitional_still_suppressed() -> None:
     assert device.filtration_mode is None
 
 
-def test_filtration_schedule_survives_manual_mode() -> None:
-    """Manual mode hides the schedule from filtration_mode, not from the unit.
+def test_filtration_schedule_survives_the_service_menu() -> None:
+    """The settings menu hides the schedule from filtration_mode, not from
+    the unit.
 
-    Going into manual mode and back out again is the same schedule throughout
-    — 0xC3 -> 0xC7 -> 0xC3 on a captured SALT — so filtration_schedule must
+    Opening the menu and leaving it again is the same schedule throughout —
+    0xC3 -> 0xC7 -> 0xC3 on a captured SALT — so filtration_schedule must
     read the same in all three, even though filtration_mode does not.
 
     This is what makes the schedule usable on a dashboard while the override
@@ -2093,6 +2125,6 @@ def test_filtration_schedule_survives_manual_mode() -> None:
     assert schedules == [AsekoFiltrationSchedule.NONSTOP_24H] * 3
     assert modes == [
         AsekoFiltrationMode.SCHEDULE,
-        AsekoFiltrationMode.MANUAL,
+        AsekoFiltrationMode.SERVICE_MENU,
         AsekoFiltrationMode.SCHEDULE,
     ]

--- a/tests/test_aseko_decoder.py
+++ b/tests/test_aseko_decoder.py
@@ -8,6 +8,7 @@ from custom_components.aseko_local.aseko_data import (
     AsekoDeviceType,
     AsekoElectrolyzerDirection,
     AsekoFiltrationMode,
+    AsekoFiltrationSchedule,
     AsekoProbeType,
 )
 from custom_components.aseko_local.aseko_decoder import AsekoDecoder
@@ -175,7 +176,7 @@ def test_decode_filtration_period2_disabled() -> None:
     # is not active.
     assert device.start2 == time(14, 0)
     assert device.stop2 == time(16, 0)
-    assert device.filtration_mode == AsekoFiltrationMode.TIMER_PERIOD_1
+    assert device.filtration_schedule == AsekoFiltrationSchedule.TIMER_PERIOD_1
 
 
 def test_decode_filtration_period2_enabled() -> None:
@@ -187,7 +188,7 @@ def test_decode_filtration_period2_enabled() -> None:
 
     assert device.start2 == time(14, 0)
     assert device.stop2 == time(16, 0)
-    assert device.filtration_mode == AsekoFiltrationMode.TIMER_PERIOD_1_AND_2
+    assert device.filtration_schedule == AsekoFiltrationSchedule.TIMER_PERIOD_1_AND_2
 
 
 def test_decode_filtration_period2_bytes_unspecified() -> None:
@@ -264,9 +265,9 @@ def test_decode_filtration_period2_real_dtpugh_frames() -> None:
         return None
 
     scenarios = {
-        "01_p1only.json": (0x11, AsekoFiltrationMode.TIMER_PERIOD_1),
-        "02_p1andp2.json": (0x31, AsekoFiltrationMode.TIMER_PERIOD_1_AND_2),
-        "03_24h.json": (0x01, AsekoFiltrationMode.NONSTOP_24H),
+        "01_p1only.json": (0x11, AsekoFiltrationSchedule.TIMER_PERIOD_1),
+        "02_p1andp2.json": (0x31, AsekoFiltrationSchedule.TIMER_PERIOD_1_AND_2),
+        "03_24h.json": (0x01, AsekoFiltrationSchedule.NONSTOP_24H),
         "04_off.json": (0x35, AsekoFiltrationMode.MANUAL),
     }
 
@@ -1065,7 +1066,7 @@ def test_decode_home_clf_real_frame() -> None:
     # Period 2 times.  Pre-fix, the assertions below were ``is None``.
     assert device.start2 == time(18, 0)
     assert device.stop2 == time(22, 0)
-    assert device.filtration_mode == AsekoFiltrationMode.NONSTOP_24H
+    assert device.filtration_schedule == AsekoFiltrationSchedule.NONSTOP_24H
     # Backwash
     assert device.backwash_every_n_days == 3
     assert device.backwash_time == time(21, 0)
@@ -1336,40 +1337,27 @@ def test_water_level_decoded_for_oxy_and_salt() -> None:
         assert device.water_level_high_alarm == 15, f"byte[4]={device_byte:#x}"
 
 
-def test_filtration_nonstop24_none_for_net() -> None:
-    """filtration_nonstop24 is None for NET only (no filtration output).
+def test_filtration_mode_nonstop_decoded_for_all_device_types() -> None:
+    """Nonstop decodes the same on every device type that has filtration.
 
-    Issue #133 follow-up: SALT / OXY / PROFI now also expose a filtration
-    mode. NET is the only AsekoDeviceType that has no filtration output
-    (Issue #66), so the legacy boolean stays None on NET.
+    byte[37] = 0x01 (firmware B "nonstop 24h") → NONSTOP_24H on SALT, OXY,
+    PROFI and HOME alike.  NET has no filtration output (Issue #66) and is
+    the only type left as None.
     """
-    data = _make_base_bytes()
-    data[4] = 0x09  # NET
-    data[37] = 0xFF  # NET byte 37 is always unspecified
-
-    device = AsekoDecoder.decode(bytes(data))
-    assert device.filtration_nonstop24 is None
-
-
-def test_filtration_nonstop24_decoded_for_all_device_types() -> None:
-    """filtration_nonstop24 mirrors the byte[37] filtration_mode flag for every
-    FILTRATION_TYPES device; NET has no filtration output and stays None.
-
-    byte[37] = 0x01 (firmware B "nonstop 24h") → NONSTOP_24H → the legacy
-    boolean reads True on SALT, OXY, PROFI and HOME alike.
-    """
-    # NET: no filtration output → legacy boolean stays None
     data = _make_base_bytes()
     data[4] = 0x09  # NET
     data[37] = 0xFF
-    assert AsekoDecoder.decode(bytes(data)).filtration_nonstop24 is None
+    assert AsekoDecoder.decode(bytes(data)).filtration_mode is None
 
-    # SALT / OXY / PROFI / HOME: byte[37] = 0x01 → NONSTOP_24H
     for device_byte in (0x0E, 0x05, 0x10, 0x03):  # SALT, OXY, PROFI, HOME
         data = _make_base_bytes()
         data[4] = device_byte
         data[37] = 0x01  # firmware B: nonstop 24h
-        assert AsekoDecoder.decode(bytes(data)).filtration_nonstop24 is True, (
+        device = AsekoDecoder.decode(bytes(data))
+        assert device.filtration_schedule == AsekoFiltrationSchedule.NONSTOP_24H, (
+            f"byte[4]={device_byte:#x}"
+        )
+        assert device.filtration_schedule == AsekoFiltrationSchedule.NONSTOP_24H, (
             f"byte[4]={device_byte:#x}"
         )
 
@@ -1391,23 +1379,6 @@ def test_alarms_decoded_for_all_device_types() -> None:
         assert device.alarm_rapid_ph_change is False, f"byte[4]={device_byte:#x}"
 
 
-def test_home_filtration_nonstop24() -> None:
-    """byte[37] filtration mode: 0x43 = nonstop, 0x53 = timer, others = None."""
-    data = _make_home_bytes()
-
-    data[37] = 0x43  # nonstop 24 h
-    assert AsekoDecoder.decode(bytes(data)).filtration_nonstop24 is True
-
-    data[37] = 0x53  # timer mode
-    assert AsekoDecoder.decode(bytes(data)).filtration_nonstop24 is False
-
-    data[37] = 0x47  # transitional edit state → None
-    assert AsekoDecoder.decode(bytes(data)).filtration_nonstop24 is None
-
-    data[37] = 0x57  # transitional edit state → None
-    assert AsekoDecoder.decode(bytes(data)).filtration_nonstop24 is None
-
-
 # ── Issue #133: HOME v7 firmware B (4-state enum + manual OFF override) ──────
 
 
@@ -1416,8 +1387,7 @@ def test_filtration_mode_new_encoding_24h() -> None:
     data = _make_home_bytes()
     data[37] = 0x01  # new encoding: nonstop 24h
     device = AsekoDecoder.decode(bytes(data))
-    assert device.filtration_mode == AsekoFiltrationMode.NONSTOP_24H
-    assert device.filtration_nonstop24 is True  # legacy mirror
+    assert device.filtration_schedule == AsekoFiltrationSchedule.NONSTOP_24H
 
 
 def test_filtration_mode_new_encoding_p1() -> None:
@@ -1425,8 +1395,7 @@ def test_filtration_mode_new_encoding_p1() -> None:
     data = _make_home_bytes()
     data[37] = 0x11  # new encoding: P1 only
     device = AsekoDecoder.decode(bytes(data))
-    assert device.filtration_mode == AsekoFiltrationMode.TIMER_PERIOD_1
-    assert device.filtration_nonstop24 is False
+    assert device.filtration_schedule == AsekoFiltrationSchedule.TIMER_PERIOD_1
 
 
 def test_filtration_mode_new_encoding_p1_and_p2() -> None:
@@ -1434,8 +1403,7 @@ def test_filtration_mode_new_encoding_p1_and_p2() -> None:
     data = _make_home_bytes()
     data[37] = 0x31  # new encoding: P1 & P2
     device = AsekoDecoder.decode(bytes(data))
-    assert device.filtration_mode == AsekoFiltrationMode.TIMER_PERIOD_1_AND_2
-    assert device.filtration_nonstop24 is False
+    assert device.filtration_schedule == AsekoFiltrationSchedule.TIMER_PERIOD_1_AND_2
 
 
 def test_filtration_mode_new_encoding_manual_p1_and_p2() -> None:
@@ -1448,7 +1416,6 @@ def test_filtration_mode_new_encoding_manual_p1_and_p2() -> None:
     data[37] = 0x35  # new encoding: P1 & P2 + manual override (bit 2 set)
     device = AsekoDecoder.decode(bytes(data))
     assert device.filtration_mode == AsekoFiltrationMode.MANUAL
-    assert device.filtration_nonstop24 is False
 
 
 def test_filtration_mode_new_encoding_manual_p1_only() -> None:
@@ -1462,7 +1429,6 @@ def test_filtration_mode_new_encoding_manual_p1_only() -> None:
     data[37] = 0x15  # P1 + manual override
     device = AsekoDecoder.decode(bytes(data))
     assert device.filtration_mode == AsekoFiltrationMode.MANUAL
-    assert device.filtration_nonstop24 is False
 
 
 def test_filtration_mode_old_encoding_24h() -> None:
@@ -1470,8 +1436,7 @@ def test_filtration_mode_old_encoding_24h() -> None:
     data = _make_home_bytes()
     data[37] = 0x43
     device = AsekoDecoder.decode(bytes(data))
-    assert device.filtration_mode == AsekoFiltrationMode.NONSTOP_24H
-    assert device.filtration_nonstop24 is True
+    assert device.filtration_schedule == AsekoFiltrationSchedule.NONSTOP_24H
 
 
 def test_filtration_mode_old_encoding_timer() -> None:
@@ -1479,8 +1444,7 @@ def test_filtration_mode_old_encoding_timer() -> None:
     data = _make_home_bytes()
     data[37] = 0x53
     device = AsekoDecoder.decode(bytes(data))
-    assert device.filtration_mode == AsekoFiltrationMode.TIMER_PERIOD_1_AND_2
-    assert device.filtration_nonstop24 is False
+    assert device.filtration_schedule == AsekoFiltrationSchedule.TIMER_PERIOD_1_AND_2
 
 
 def test_filtration_mode_old_encoding_transitional() -> None:
@@ -1490,7 +1454,6 @@ def test_filtration_mode_old_encoding_transitional() -> None:
         data[37] = transitional
         device = AsekoDecoder.decode(bytes(data))
         assert device.filtration_mode is None
-        assert device.filtration_nonstop24 is None
 
 
 def test_filtration_mode_unspecified() -> None:
@@ -1499,7 +1462,6 @@ def test_filtration_mode_unspecified() -> None:
     data[37] = 0xFF
     device = AsekoDecoder.decode(bytes(data))
     assert device.filtration_mode is None
-    assert device.filtration_nonstop24 is None
 
 
 def test_filtration_mode_none_for_net() -> None:
@@ -1528,9 +1490,9 @@ def test_filtration_mode_byte37_flags_for_salt_oxy_profi() -> None:
         data[4] = device_byte
         data[37] = 0x31  # firmware B: P1 & P2
         device = AsekoDecoder.decode(bytes(data))
-        assert device.filtration_mode == AsekoFiltrationMode.TIMER_PERIOD_1_AND_2, (
-            f"byte[4]={device_byte:#x}"
-        )
+        assert (
+            device.filtration_schedule == AsekoFiltrationSchedule.TIMER_PERIOD_1_AND_2
+        ), f"byte[4]={device_byte:#x}"
 
 
 def test_filtration_mode_salt_p1_only_when_period2_disabled() -> None:
@@ -1545,7 +1507,7 @@ def test_filtration_mode_salt_p1_only_when_period2_disabled() -> None:
     data[37] = 0x93  # bit 0x20 clear, period 2 disabled
 
     device = AsekoDecoder.decode(bytes(data))
-    assert device.filtration_mode == AsekoFiltrationMode.TIMER_PERIOD_1
+    assert device.filtration_schedule == AsekoFiltrationSchedule.TIMER_PERIOD_1
 
 
 def test_filtration_mode_salt_byte37_nonstop() -> None:
@@ -1561,7 +1523,7 @@ def test_filtration_mode_salt_byte37_nonstop() -> None:
     data[37] = 0x01  # firmware B: nonstop 24h
 
     device = AsekoDecoder.decode(bytes(data))
-    assert device.filtration_mode == AsekoFiltrationMode.NONSTOP_24H
+    assert device.filtration_schedule == AsekoFiltrationSchedule.NONSTOP_24H
 
 
 def test_filtration_pump_running_off_when_manual_override() -> None:
@@ -1598,7 +1560,7 @@ def test_filtration_pump_running_on_when_not_override() -> None:
     data[37] = 0x11  # P1 only — pump should be on per the schedule
 
     device = AsekoDecoder.decode(bytes(data))
-    assert device.filtration_mode == AsekoFiltrationMode.TIMER_PERIOD_1
+    assert device.filtration_schedule == AsekoFiltrationSchedule.TIMER_PERIOD_1
     assert device.filtration_pump_running is True
 
 
@@ -2005,7 +1967,9 @@ def test_home_issue_110_frame() -> None:
     assert device.water_level == 14  # byte[27] = 0x0e confirmed
     assert device.water_flow_to_probes is True  # byte[28] = 0xAA
     assert device.water_filling_active is False  # byte[29] = 0x08, bit 0x02 not set
-    assert device.filtration_nonstop24 is False  # byte[37] = 0x53 = timer mode
+    assert (
+        device.filtration_schedule == AsekoFiltrationSchedule.TIMER_PERIOD_1_AND_2
+    )  # byte[37] = 0x53
     assert device.water_level_low_alarm == 9  # byte[102]
     assert device.water_level_filling_on == 11  # byte[103]
     assert device.water_level_filling_off == 13  # byte[104]
@@ -2023,18 +1987,28 @@ def test_home_issue_110_frame() -> None:
 
 
 @pytest.mark.parametrize(
-    ("byte37", "expected_mode", "nonstop"),
+    ("byte37", "expected_mode", "expected_schedule"),
     [
-        (0xC3, AsekoFiltrationMode.NONSTOP_24H, True),
-        (0xD3, AsekoFiltrationMode.TIMER_PERIOD_1, False),
-        (0xF3, AsekoFiltrationMode.TIMER_PERIOD_1_AND_2, False),
-        (0xC7, AsekoFiltrationMode.MANUAL, False),
-        (0xD7, AsekoFiltrationMode.MANUAL, False),
-        (0xF7, AsekoFiltrationMode.MANUAL, False),
+        (0xC3, AsekoFiltrationMode.SCHEDULE, AsekoFiltrationSchedule.NONSTOP_24H),
+        (0xD3, AsekoFiltrationMode.SCHEDULE, AsekoFiltrationSchedule.TIMER_PERIOD_1),
+        (
+            0xF3,
+            AsekoFiltrationMode.SCHEDULE,
+            AsekoFiltrationSchedule.TIMER_PERIOD_1_AND_2,
+        ),
+        (0xC7, AsekoFiltrationMode.MANUAL, AsekoFiltrationSchedule.NONSTOP_24H),
+        (0xD7, AsekoFiltrationMode.MANUAL, AsekoFiltrationSchedule.TIMER_PERIOD_1),
+        (
+            0xF7,
+            AsekoFiltrationMode.MANUAL,
+            AsekoFiltrationSchedule.TIMER_PERIOD_1_AND_2,
+        ),
     ],
 )
 def test_filtration_mode_salt_uses_the_firmware_b_bits(
-    byte37: int, expected_mode: AsekoFiltrationMode, nonstop: bool
+    byte37: int,
+    expected_mode: AsekoFiltrationMode,
+    expected_schedule: AsekoFiltrationSchedule,
 ) -> None:
     """SALT carries the mode in the same bits as HOME firmware B.
 
@@ -2047,7 +2021,8 @@ def test_filtration_mode_salt_uses_the_firmware_b_bits(
 
     Note 0xF7 is MANUAL, not two filtration periods: bit 0x04 is set, and
     whatever was configured stays underneath it.  The same goes for 0xC7,
-    which is manual mode entered from nonstop.
+    which is manual mode entered from nonstop — hence the second column:
+    the schedule is reported alongside the mode, not replaced by it.
     """
     data = _make_base_bytes()  # SALT
     data[37] = byte37
@@ -2058,7 +2033,7 @@ def test_filtration_mode_salt_uses_the_firmware_b_bits(
 
     assert device.device_type == AsekoDeviceType.SALT
     assert device.filtration_mode == expected_mode
-    assert device.filtration_nonstop24 is nonstop
+    assert device.filtration_schedule == expected_schedule
 
 
 def test_filtration_mode_salt_unknown_bits_stay_unknown() -> None:
@@ -2077,7 +2052,7 @@ def test_filtration_mode_salt_unknown_bits_stay_unknown() -> None:
 
     assert device.device_type == AsekoDeviceType.SALT
     assert device.filtration_mode is None
-    assert device.filtration_nonstop24 is None
+    assert device.filtration_schedule is None
 
 
 def test_filtration_mode_home_transitional_still_suppressed() -> None:
@@ -2093,4 +2068,31 @@ def test_filtration_mode_home_transitional_still_suppressed() -> None:
 
     assert device.device_type == AsekoDeviceType.HOME
     assert device.filtration_mode is None
-    assert device.filtration_nonstop24 is None
+
+
+def test_filtration_schedule_survives_manual_mode() -> None:
+    """Manual mode hides the schedule from filtration_mode, not from the unit.
+
+    Going into manual mode and back out again is the same schedule throughout
+    — 0xC3 -> 0xC7 -> 0xC3 on a captured SALT — so filtration_schedule must
+    read the same in all three, even though filtration_mode does not.
+
+    This is what makes the schedule usable on a dashboard while the override
+    is on: it can be shown greyed out rather than disappearing.
+    """
+    data = _make_base_bytes()  # SALT
+
+    schedules = []
+    modes = []
+    for byte37 in (0xC3, 0xC7, 0xC3):
+        data[37] = byte37
+        device = AsekoDecoder.decode(bytes(data))
+        schedules.append(device.filtration_schedule)
+        modes.append(device.filtration_mode)
+
+    assert schedules == [AsekoFiltrationSchedule.NONSTOP_24H] * 3
+    assert modes == [
+        AsekoFiltrationMode.SCHEDULE,
+        AsekoFiltrationMode.MANUAL,
+        AsekoFiltrationMode.SCHEDULE,
+    ]

--- a/tests/test_aseko_decoder.py
+++ b/tests/test_aseko_decoder.py
@@ -7,7 +7,6 @@ import pytest
 from custom_components.aseko_local.aseko_data import (
     AsekoDeviceType,
     AsekoElectrolyzerDirection,
-    AsekoFiltrationMode,
     AsekoFiltrationSchedule,
     AsekoProbeType,
 )
@@ -270,29 +269,29 @@ def test_decode_filtration_period2_real_dtpugh_frames() -> None:
         "01_p1only.json": (
             0x11,
             AsekoFiltrationSchedule.TIMER_PERIOD_1,
-            AsekoFiltrationMode.SCHEDULE,
+            False,
         ),
         "02_p1andp2.json": (
             0x31,
             AsekoFiltrationSchedule.TIMER_PERIOD_1_AND_2,
-            AsekoFiltrationMode.SCHEDULE,
+            False,
         ),
         "03_24h.json": (
             0x01,
             AsekoFiltrationSchedule.NONSTOP_24H,
-            AsekoFiltrationMode.SCHEDULE,
+            False,
         ),
         "04_off.json": (
             0x35,
             AsekoFiltrationSchedule.TIMER_PERIOD_1_AND_2,
-            AsekoFiltrationMode.SERVICE_MENU,
+            True,
         ),
     }
 
     for filename, (
         expected_b37,
         expected_schedule,
-        expected_mode,
+        expected_menu,
     ) in scenarios.items():
         with open(diag_dir / filename) as f:
             frame = bytes.fromhex(_first_frame(json.load(f)))
@@ -314,9 +313,9 @@ def test_decode_filtration_period2_real_dtpugh_frames() -> None:
             f"{filename}: expected {expected_schedule}, "
             f"got {device.filtration_schedule}"
         )
-        # ...and the mode entity whether it is the one in charge.
-        assert device.filtration_mode == expected_mode, (
-            f"{filename}: expected {expected_mode}, got {device.filtration_mode}"
+        # ...and the service-menu flag whether anybody was at the unit.
+        assert device.service_menu_open is expected_menu, (
+            f"{filename}: expected {expected_menu}, got {device.service_menu_open}"
         )
 
 
@@ -1364,7 +1363,7 @@ def test_water_level_decoded_for_oxy_and_salt() -> None:
         assert device.water_level_high_alarm == 15, f"byte[4]={device_byte:#x}"
 
 
-def test_filtration_mode_nonstop_decoded_for_all_device_types() -> None:
+def test_filtration_schedule_nonstop_decoded_for_all_device_types() -> None:
     """Nonstop decodes the same on every device type that has filtration.
 
     byte[37] = 0x01 (firmware B "nonstop 24h") → NONSTOP_24H on SALT, OXY,
@@ -1374,7 +1373,7 @@ def test_filtration_mode_nonstop_decoded_for_all_device_types() -> None:
     data = _make_base_bytes()
     data[4] = 0x09  # NET
     data[37] = 0xFF
-    assert AsekoDecoder.decode(bytes(data)).filtration_mode is None
+    assert AsekoDecoder.decode(bytes(data)).filtration_schedule is None
 
     for device_byte in (0x0E, 0x05, 0x10, 0x03):  # SALT, OXY, PROFI, HOME
         data = _make_base_bytes()
@@ -1409,7 +1408,7 @@ def test_alarms_decoded_for_all_device_types() -> None:
 # ── Issue #133: HOME v7 firmware B (4-state enum + manual OFF override) ──────
 
 
-def test_filtration_mode_new_encoding_24h() -> None:
+def test_filtration_schedule_new_encoding_24h() -> None:
     """Firmware B byte[37] = 0x01 → NONSTOP_24H (serial 110169464)."""
     data = _make_home_bytes()
     data[37] = 0x01  # new encoding: nonstop 24h
@@ -1417,7 +1416,7 @@ def test_filtration_mode_new_encoding_24h() -> None:
     assert device.filtration_schedule == AsekoFiltrationSchedule.NONSTOP_24H
 
 
-def test_filtration_mode_new_encoding_p1() -> None:
+def test_filtration_schedule_new_encoding_p1() -> None:
     """Firmware B byte[37] = 0x11 → TIMER_PERIOD_1 (P1 only, P2 disabled)."""
     data = _make_home_bytes()
     data[37] = 0x11  # new encoding: P1 only
@@ -1425,7 +1424,7 @@ def test_filtration_mode_new_encoding_p1() -> None:
     assert device.filtration_schedule == AsekoFiltrationSchedule.TIMER_PERIOD_1
 
 
-def test_filtration_mode_new_encoding_p1_and_p2() -> None:
+def test_filtration_schedule_new_encoding_p1_and_p2() -> None:
     """Firmware B byte[37] = 0x31 → TIMER_PERIOD_1_AND_2 (both periods)."""
     data = _make_home_bytes()
     data[37] = 0x31  # new encoding: P1 & P2
@@ -1433,7 +1432,7 @@ def test_filtration_mode_new_encoding_p1_and_p2() -> None:
     assert device.filtration_schedule == AsekoFiltrationSchedule.TIMER_PERIOD_1_AND_2
 
 
-def test_filtration_mode_new_encoding_manual_p1_and_p2() -> None:
+def test_service_menu_new_encoding_p1_and_p2() -> None:
     """Firmware B byte[37] = 0x35 → MANUAL (P1 & P2 + manual override).
 
     The original frame from @dtpugh (serial 110169464) had 0x35: both
@@ -1442,10 +1441,10 @@ def test_filtration_mode_new_encoding_manual_p1_and_p2() -> None:
     data = _make_home_bytes()
     data[37] = 0x35  # new encoding: P1 & P2 + manual override (bit 2 set)
     device = AsekoDecoder.decode(bytes(data))
-    assert device.filtration_mode == AsekoFiltrationMode.SERVICE_MENU
+    assert device.service_menu_open is True
 
 
-def test_filtration_mode_new_encoding_manual_p1_only() -> None:
+def test_service_menu_new_encoding_p1_only() -> None:
     """Firmware B byte[37] = 0x15 → MANUAL (P1 only + manual override).
 
     Diagnostic 42 from @dtpugh (serial 110175608): user switched to manual
@@ -1455,10 +1454,10 @@ def test_filtration_mode_new_encoding_manual_p1_only() -> None:
     data = _make_home_bytes()
     data[37] = 0x15  # P1 + manual override
     device = AsekoDecoder.decode(bytes(data))
-    assert device.filtration_mode == AsekoFiltrationMode.SERVICE_MENU
+    assert device.service_menu_open is True
 
 
-def test_filtration_mode_old_encoding_24h() -> None:
+def test_filtration_schedule_old_encoding_24h() -> None:
     """Firmware A byte[37] = 0x43 → NONSTOP_24H (serial 110128063)."""
     data = _make_home_bytes()
     data[37] = 0x43
@@ -1466,7 +1465,7 @@ def test_filtration_mode_old_encoding_24h() -> None:
     assert device.filtration_schedule == AsekoFiltrationSchedule.NONSTOP_24H
 
 
-def test_filtration_mode_old_encoding_timer() -> None:
+def test_filtration_schedule_old_encoding_timer() -> None:
     """Firmware A byte[37] = 0x53 → TIMER_PERIOD_1_AND_2 (cannot distinguish P1 vs P1&P2)."""
     data = _make_home_bytes()
     data[37] = 0x53
@@ -1474,28 +1473,28 @@ def test_filtration_mode_old_encoding_timer() -> None:
     assert device.filtration_schedule == AsekoFiltrationSchedule.TIMER_PERIOD_1_AND_2
 
 
-def test_filtration_mode_old_encoding_transitional() -> None:
+def test_filtration_schedule_old_encoding_transitional() -> None:
     """Firmware A byte[37] = 0x47 / 0x57 → leave as None (transitional edit state)."""
     for transitional in (0x47, 0x57):
         data = _make_home_bytes()
         data[37] = transitional
         device = AsekoDecoder.decode(bytes(data))
-        assert device.filtration_mode is None
+        assert device.filtration_schedule is None
 
 
-def test_filtration_mode_unspecified() -> None:
+def test_filtration_schedule_unspecified() -> None:
     """byte[37] = 0xFF → None (defensive, also covers NET-like values on HOME)."""
     data = _make_home_bytes()
     data[37] = 0xFF
     device = AsekoDecoder.decode(bytes(data))
-    assert device.filtration_mode is None
+    assert device.filtration_schedule is None
 
 
-def test_filtration_mode_none_for_net() -> None:
-    """filtration_mode stays None for NET — no filtration output (Issue #66).
+def test_filtration_schedule_none_for_net() -> None:
+    """filtration_schedule stays None for NET — no filtration output (Issue #66).
 
     NET is the only AsekoDeviceType excluded from FILTRATION_TYPES, so the
-    decoder returns without setting filtration_mode. SALT, HOME, OXY and
+    decoder returns without setting filtration_schedule. SALT, HOME, OXY and
     PROFI all populate the field.
     """
     data = _make_base_bytes()
@@ -1503,10 +1502,10 @@ def test_filtration_mode_none_for_net() -> None:
     data[37] = 0xFF  # NET byte 37 is always unspecified
     device = AsekoDecoder.decode(bytes(data))
     assert device.device_type == AsekoDeviceType.NET
-    assert device.filtration_mode is None
+    assert device.filtration_schedule is None
 
 
-def test_filtration_mode_byte37_flags_for_salt_oxy_profi() -> None:
+def test_filtration_schedule_byte37_flags_for_salt_oxy_profi() -> None:
     """SALT / OXY / PROFI decode the byte[37] mode flag exactly like HOME.
 
     byte[37] = 0x31 (firmware B: P1 & P2) → TIMER_PERIOD_1_AND_2 for every
@@ -1522,11 +1521,11 @@ def test_filtration_mode_byte37_flags_for_salt_oxy_profi() -> None:
         ), f"byte[4]={device_byte:#x}"
 
 
-def test_filtration_mode_salt_p1_only_when_period2_disabled() -> None:
+def test_filtration_schedule_salt_p1_only_when_period2_disabled() -> None:
     """SALT with byte[37] bit 0x20 clear (period-2 disabled) → TIMER_PERIOD_1.
 
     Mirrors test_decode_filtration_period2_disabled but checks the new
-    `filtration_mode` enum (not the legacy boolean).
+    `filtration_schedule` enum (not the legacy boolean).
     """
     data = _make_base_bytes()
     data[4] = 0x0E  # SALT
@@ -1537,7 +1536,7 @@ def test_filtration_mode_salt_p1_only_when_period2_disabled() -> None:
     assert device.filtration_schedule == AsekoFiltrationSchedule.TIMER_PERIOD_1
 
 
-def test_filtration_mode_salt_byte37_nonstop() -> None:
+def test_filtration_schedule_salt_byte37_nonstop() -> None:
     """SALT decodes NONSTOP_24H from byte[37] = 0x01 even with no schedule.
 
     The mode now comes from the byte[37] flag, not from the schedule bytes
@@ -1573,9 +1572,7 @@ def test_filtration_pump_running_off_when_manual_override() -> None:
         data[37] = override_value  # OFF (manual override)
 
         device = AsekoDecoder.decode(bytes(data))
-        assert device.filtration_mode == AsekoFiltrationMode.SERVICE_MENU, (
-            f"byte[37]={override_value:#x}"
-        )
+        assert device.service_menu_open is True, f"byte[37]={override_value:#x}"
         assert device.filtration_pump_running is False, f"byte[37]={override_value:#x}"
 
 
@@ -1605,7 +1602,7 @@ def test_filtration_pump_running_not_overridden_on_salt() -> None:
     data[37] = 0x35  # firmware B: P1 & P2 + manual override → MANUAL
 
     device = AsekoDecoder.decode(bytes(data))
-    assert device.filtration_mode == AsekoFiltrationMode.SERVICE_MENU
+    assert device.service_menu_open is True
     assert device.filtration_pump_running is True  # unchanged: byte[29] bit 3 wins
 
 
@@ -2014,31 +2011,31 @@ def test_home_issue_110_frame() -> None:
 
 
 @pytest.mark.parametrize(
-    ("byte37", "expected_mode", "expected_schedule"),
+    ("byte37", "expected_menu", "expected_schedule"),
     [
-        (0xC3, AsekoFiltrationMode.SCHEDULE, AsekoFiltrationSchedule.NONSTOP_24H),
-        (0xD3, AsekoFiltrationMode.SCHEDULE, AsekoFiltrationSchedule.TIMER_PERIOD_1),
+        (0xC3, False, AsekoFiltrationSchedule.NONSTOP_24H),
+        (0xD3, False, AsekoFiltrationSchedule.TIMER_PERIOD_1),
         (
             0xF3,
-            AsekoFiltrationMode.SCHEDULE,
+            False,
             AsekoFiltrationSchedule.TIMER_PERIOD_1_AND_2,
         ),
-        (0xC7, AsekoFiltrationMode.SERVICE_MENU, AsekoFiltrationSchedule.NONSTOP_24H),
+        (0xC7, True, AsekoFiltrationSchedule.NONSTOP_24H),
         (
             0xD7,
-            AsekoFiltrationMode.SERVICE_MENU,
+            True,
             AsekoFiltrationSchedule.TIMER_PERIOD_1,
         ),
         (
             0xF7,
-            AsekoFiltrationMode.SERVICE_MENU,
+            True,
             AsekoFiltrationSchedule.TIMER_PERIOD_1_AND_2,
         ),
     ],
 )
-def test_filtration_mode_salt_uses_the_firmware_b_bits(
+def test_filtration_schedule_salt_uses_the_firmware_b_bits(
     byte37: int,
-    expected_mode: AsekoFiltrationMode,
+    expected_menu: bool,
     expected_schedule: AsekoFiltrationSchedule,
 ) -> None:
     """SALT carries the mode in the same bits as HOME firmware B.
@@ -2063,11 +2060,11 @@ def test_filtration_mode_salt_uses_the_firmware_b_bits(
     device = AsekoDecoder.decode(bytes(data))
 
     assert device.device_type == AsekoDeviceType.SALT
-    assert device.filtration_mode == expected_mode
+    assert device.service_menu_open is expected_menu
     assert device.filtration_schedule == expected_schedule
 
 
-def test_filtration_mode_salt_unknown_bits_stay_unknown() -> None:
+def test_filtration_schedule_salt_unknown_bits_stay_unknown() -> None:
     """An unrecognised SALT value yields no mode rather than a guess.
 
     The schedule-derived fallback is HOME-only: SALT reports the filtration
@@ -2082,11 +2079,11 @@ def test_filtration_mode_salt_unknown_bits_stay_unknown() -> None:
     device = AsekoDecoder.decode(bytes(data))
 
     assert device.device_type == AsekoDeviceType.SALT
-    assert device.filtration_mode is None
+    assert device.filtration_schedule is None
     assert device.filtration_schedule is None
 
 
-def test_filtration_mode_home_transitional_still_suppressed() -> None:
+def test_filtration_schedule_home_transitional_still_suppressed() -> None:
     """The transitional check keeps working where it came from.
 
     0x47 is a half-finished edit on HOME firmware A: no mode should be
@@ -2098,16 +2095,15 @@ def test_filtration_mode_home_transitional_still_suppressed() -> None:
     device = AsekoDecoder.decode(bytes(data))
 
     assert device.device_type == AsekoDeviceType.HOME
-    assert device.filtration_mode is None
+    assert device.filtration_schedule is None
 
 
 def test_filtration_schedule_survives_the_service_menu() -> None:
-    """The settings menu hides the schedule from filtration_mode, not from
-    the unit.
+    """Opening the settings menu does not disturb the schedule.
 
-    Opening the menu and leaving it again is the same schedule throughout —
-    0xC3 -> 0xC7 -> 0xC3 on a captured SALT — so filtration_schedule must
-    read the same in all three, even though filtration_mode does not.
+    Opening it and leaving again is the same schedule throughout —
+    0xC3 -> 0xC7 -> 0xC3 on a captured SALT — so filtration_schedule reads
+    the same in all three while service_menu_open flips.
 
     This is what makes the schedule usable on a dashboard while the override
     is on: it can be shown greyed out rather than disappearing.
@@ -2115,16 +2111,12 @@ def test_filtration_schedule_survives_the_service_menu() -> None:
     data = _make_base_bytes()  # SALT
 
     schedules = []
-    modes = []
+    menus = []
     for byte37 in (0xC3, 0xC7, 0xC3):
         data[37] = byte37
         device = AsekoDecoder.decode(bytes(data))
         schedules.append(device.filtration_schedule)
-        modes.append(device.filtration_mode)
+        menus.append(device.service_menu_open)
 
     assert schedules == [AsekoFiltrationSchedule.NONSTOP_24H] * 3
-    assert modes == [
-        AsekoFiltrationMode.SCHEDULE,
-        AsekoFiltrationMode.SERVICE_MENU,
-        AsekoFiltrationMode.SCHEDULE,
-    ]
+    assert menus == [False, True, False]

--- a/tests/test_aseko_decoder.py
+++ b/tests/test_aseko_decoder.py
@@ -2017,3 +2017,80 @@ def test_home_issue_110_frame() -> None:
     # 94-95 — that is flowrate_ph_minus, and the unit happened to run a
     # 60 ml/min pH- pump alongside a 60 min filling limit.
     assert device.max_filling_time == 0  # 0x0000 from the placeholder segment
+
+
+# ── byte[37] firmware-A fallback is HOME-only ────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("byte37", "expected_mode", "nonstop"),
+    [
+        (0xC3, AsekoFiltrationMode.NONSTOP_24H, True),
+        (0xD3, AsekoFiltrationMode.TIMER_PERIOD_1, False),
+        (0xF3, AsekoFiltrationMode.TIMER_PERIOD_1_AND_2, False),
+        (0xC7, AsekoFiltrationMode.MANUAL, False),
+        (0xD7, AsekoFiltrationMode.MANUAL, False),
+        (0xF7, AsekoFiltrationMode.MANUAL, False),
+    ],
+)
+def test_filtration_mode_salt_uses_the_firmware_b_bits(
+    byte37: int, expected_mode: AsekoFiltrationMode, nonstop: bool
+) -> None:
+    """SALT carries the mode in the same bits as HOME firmware B.
+
+    Every value here was captured on an ASIN AQUA Salt while the mode shown
+    on the unit itself was known, in both directions of each transition.
+    The high nibble is SALT's own configuration (0x80 = algicide routing)
+    and bit 0x40 is set in every frame — which is why routing on that bit
+    sent SALT into the HOME firmware-A branch, where it matched none of the
+    exact values and came out with no mode at all.
+
+    Note 0xF7 is MANUAL, not two filtration periods: bit 0x04 is set, and
+    whatever was configured stays underneath it.  The same goes for 0xC7,
+    which is manual mode entered from nonstop.
+    """
+    data = _make_base_bytes()  # SALT
+    data[37] = byte37
+    assert data[56] != 0xFF  # period 1 configured
+    assert data[60] != 0xFF  # period 2 configured
+
+    device = AsekoDecoder.decode(bytes(data))
+
+    assert device.device_type == AsekoDeviceType.SALT
+    assert device.filtration_mode == expected_mode
+    assert device.filtration_nonstop24 is nonstop
+
+
+def test_filtration_mode_salt_unknown_bits_stay_unknown() -> None:
+    """An unrecognised SALT value yields no mode rather than a guess.
+
+    The schedule-derived fallback is HOME-only: SALT reports the filtration
+    times unchanged in every mode, so deriving the mode from them there
+    could only ever return one constant answer regardless of the truth.
+    0xE3 has period 2 set without period 1, which the unit never sends.
+    """
+    data = _make_base_bytes()  # SALT
+    data[37] = 0xE3
+    assert data[56] != 0xFF  # a schedule is present to fall back on
+
+    device = AsekoDecoder.decode(bytes(data))
+
+    assert device.device_type == AsekoDeviceType.SALT
+    assert device.filtration_mode is None
+    assert device.filtration_nonstop24 is None
+
+
+def test_filtration_mode_home_transitional_still_suppressed() -> None:
+    """The transitional check keeps working where it came from.
+
+    0x47 is a half-finished edit on HOME firmware A: no mode should be
+    reported for it, even though the schedule bytes are populated.
+    """
+    data = _make_home_bytes()
+    data[37] = 0x47
+
+    device = AsekoDecoder.decode(bytes(data))
+
+    assert device.device_type == AsekoDeviceType.HOME
+    assert device.filtration_mode is None
+    assert device.filtration_nonstop24 is None

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -7,9 +7,12 @@ from homeassistant.helpers import entity_registry as er
 from custom_components.aseko_local.binary_sensor import (
     async_remove_retired_entities,
     async_setup_entry as binary_async_setup_entry,
+    BINARY_SENSORS,
     AsekoLocalBinarySensorEntity,
 )
 from custom_components.aseko_local.sensor import (
+    RETIRED_UNIQUE_ID_SUFFIXES as RETIRED_SENSOR_IDS,
+    async_remove_retired_entities as async_remove_retired_sensors,
     async_setup_entry,
     AsekoLocalSensorEntity,
     AsekoConsumptionSensorEntity,
@@ -283,12 +286,12 @@ async def test_async_setup_salt_redox(hass) -> None:
     # + 2 new backwash schedule sensors (last_backwash, next_backwash)
     # + 1 new backwash_active binary sensor
     # + 1 new heating_active binary sensor
-    # + 1 new filtration_mode sensor (Issue #133) — SALT has filtration
-    # The legacy filtration_nonstop24 binary sensor is gone: filtration_mode
-    # reports all four modes, so it said nothing new.  -1 entity.
-    # + 1 filtration_schedule sensor: byte[37] carries a schedule and a manual
-    #   override, and one value cannot report both.  filtration_mode says which
-    #   of the two is in charge; filtration_schedule says which schedule.
+    # byte[37] reshuffle, net zero:
+    #   -1 filtration_nonstop24 binary sensor (the schedule sensor covers it)
+    #   -1 filtration_mode sensor (it conflated the schedule with bit 0x04)
+    #   +1 filtration_schedule sensor  — what the unit runs unattended
+    #   +1 service_menu binary sensor  — bit 0x04, a device state, not a
+    #      filtration one
     assert len(added_entities) == 40
     assert any(
         getattr(e.entity_description, "key", None) != "water_flow_to_probes"
@@ -396,12 +399,12 @@ async def test_async_setup_salt_clf(hass) -> None:
     # + 2 new backwash schedule sensors (last_backwash, next_backwash)
     # + 1 new backwash_active binary sensor
     # + 1 new heating_active binary sensor
-    # + 1 new filtration_mode sensor (Issue #133) — SALT has filtration
-    # The legacy filtration_nonstop24 binary sensor is gone: filtration_mode
-    # reports all four modes, so it said nothing new.  -1 entity.
-    # + 1 filtration_schedule sensor: byte[37] carries a schedule and a manual
-    #   override, and one value cannot report both.  filtration_mode says which
-    #   of the two is in charge; filtration_schedule says which schedule.
+    # byte[37] reshuffle, net zero:
+    #   -1 filtration_nonstop24 binary sensor (the schedule sensor covers it)
+    #   -1 filtration_mode sensor (it conflated the schedule with bit 0x04)
+    #   +1 filtration_schedule sensor  — what the unit runs unattended
+    #   +1 service_menu binary sensor  — bit 0x04, a device state, not a
+    #      filtration one
     assert len(added_entities) == 41
     assert any(
         getattr(e.entity_description, "key", None) != "water_flow_to_probes"
@@ -653,13 +656,12 @@ async def test_async_setup_profi_clf_redox(hass) -> None:
     # though bytes 94-95 carry a real value. -1 entity compared to the PR #120
     # baseline.
     #
-    # Issue #133: PROFI is in FILTRATION_TYPES, so the new filtration_mode
-    # sensor is now created. +1 entity compared to the PR #120 baseline.
-    # The legacy filtration_nonstop24 binary sensor is gone: filtration_mode
-    # reports all four modes, so it said nothing new.  -1 entity.
-    # + 1 filtration_schedule sensor: byte[37] carries a schedule and a manual
-    #   override, and one value cannot report both.  filtration_mode says which
-    #   of the two is in charge; filtration_schedule says which schedule.
+    # byte[37] reshuffle, net zero:
+    #   -1 filtration_nonstop24 binary sensor (the schedule sensor covers it)
+    #   -1 filtration_mode sensor (it conflated the schedule with bit 0x04)
+    #   +1 filtration_schedule sensor  — what the unit runs unattended
+    #   +1 service_menu binary sensor  — bit 0x04, a device state, not a
+    #      filtration one
     assert len(added_entities) == 43
     assert any(
         getattr(e.entity_description, "key", None) == "free_chlorine"
@@ -740,7 +742,7 @@ async def test_retired_removal_leaves_other_entities_alone(
     keep_sensor = registry.async_get_or_create(
         "sensor",
         DOMAIN,
-        "1234filtration_mode",
+        "1234filtration_schedule",
         config_entry=mock_config_entry,
     )
 
@@ -773,7 +775,7 @@ async def test_retired_removal_is_idempotent(hass, mock_config_entry) -> None:
     ]
 
 
-# ── filtration mode and schedule as two entities ────────────────────────────
+# ── filtration schedule, and the settings-menu flag beside it ───────────────
 
 
 def _decode_salt(byte37: int):
@@ -784,61 +786,81 @@ def _decode_salt(byte37: int):
 
 
 @pytest.mark.parametrize(
-    ("byte37", "expected_mode", "expected_schedule"),
+    ("byte37", "expected_schedule", "expected_menu"),
     [
-        (0xC3, "schedule", "nonstop_24h"),
-        (0xD3, "schedule", "timer_period_1"),
-        (0xF3, "schedule", "timer_period_1_and_2"),
-        (0xC7, "service_menu", "nonstop_24h"),
-        (0xD7, "service_menu", "timer_period_1"),
-        (0xF7, "service_menu", "timer_period_1_and_2"),
+        (0xC3, "nonstop_24h", False),
+        (0xD3, "timer_period_1", False),
+        (0xF3, "timer_period_1_and_2", False),
+        (0xC7, "nonstop_24h", True),
+        (0xD7, "timer_period_1", True),
+        (0xF7, "timer_period_1_and_2", True),
     ],
 )
-def test_mode_and_schedule_are_each_readable_on_their_own(
-    byte37: int, expected_mode: str, expected_schedule: str
+def test_schedule_and_service_menu_are_independent(
+    byte37: int, expected_schedule: str, expected_menu: bool
 ) -> None:
-    """Both halves of byte[37] stay readable, whatever the other one says.
+    """byte[37] holds two unrelated things, reported by two entities.
 
-    One sensor answers "is anyone at the unit?", the other "which schedule
-    does it run otherwise?".  Reporting them as a single value would drop
-    the schedule exactly when somebody is there — which is the moment it
-    matters, since the unit goes quiet then and this is the last frame you
-    get.
+    The schedule is what the unit runs when nobody is at it.  The service
+    menu says somebody is — and nothing more, because the unit stops
+    transmitting while it is open.  Neither can stand in for the other.
     """
-    mode = next(d for d in SENSORS if d.key == "filtration_mode")
     schedule = next(d for d in SENSORS if d.key == "filtration_schedule")
+    menu = next(d for d in BINARY_SENSORS if d.key == "service_menu")
     device = _decode_salt(byte37)
 
-    assert mode.value_fn(device) == expected_mode
     assert schedule.value_fn(device) == expected_schedule
+    assert menu.value_fn(device) is expected_menu
 
 
-def test_mode_and_schedule_options_do_not_overlap() -> None:
-    """Neither sensor can report the other's states.
+def test_no_filtration_mode_sensor_remains() -> None:
+    """The conflated sensor is gone, and its registry entry with it.
 
-    An ENUM sensor is validated against its options, so this is what stops
-    the two from drifting back together — no "service_menu" among the
-    schedules, no schedule among the modes.
+    It reported a schedule *or* the menu flag, never both, so it could not
+    answer either question reliably.
     """
-    mode = next(d for d in SENSORS if d.key == "filtration_mode")
+    assert not any(d.key == "filtration_mode" for d in SENSORS)
+    assert "filtration_mode" in RETIRED_SENSOR_IDS
+
+
+def test_schedule_and_service_menu_absent_without_filtration() -> None:
+    """NET has no filtration output, so neither entity is created for it."""
     schedule = next(d for d in SENSORS if d.key == "filtration_schedule")
-
-    assert set(mode.options) == {"schedule", "service_menu"}
-    assert set(schedule.options) == {
-        "nonstop_24h",
-        "timer_period_1",
-        "timer_period_1_and_2",
-    }
-    assert not set(mode.options) & set(schedule.options)
-
-
-def test_mode_and_schedule_absent_without_filtration() -> None:
-    """NET has no filtration output, so neither sensor is created for it."""
-    mode = next(d for d in SENSORS if d.key == "filtration_mode")
-    schedule = next(d for d in SENSORS if d.key == "filtration_schedule")
+    menu = next(d for d in BINARY_SENSORS if d.key == "service_menu")
     device = AsekoDecoder.decode(bytes(_make_net_clf_bytes()))
 
     assert device.device_type == AsekoDeviceType.NET
     # A None value is what keeps an entity from being built for a device.
-    assert mode.value_fn(device) is None
     assert schedule.value_fn(device) is None
+    assert menu.value_fn(device) is None
+
+
+@pytest.mark.asyncio
+async def test_retired_filtration_mode_sensor_is_removed(
+    hass, mock_config_entry
+) -> None:
+    """The dropped filtration_mode sensor is deleted from the registry.
+
+    It shipped, so it exists in users' registries.  Dropping the
+    description alone would leave it in the UI as unavailable forever.
+    """
+    registry = er.async_get(hass)
+    retired = registry.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        "1234filtration_mode",
+        config_entry=mock_config_entry,
+        suggested_object_id="aseko_filtration_mode",
+    )
+    kept = registry.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        "1234filtration_schedule",
+        config_entry=mock_config_entry,
+    )
+
+    async_remove_retired_sensors(hass, mock_config_entry)
+    async_remove_retired_sensors(hass, mock_config_entry)
+
+    assert registry.async_get(retired.entity_id) is None
+    assert registry.async_get(kept.entity_id) is not None

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2,8 +2,10 @@ import pytest
 from unittest.mock import MagicMock
 
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers import entity_registry as er
 
 from custom_components.aseko_local.binary_sensor import (
+    async_remove_retired_entities,
     async_setup_entry as binary_async_setup_entry,
     AsekoLocalBinarySensorEntity,
 )
@@ -14,7 +16,11 @@ from custom_components.aseko_local.sensor import (
 )
 from custom_components.aseko_local.aseko_decoder import AsekoDecoder
 
-from custom_components.aseko_local.const import UNIT_TYPE_PROFI, WATER_FLOW_TO_PROBES
+from custom_components.aseko_local.const import (
+    DOMAIN,
+    UNIT_TYPE_PROFI,
+    WATER_FLOW_TO_PROBES,
+)
 from custom_components.aseko_local.aseko_data import AsekoDeviceType
 
 
@@ -232,6 +238,9 @@ async def test_async_setup_salt_redox(hass) -> None:
 
     # Create a MagicMock for ConfigEntry with runtime_data attribute
     dummy_entry = MagicMock(spec=ConfigEntry)
+    # entry_id is an instance attribute, so spec= does not provide it, but
+    # async_setup_entry needs it to clean up retired entities.
+    dummy_entry.entry_id = "test_entry_id"
     dummy_entry.runtime_data = type(
         "RuntimeData", (), {"coordinator": DummyCoordinator()}
     )
@@ -274,7 +283,9 @@ async def test_async_setup_salt_redox(hass) -> None:
     # + 1 new backwash_active binary sensor
     # + 1 new heating_active binary sensor
     # + 1 new filtration_mode sensor (Issue #133) — SALT has filtration
-    assert len(added_entities) == 40
+    # The legacy filtration_nonstop24 binary sensor is gone: filtration_mode
+    # reports all four modes, so it said nothing new.  -1 entity.
+    assert len(added_entities) == 39
     assert any(
         getattr(e.entity_description, "key", None) != "water_flow_to_probes"
         for e in added_entities
@@ -336,6 +347,9 @@ async def test_async_setup_salt_clf(hass) -> None:
 
     # Create a MagicMock for ConfigEntry with runtime_data attribute
     dummy_entry = MagicMock(spec=ConfigEntry)
+    # entry_id is an instance attribute, so spec= does not provide it, but
+    # async_setup_entry needs it to clean up retired entities.
+    dummy_entry.entry_id = "test_entry_id"
     dummy_entry.runtime_data = type(
         "RuntimeData", (), {"coordinator": DummyCoordinator()}
     )
@@ -379,7 +393,9 @@ async def test_async_setup_salt_clf(hass) -> None:
     # + 1 new backwash_active binary sensor
     # + 1 new heating_active binary sensor
     # + 1 new filtration_mode sensor (Issue #133) — SALT has filtration
-    assert len(added_entities) == 41
+    # The legacy filtration_nonstop24 binary sensor is gone: filtration_mode
+    # reports all four modes, so it said nothing new.  -1 entity.
+    assert len(added_entities) == 40
     assert any(
         getattr(e.entity_description, "key", None) != "water_flow_to_probes"
         for e in added_entities
@@ -434,6 +450,9 @@ async def test_async_setup_net_clf(hass) -> None:
 
     # Create a MagicMock for ConfigEntry with runtime_data attribute
     dummy_entry = MagicMock(spec=ConfigEntry)
+    # entry_id is an instance attribute, so spec= does not provide it, but
+    # async_setup_entry needs it to clean up retired entities.
+    dummy_entry.entry_id = "test_entry_id"
     dummy_entry.runtime_data = type(
         "RuntimeData", (), {"coordinator": DummyCoordinator()}
     )
@@ -469,7 +488,8 @@ async def test_async_setup_net_clf(hass) -> None:
         for e in added_entities
     )
     # 8 sensors + 3 new (pool_volume, delay_after_startup, delay_after_dose; filtration None)
-    # + 3 binary (water_flow, cl_pump, ph_minus_pump – NET has no filtration output)
+    # + 3 binary (water_flow, cl_pump, ph_minus_pump – NET has no filtration output,
+    #   so it never had the retired filtration_nonstop24 sensor either)
     # + 4 consumption (ph_minus canister + total, cl canister + total) + 1 connection_status
     # note: required_algicide/required_floc are absent because byte[37]=0xFF (undefined)
     # note: filtration sensors skipped because start/stop times are None in NET test data
@@ -555,6 +575,9 @@ async def test_async_setup_profi_clf_redox(hass) -> None:
 
     # Create a MagicMock for ConfigEntry with runtime_data attribute
     dummy_entry = MagicMock(spec=ConfigEntry)
+    # entry_id is an instance attribute, so spec= does not provide it, but
+    # async_setup_entry needs it to clean up retired entities.
+    dummy_entry.entry_id = "test_entry_id"
     dummy_entry.runtime_data = type(
         "RuntimeData", (), {"coordinator": DummyCoordinator()}
     )
@@ -625,7 +648,9 @@ async def test_async_setup_profi_clf_redox(hass) -> None:
     #
     # Issue #133: PROFI is in FILTRATION_TYPES, so the new filtration_mode
     # sensor is now created. +1 entity compared to the PR #120 baseline.
-    assert len(added_entities) == 43
+    # The legacy filtration_nonstop24 binary sensor is gone: filtration_mode
+    # reports all four modes, so it said nothing new.  -1 entity.
+    assert len(added_entities) == 42
     assert any(
         getattr(e.entity_description, "key", None) == "free_chlorine"
         for e in added_entities
@@ -663,3 +688,76 @@ async def test_async_setup_profi_clf_redox(hass) -> None:
         getattr(e.entity_description, "key", None) == "max_filling_time"
         for e in added_entities
     )
+
+
+# ── retired entities ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_retired_nonstop24_entity_is_removed(hass, mock_config_entry) -> None:
+    """The dropped filtration_nonstop24 sensor is deleted from the registry.
+
+    Removing the entity description alone would leave the registry entry
+    behind, and the entity would sit in the UI as unavailable forever with
+    no sign that it is never coming back.
+    """
+    registry = er.async_get(hass)
+    retired = registry.async_get_or_create(
+        "binary_sensor",
+        DOMAIN,
+        "1234filtration_nonstop24",
+        config_entry=mock_config_entry,
+        suggested_object_id="aseko_filtration_nonstop_24h",
+    )
+
+    async_remove_retired_entities(hass, mock_config_entry)
+
+    assert registry.async_get(retired.entity_id) is None
+
+
+@pytest.mark.asyncio
+async def test_retired_removal_leaves_other_entities_alone(
+    hass, mock_config_entry
+) -> None:
+    """Only the retired key is touched — and only in its own domain."""
+    registry = er.async_get(hass)
+    keep_binary = registry.async_get_or_create(
+        "binary_sensor",
+        DOMAIN,
+        "1234filtration_pump_running",
+        config_entry=mock_config_entry,
+    )
+    keep_sensor = registry.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        "1234filtration_mode",
+        config_entry=mock_config_entry,
+    )
+
+    async_remove_retired_entities(hass, mock_config_entry)
+
+    assert registry.async_get(keep_binary.entity_id) is not None
+    assert registry.async_get(keep_sensor.entity_id) is not None
+
+
+@pytest.mark.asyncio
+async def test_retired_removal_is_idempotent(hass, mock_config_entry) -> None:
+    """A second run has nothing left to do and must not raise."""
+    registry = er.async_get(hass)
+    registry.async_get_or_create(
+        "binary_sensor",
+        DOMAIN,
+        "1234filtration_nonstop24",
+        config_entry=mock_config_entry,
+    )
+
+    async_remove_retired_entities(hass, mock_config_entry)
+    async_remove_retired_entities(hass, mock_config_entry)
+
+    assert not [
+        entry
+        for entry in er.async_entries_for_config_entry(
+            registry, mock_config_entry.entry_id
+        )
+        if entry.unique_id.endswith("filtration_nonstop24")
+    ]

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -789,9 +789,9 @@ def _decode_salt(byte37: int):
         (0xC3, "schedule", "nonstop_24h"),
         (0xD3, "schedule", "timer_period_1"),
         (0xF3, "schedule", "timer_period_1_and_2"),
-        (0xC7, "manual", "nonstop_24h"),
-        (0xD7, "manual", "timer_period_1"),
-        (0xF7, "manual", "timer_period_1_and_2"),
+        (0xC7, "service_menu", "nonstop_24h"),
+        (0xD7, "service_menu", "timer_period_1"),
+        (0xF7, "service_menu", "timer_period_1_and_2"),
     ],
 )
 def test_mode_and_schedule_are_each_readable_on_their_own(
@@ -799,10 +799,11 @@ def test_mode_and_schedule_are_each_readable_on_their_own(
 ) -> None:
     """Both halves of byte[37] stay readable, whatever the other one says.
 
-    One sensor answers "is the schedule in charge?", the other "which
-    schedule?".  Reporting them as a single value would drop the schedule
-    whenever the answer is manual — which is the moment it matters, since
-    the unit goes quiet there and this is the last frame you get.
+    One sensor answers "is anyone at the unit?", the other "which schedule
+    does it run otherwise?".  Reporting them as a single value would drop
+    the schedule exactly when somebody is there — which is the moment it
+    matters, since the unit goes quiet then and this is the last frame you
+    get.
     """
     mode = next(d for d in SENSORS if d.key == "filtration_mode")
     schedule = next(d for d in SENSORS if d.key == "filtration_schedule")
@@ -816,13 +817,13 @@ def test_mode_and_schedule_options_do_not_overlap() -> None:
     """Neither sensor can report the other's states.
 
     An ENUM sensor is validated against its options, so this is what stops
-    the two from drifting back together — no "manual" among the schedules,
-    no schedule among the modes.
+    the two from drifting back together — no "service_menu" among the
+    schedules, no schedule among the modes.
     """
     mode = next(d for d in SENSORS if d.key == "filtration_mode")
     schedule = next(d for d in SENSORS if d.key == "filtration_schedule")
 
-    assert set(mode.options) == {"schedule", "manual"}
+    assert set(mode.options) == {"schedule", "service_menu"}
     assert set(schedule.options) == {
         "nonstop_24h",
         "timer_period_1",

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -13,6 +13,7 @@ from custom_components.aseko_local.sensor import (
     async_setup_entry,
     AsekoLocalSensorEntity,
     AsekoConsumptionSensorEntity,
+    SENSORS,
 )
 from custom_components.aseko_local.aseko_decoder import AsekoDecoder
 
@@ -285,7 +286,10 @@ async def test_async_setup_salt_redox(hass) -> None:
     # + 1 new filtration_mode sensor (Issue #133) — SALT has filtration
     # The legacy filtration_nonstop24 binary sensor is gone: filtration_mode
     # reports all four modes, so it said nothing new.  -1 entity.
-    assert len(added_entities) == 39
+    # + 1 filtration_schedule sensor: byte[37] carries a schedule and a manual
+    #   override, and one value cannot report both.  filtration_mode says which
+    #   of the two is in charge; filtration_schedule says which schedule.
+    assert len(added_entities) == 40
     assert any(
         getattr(e.entity_description, "key", None) != "water_flow_to_probes"
         for e in added_entities
@@ -395,7 +399,10 @@ async def test_async_setup_salt_clf(hass) -> None:
     # + 1 new filtration_mode sensor (Issue #133) — SALT has filtration
     # The legacy filtration_nonstop24 binary sensor is gone: filtration_mode
     # reports all four modes, so it said nothing new.  -1 entity.
-    assert len(added_entities) == 40
+    # + 1 filtration_schedule sensor: byte[37] carries a schedule and a manual
+    #   override, and one value cannot report both.  filtration_mode says which
+    #   of the two is in charge; filtration_schedule says which schedule.
+    assert len(added_entities) == 41
     assert any(
         getattr(e.entity_description, "key", None) != "water_flow_to_probes"
         for e in added_entities
@@ -650,7 +657,10 @@ async def test_async_setup_profi_clf_redox(hass) -> None:
     # sensor is now created. +1 entity compared to the PR #120 baseline.
     # The legacy filtration_nonstop24 binary sensor is gone: filtration_mode
     # reports all four modes, so it said nothing new.  -1 entity.
-    assert len(added_entities) == 42
+    # + 1 filtration_schedule sensor: byte[37] carries a schedule and a manual
+    #   override, and one value cannot report both.  filtration_mode says which
+    #   of the two is in charge; filtration_schedule says which schedule.
+    assert len(added_entities) == 43
     assert any(
         getattr(e.entity_description, "key", None) == "free_chlorine"
         for e in added_entities
@@ -761,3 +771,73 @@ async def test_retired_removal_is_idempotent(hass, mock_config_entry) -> None:
         )
         if entry.unique_id.endswith("filtration_nonstop24")
     ]
+
+
+# ── filtration mode and schedule as two entities ────────────────────────────
+
+
+def _decode_salt(byte37: int):
+    """Decode a SALT frame carrying the given byte[37]."""
+    data = _make_salt_redox_bytes()
+    data[37] = byte37
+    return AsekoDecoder.decode(bytes(data))
+
+
+@pytest.mark.parametrize(
+    ("byte37", "expected_mode", "expected_schedule"),
+    [
+        (0xC3, "schedule", "nonstop_24h"),
+        (0xD3, "schedule", "timer_period_1"),
+        (0xF3, "schedule", "timer_period_1_and_2"),
+        (0xC7, "manual", "nonstop_24h"),
+        (0xD7, "manual", "timer_period_1"),
+        (0xF7, "manual", "timer_period_1_and_2"),
+    ],
+)
+def test_mode_and_schedule_are_each_readable_on_their_own(
+    byte37: int, expected_mode: str, expected_schedule: str
+) -> None:
+    """Both halves of byte[37] stay readable, whatever the other one says.
+
+    One sensor answers "is the schedule in charge?", the other "which
+    schedule?".  Reporting them as a single value would drop the schedule
+    whenever the answer is manual — which is the moment it matters, since
+    the unit goes quiet there and this is the last frame you get.
+    """
+    mode = next(d for d in SENSORS if d.key == "filtration_mode")
+    schedule = next(d for d in SENSORS if d.key == "filtration_schedule")
+    device = _decode_salt(byte37)
+
+    assert mode.value_fn(device) == expected_mode
+    assert schedule.value_fn(device) == expected_schedule
+
+
+def test_mode_and_schedule_options_do_not_overlap() -> None:
+    """Neither sensor can report the other's states.
+
+    An ENUM sensor is validated against its options, so this is what stops
+    the two from drifting back together — no "manual" among the schedules,
+    no schedule among the modes.
+    """
+    mode = next(d for d in SENSORS if d.key == "filtration_mode")
+    schedule = next(d for d in SENSORS if d.key == "filtration_schedule")
+
+    assert set(mode.options) == {"schedule", "manual"}
+    assert set(schedule.options) == {
+        "nonstop_24h",
+        "timer_period_1",
+        "timer_period_1_and_2",
+    }
+    assert not set(mode.options) & set(schedule.options)
+
+
+def test_mode_and_schedule_absent_without_filtration() -> None:
+    """NET has no filtration output, so neither sensor is created for it."""
+    mode = next(d for d in SENSORS if d.key == "filtration_mode")
+    schedule = next(d for d in SENSORS if d.key == "filtration_schedule")
+    device = AsekoDecoder.decode(bytes(_make_net_clf_bytes()))
+
+    assert device.device_type == AsekoDeviceType.NET
+    # A None value is what keeps an entity from being built for a device.
+    assert mode.value_fn(device) is None
+    assert schedule.value_fn(device) is None


### PR DESCRIPTION
Fixes the SALT decoding of `byte[37]`, and splits what that byte carries into
the two independent facts it actually holds.

## The decoding bug

`_fill_filtration_mode` routed every device through the HOME firmware-A branch,
which matches exact values (`0x43` / `0x53` / `0x47` / `0x57`). SALT uses the
bit-flag firmware and sends values like `0xC3`, so nothing ever matched and
`filtration_mode` stayed `None` on every ASIN AQUA Salt. The branch is now
gated on `device_type is HOME`, and non-HOME devices read the bits.

Verified against captures from a live SALT unit:

| `byte[37]` | `filtration_schedule` | `service_menu` |
|---|---|---|
| `0xC3` | `nonstop_24h` | off |
| `0xD3` | `timer_period_1` | off |
| `0xF3` | `timer_period_1_and_2` | off |
| `0xC7` | `nonstop_24h` | on |
| `0xD7` | `timer_period_1` | on |
| `0xF7` | `timer_period_1_and_2` | on |

Firmware A is untouched: `0x43` still decodes to `nonstop_24h`, and the
schedule fallback for HOME stays exactly as it was.

## What bit 0x04 actually is

Issue #133 documented `0x04` as a manual override of filtration. On SALT it is
not one, and the captures show why: **the bit is set the moment the unit's
settings menu is opened, before anything in there is touched.** Three separate
diagnostics labelled "entered manual mode, did nothing" all carry it.

The unit then **stops transmitting** until the user leaves the menu again. So
whatever happens in there — filtration started by hand, a setting changed,
nothing at all — is not observable from the protocol. The bit says a person is
standing at the unit, and nothing more.

That makes it a device state, not a filtration state, and it cannot be
expressed as a value of a filtration sensor.

## The entities

`filtration_mode` conflated the two: it reported either a schedule or the bit,
never both, so it could not answer either question reliably. It is dropped, and
its registry entries are removed at setup — the same treatment
`filtration_nonstop24` gets here, so neither is left in the UI as permanently
unavailable.

| | |
|---|---|
| `sensor.filtration_schedule` | `nonstop_24h` / `timer_period_1` / `timer_period_1_and_2` — what the unit runs unattended |
| `binary_sensor.service_menu` | somebody has the unit's settings menu open |

Net entity count is unchanged (`-filtration_nonstop24 -filtration_mode
+filtration_schedule +service_menu`). Keeping the schedule readable while the
menu is open is the point of the split: a dashboard can grey out the schedule
without losing it.

`service_menu_open` is left `None` where the bit means something else or
nothing: firmware A, where `0x04` belongs to the transitional edit states, and
NET, which has no filtration output at all.

## Note for the maintainer

The HOME firmware-B **pump-off override** in `_fill_pump_states` is deliberately
left alone and still gated on HOME. On SALT the same bit cannot justify forcing
the pump off — the user may equally have switched it *on* — so extending the
override there would invent a state the unit never reported.

Whether HOME's `0x04` is literally the same settings-menu flag is **unverified**.
The four Issue #133 diagnostics were captured one per mode, so a HOME unit going
quiet the way SALT does would not have shown up in them. If HOME behaves the
same way, the override is reading a menu session rather than a standing
override, and should probably be reconsidered — but that needs a HOME capture,
which I do not have.

## Testing

Decoder and sensor tests cover all six SALT `byte[37]` values, both firmware-A
values, the NET no-filtration case, and the schedule surviving a
`0xC3 → 0xC7 → 0xC3` menu excursion unchanged. Registry-retirement tests cover
both dropped entities, including a second run being a no-op.